### PR TITLE
chore: scrub local-environment refs from docs before going public

### DIFF
--- a/docs/plans/2026-04-10-phase-0-foundation.md
+++ b/docs/plans/2026-04-10-phase-0-foundation.md
@@ -65,7 +65,7 @@
   test -f docs/specs/2026-04-10-gh-manage-design.md && echo "spec: ok" || echo "spec: MISSING"
   ```
   Expected:
-  - `pwd` prints `/home/server160/repos/gh-manage`
+  - `pwd` prints the gh-manage clone path (e.g., `~/repos/gh-manage`)
   - `docs/` directory exists (contains `plans/` and `specs/`)
   - No `.git/` directory yet
   - spec: ok
@@ -100,7 +100,7 @@
   cd ~/repos/gh-manage
   git init -b main
   ```
-  Expected output: `Initialized empty Git repository in /home/server160/repos/gh-manage/.git/`
+  Expected output: `Initialized empty Git repository in <repo>/gh-manage/.git/`
 
 - [ ] **Step 1.2: Create `.gitignore`**
 

--- a/docs/specs/2026-04-10-gh-manage-design.md
+++ b/docs/specs/2026-04-10-gh-manage-design.md
@@ -18,7 +18,7 @@
 - CI ワークフローがあるリポでも設定がバラバラで、PR レビュー品質が再現不可能
 - ラベル体系・Issue テンプレ・ブランチ保護ルールが各リポ任意で、規約のドリフトが蓄積している
 - `claude-dotfiles` リポジトリ内に CI スクリプト、reusable workflow、レビュー関連ルールが混在しており、Claude ハーネスとしての責務が曖昧
-- 既存の `reusable-pr-gate.yml` (claude-dotfiles) は未利用のまま 1 年以上経過し、`SHELF_BRAIN_DB_PASSWORD` のプロジェクト固有環境変数の漏れ、`lock-validation` ジョブの常時実行、ランタイム分岐のハードコードなど、設計品質が低い
+- 既存の `reusable-pr-gate.yml` (claude-dotfiles) は未利用のまま 1 年以上経過し、プロジェクト固有環境変数の漏れ込み、`lock-validation` ジョブの常時実行、ランタイム分岐のハードコードなど、設計品質が低い
 - 新規リポジトリを立ち上げるたびに同じセットアップを手作業で繰り返している
 
 ### 着想と判断


### PR DESCRIPTION
## Summary

Phase 3 cross-repo invocation revealed that gh-manage needs to be public for consumers to clone via the self-checkout pattern. Before flipping visibility, scrub references that would expose either the maintainer's local environment or unrelated personal projects.

**Changes (3 lines, 2 files, doc-only):**

1. \`docs/plans/2026-04-10-phase-0-foundation.md\`: replace two literal \`/home/server160/repos/gh-manage\` paths with generic \`~/repos/\` and \`<repo>/\` forms
2. \`docs/specs/2026-04-10-gh-manage-design.md\`: drop the \`SHELF_BRAIN_DB_PASSWORD\` example name (the surrounding sentence still conveys the same point about claude-dotfiles' old workflow leaking project-specific env vars)

**Audit performed:**
- \`grep\` for \`/home/[user]\`, \`server160\`, \`SHELF_BRAIN\`, \`shelf-brain\`: clean after fixes
- \`grep\` for typical secret patterns (passwords, tokens, AKIA keys, sk- keys, ssh-rsa, BEGIN PRIVATE KEY): no real hits (only false positives in uv.lock SHA256 hashes)
- \`find\` for \`.env*\` files: none tracked
- \`git ls-files\` for caches: none tracked
- Author email in git history: \`zeficpgrf@gmail.com\` (already public via the maintainer's other public repos; not a blocker, but a candidate for switching to GitHub no-reply email in a follow-up)

**Why this PR is small but load-bearing:** It must merge BEFORE the visibility flip so the literal local paths and unrelated project references don't get exposed even briefly.

## Test plan

- [ ] CI green (self-dogfood Python gate + smoke-test)
- [ ] Skim the diff to confirm only the 3 prescribed lines change

This PR is a candidate for the workflow-review.md skip exemption (doc-only, ~3 lines, no logic). I will rely on a fast self-review before merge given the urgency of the cross-repo blocker.

Generated with [Claude Code](https://claude.ai/code)