### PR TITLE
fix: replace github.workflow_ref parsing with explicit gh-manage-ref input (v0.2.1, CRITICAL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,7 @@ jobs:
       working-directory: "."
       install-command: "uv sync"
       test-command: "uv run pytest"
+      # Same-repo dogfood: pass the current commit SHA so the reusable
+      # checks out THIS PR's gh-manage tree (not a tagged release). This
+      # is what makes dogfood actually exercise in-PR action changes.
+      gh-manage-ref: ${{ github.sha }}

--- a/.github/workflows/reusable-pr-gate-python.yml
+++ b/.github/workflows/reusable-pr-gate-python.yml
@@ -42,6 +42,18 @@ on:
         required: false
         type: string
         default: "0.5.0"
+      gh-manage-ref:
+        description: >
+          Ref of yakkuro/gh-manage to check out for Layer-2 composite actions.
+          MUST match the `@<ref>` you used in the `uses:` line of your workflow
+          (e.g., if you wrote `uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v0.2.1`,
+          set this to `"v0.2.1"`). GitHub Actions does NOT expose the called
+          reusable workflow's own ref to the workflow at runtime — `github.workflow_ref`
+          reflects the TOP-LEVEL caller's workflow, so the consumer must pass
+          this value explicitly. Same-repo dogfood and smoke-test pass
+          `${{ github.sha }}` to test in-PR action changes.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -51,46 +63,20 @@ jobs:
     name: PR Gate
     runs-on: ubuntu-latest
     steps:
-      # GitHub Actions resolves `./<path>` references in a reusable workflow
-      # against the runner's current workspace, which (after checkout of the
-      # caller) contains the caller's repository, not gh-manage's. To make the
-      # Layer-2 composite actions available in BOTH same-repo and cross-repo
-      # invocations, the reusable workflow self-checks-out gh-manage into
-      # `.gh-manage/` and references actions from there.
-      - name: Extract gh-manage ref from github.workflow_ref
-        id: self-ref
-        shell: bash
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-        run: |
-          set -euo pipefail
-          # github.workflow_ref is "<owner>/<repo>/<path-to-workflow>@<ref>".
-          # The workflow path always ends with `.yml`, so strip the shortest
-          # prefix up to and including `.yml@` — this correctly handles refs
-          # that themselves contain `@` (e.g., `release@candidate`). A naive
-          # `${VAR##*@}` (longest prefix) would truncate such refs.
-          if [[ "${WORKFLOW_REF}" != *.yml@* ]]; then
-            echo "::error::Unexpected github.workflow_ref format (missing .yml@): ${WORKFLOW_REF}"
-            exit 1
-          fi
-          ref="${WORKFLOW_REF#*.yml@}"
-          if [[ -z "${ref}" ]]; then
-            echo "::error::Empty ref parsed from github.workflow_ref='${WORKFLOW_REF}'"
-            exit 1
-          fi
-          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
-          echo "gh-manage ref resolved to: ${ref}"
-
       - name: Checkout consumer repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      # Layer-2 composite actions live in this repo (yakkuro/gh-manage) and
+      # are referenced via `./.gh-manage/actions/<name>` after this checkout.
+      # Cross-repo consumers MUST pin `gh-manage-ref` to the same `@<ref>`
+      # they used in the `uses:` line — see input description above.
       - name: Checkout gh-manage (self, for Layer-2 composite actions)
         uses: actions/checkout@v4
         with:
           repository: yakkuro/gh-manage
-          ref: ${{ steps.self-ref.outputs.ref }}
+          ref: ${{ inputs.gh-manage-ref }}
           path: .gh-manage
           fetch-depth: 1
 

--- a/.github/workflows/reusable-pr-gate-python.yml
+++ b/.github/workflows/reusable-pr-gate-python.yml
@@ -43,15 +43,7 @@ on:
         type: string
         default: "0.5.0"
       gh-manage-ref:
-        description: >
-          Ref of yakkuro/gh-manage to check out for Layer-2 composite actions.
-          MUST match the `@<ref>` you used in the `uses:` line of your workflow
-          (e.g., if you wrote `uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v0.2.1`,
-          set this to `"v0.2.1"`). GitHub Actions does NOT expose the called
-          reusable workflow's own ref to the workflow at runtime — `github.workflow_ref`
-          reflects the TOP-LEVEL caller's workflow, so the consumer must pass
-          this value explicitly. Same-repo dogfood and smoke-test pass
-          `${{ github.sha }}` to test in-PR action changes.
+        description: "Ref of yakkuro/gh-manage to check out for Layer-2 composite actions. MUST match the @<ref> you used in the uses: line. See docs/usage/python.md for the rationale."
         required: true
         type: string
 

--- a/.github/workflows/reusable-pr-gate-typescript.yml
+++ b/.github/workflows/reusable-pr-gate-typescript.yml
@@ -42,6 +42,18 @@ on:
         required: false
         type: string
         default: "10.33.0"
+      gh-manage-ref:
+        description: >
+          Ref of yakkuro/gh-manage to check out for Layer-2 composite actions.
+          MUST match the `@<ref>` you used in the `uses:` line of your workflow
+          (e.g., if you wrote `uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-typescript.yml@v0.2.1`,
+          set this to `"v0.2.1"`). GitHub Actions does NOT expose the called
+          reusable workflow's own ref to the workflow at runtime — `github.workflow_ref`
+          reflects the TOP-LEVEL caller's workflow, so the consumer must pass
+          this value explicitly. Same-repo dogfood and smoke-test pass
+          `${{ github.sha }}` to test in-PR action changes.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -51,46 +63,20 @@ jobs:
     name: PR Gate
     runs-on: ubuntu-latest
     steps:
-      # GitHub Actions resolves `./<path>` references in a reusable workflow
-      # against the runner's current workspace, which (after checkout of the
-      # caller) contains the caller's repository, not gh-manage's. To make the
-      # Layer-2 composite actions available in BOTH same-repo and cross-repo
-      # invocations, the reusable workflow self-checks-out gh-manage into
-      # `.gh-manage/` and references actions from there.
-      - name: Extract gh-manage ref from github.workflow_ref
-        id: self-ref
-        shell: bash
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-        run: |
-          set -euo pipefail
-          # github.workflow_ref is "<owner>/<repo>/<path-to-workflow>@<ref>".
-          # The workflow path always ends with `.yml`, so strip the shortest
-          # prefix up to and including `.yml@` — this correctly handles refs
-          # that themselves contain `@` (e.g., `release@candidate`). A naive
-          # `${VAR##*@}` (longest prefix) would truncate such refs.
-          if [[ "${WORKFLOW_REF}" != *.yml@* ]]; then
-            echo "::error::Unexpected github.workflow_ref format (missing .yml@): ${WORKFLOW_REF}"
-            exit 1
-          fi
-          ref="${WORKFLOW_REF#*.yml@}"
-          if [[ -z "${ref}" ]]; then
-            echo "::error::Empty ref parsed from github.workflow_ref='${WORKFLOW_REF}'"
-            exit 1
-          fi
-          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
-          echo "gh-manage ref resolved to: ${ref}"
-
       - name: Checkout consumer repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      # Layer-2 composite actions live in this repo (yakkuro/gh-manage) and
+      # are referenced via `./.gh-manage/actions/<name>` after this checkout.
+      # Cross-repo consumers MUST pin `gh-manage-ref` to the same `@<ref>`
+      # they used in the `uses:` line — see input description above.
       - name: Checkout gh-manage (self, for Layer-2 composite actions)
         uses: actions/checkout@v4
         with:
           repository: yakkuro/gh-manage
-          ref: ${{ steps.self-ref.outputs.ref }}
+          ref: ${{ inputs.gh-manage-ref }}
           path: .gh-manage
           fetch-depth: 1
 

--- a/.github/workflows/reusable-pr-gate-typescript.yml
+++ b/.github/workflows/reusable-pr-gate-typescript.yml
@@ -43,15 +43,7 @@ on:
         type: string
         default: "10.33.0"
       gh-manage-ref:
-        description: >
-          Ref of yakkuro/gh-manage to check out for Layer-2 composite actions.
-          MUST match the `@<ref>` you used in the `uses:` line of your workflow
-          (e.g., if you wrote `uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-typescript.yml@v0.2.1`,
-          set this to `"v0.2.1"`). GitHub Actions does NOT expose the called
-          reusable workflow's own ref to the workflow at runtime — `github.workflow_ref`
-          reflects the TOP-LEVEL caller's workflow, so the consumer must pass
-          this value explicitly. Same-repo dogfood and smoke-test pass
-          `${{ github.sha }}` to test in-PR action changes.
+        description: "Ref of yakkuro/gh-manage to check out for Layer-2 composite actions. MUST match the @<ref> you used in the uses: line. See docs/usage/typescript.md for the rationale."
         required: true
         type: string
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,6 +30,9 @@ jobs:
     with:
       python-version: "3.12"
       working-directory: tests/fixtures/projects/python-sample
+      # Smoke-test passes the current commit SHA so the reusable's
+      # self-checkout fetches the in-PR gh-manage tree, not a release tag.
+      gh-manage-ref: ${{ github.sha }}
 
   # ---------- Negative fixture: lint failure ----------
   # GitHub Actions does NOT support continue-on-error at the job level for
@@ -179,6 +182,7 @@ jobs:
     with:
       node-version: "20"
       working-directory: tests/fixtures/projects/typescript-sample
+      gh-manage-ref: ${{ github.sha }}
 
   # ---------- Negative TypeScript fixture: lint failure ----------
   # Same reasoning as the Python negative jobs: GitHub Actions does NOT

--- a/CHANGELOG-reusable.md
+++ b/CHANGELOG-reusable.md
@@ -8,6 +8,31 @@ The CLI changelog lives in `CHANGELOG-cli.md`.
 
 _Nothing yet._
 
+## [0.2.1] - 2026-04-10
+
+Hotfix release. The Phase 3 first-external-consumer test (yakkuro/llm-kb) discovered that v0.2.0's self-checkout pattern is fundamentally broken for cross-repo invocation. v0.2.1 replaces the implicit `github.workflow_ref` parsing with an explicit `gh-manage-ref` input that the consumer must specify.
+
+### Fixed
+
+- **Cross-repo self-checkout** (CRITICAL) — both `reusable-pr-gate-python.yml` and `reusable-pr-gate-typescript.yml` previously parsed `github.workflow_ref` to determine which gh-manage ref to check out for Layer-2 composite actions. The assumption was that `github.workflow_ref` reflects the called reusable workflow's ref. **It does not.** GitHub Actions populates `github.workflow_ref` with the **top-level caller's** workflow ref, not the called reusable's ref. In same-repo dogfood (Phases 1 and 2), the consumer ref happened to coincide with the gh-manage ref, masking the bug. In cross-repo (Phase 3), the parser returned the consumer's PR merge ref (e.g., `refs/pull/14/merge`), which the gh-manage repo does not contain, and the self-checkout step failed with `fatal: couldn't find remote ref refs/pull/14/merge`.
+
+  **Fix**: replace the implicit parser with a new required input `gh-manage-ref`. Consumers MUST pass the same `@<ref>` they used in `uses:`. The duplication is required because GitHub Actions does not allow dynamic values in `uses:` lines, and there is no built-in context variable that exposes the called workflow's own ref.
+
+  Affected: every cross-repo consumer of v0.2.0. Workaround: pin to v0.2.1 and add the new required input. Same-repo dogfood and smoke-test now pass `${{ github.sha }}`.
+
+### Added
+
+- **`gh-manage-ref` input on both reusable workflows** — required, string. See the input description in `reusable-pr-gate-{python,typescript}.yml` for the full rationale, or `docs/usage/{python,typescript}.md` for consumer-facing examples.
+
+### Changed
+
+- **`docs/usage/python.md` and `docs/usage/typescript.md`** — minimal example, Inputs table, Disabling checks, and Setup command examples all updated to show the new `gh-manage-ref` input. Bumped pin references from `@v0.1.0` / `@v0.2.0` to `@v0.2.1`.
+- **`gh-manage` repository visibility** — `yakkuro/gh-manage` was switched from private to public on 2026-04-10 to enable cross-repo `actions/checkout@v4` from consumer runners. The default `GITHUB_TOKEN` of a consumer repo can clone public repositories without additional configuration; private would have required PAT setup for every consumer. This is a one-time visibility change documented here for traceability.
+
+### Known limitations (carried forward from v0.2.0)
+
+All v0.2.0 known limitations still apply (pnpm only, eslint pinning recommendation-only, Node 20+ minimum, no `cache: pnpm`, non-root working-directory test gap, version skew detection gap, Python tool refresh deferred).
+
 ## [0.2.0] - 2026-04-10
 
 Second release. Adds the TypeScript PR gate alongside the Phase 1 Python gate and fixes a latent `github.workflow_ref` parser bug shared by both reusables.
@@ -74,6 +99,7 @@ _N/A — first release._
 - **Cross-repo self-checkout has NOT been empirically validated** in v0.1.0 — the same-repo dogfood (gh-manage's own `ci.yml`) and smoke-test are the only tested invocation paths. Phase 3 (port-registry adoption) will be the first real cross-repo test. If issues arise, they will be fixed in v0.1.1 or v0.2.0.
 - **Pinned tool versions are not the latest available** as of 2026-04-10. `uv` is pinned at 0.5.0 (latest: 0.11.6), `ruff` at 0.8.0 (latest: 0.15.10), `mypy` at 1.12.0 (latest: 1.20.0). Tool version refresh is scheduled for v0.2.0.
 
-[Unreleased]: https://github.com/yakkuro/gh-manage/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/yakkuro/gh-manage/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/yakkuro/gh-manage/releases/tag/v0.2.1
 [0.2.0]: https://github.com/yakkuro/gh-manage/releases/tag/v0.2.0
 [0.1.0]: https://github.com/yakkuro/gh-manage/releases/tag/v0.1.0

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -22,10 +22,13 @@ on:
 
 jobs:
   pr-gate:
-    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v0.1.0
+    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v0.2.1
     with:
       python-version: "3.12"
+      gh-manage-ref: "v0.2.1"  # MUST match the @<ref> on the line above
 ```
+
+> **Why `gh-manage-ref` is required and duplicated**: GitHub Actions does not expose the called reusable workflow's own ref to the workflow at runtime — `github.workflow_ref` reflects the top-level caller's workflow (yours, not gh-manage's). To make the reusable's internal `actions/checkout@v4` of `yakkuro/gh-manage` work, you must pass the gh-manage version explicitly. Keep both `@v0.2.1` and `gh-manage-ref: "v0.2.1"` in sync; mismatching them produces an obvious error at job start. (We agree the duplication is ugly. The cleanest workaround would require breaking changes to the cross-repo reusable workflow contract.)
 
 That's it. The workflow will:
 
@@ -41,6 +44,7 @@ That's it. The workflow will:
 | Input | Type | Default | Description |
 |---|---|---|---|
 | `python-version` | string | **required** | Python version to install (e.g., `"3.12"`). |
+| `gh-manage-ref` | string | **required** | Same value as the `@<ref>` you used in `uses:`. See the note above the Minimal example. |
 | `working-directory` | string | `"."` | Project directory inside the repo. Set this if your Python project lives in a subdirectory. |
 | `install-command` | string | `"uv sync"` | Dependency install command. |
 | `test-command` | string | `"uv run pytest"` | Test command. |
@@ -68,9 +72,10 @@ If your project can't pass `mypy` yet (or you don't want it), disable it:
 ```yaml
 jobs:
   pr-gate:
-    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v0.1.0
+    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v0.2.1
     with:
       python-version: "3.12"
+      gh-manage-ref: "v0.2.1"
       type-check: false
 ```
 
@@ -83,9 +88,10 @@ If your tests need a database or filesystem initialization step:
 ```yaml
 jobs:
   pr-gate:
-    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v0.1.0
+    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v0.2.1
     with:
       python-version: "3.12"
+      gh-manage-ref: "v0.2.1"
       setup-command: "uv run python scripts/init_db.py"
 ```
 

--- a/docs/usage/typescript.md
+++ b/docs/usage/typescript.md
@@ -26,10 +26,13 @@ on:
 
 jobs:
   pr-gate:
-    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-typescript.yml@v0.2.0
+    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-typescript.yml@v0.2.1
     with:
       node-version: "20"
+      gh-manage-ref: "v0.2.1"  # MUST match the @<ref> on the line above
 ```
+
+> **Why `gh-manage-ref` is required and duplicated**: GitHub Actions does not expose the called reusable workflow's own ref to the workflow at runtime — `github.workflow_ref` reflects the top-level caller's workflow (yours, not gh-manage's). To make the reusable's internal `actions/checkout@v4` of `yakkuro/gh-manage` work, you must pass the gh-manage version explicitly. Keep both `@v0.2.1` and `gh-manage-ref: "v0.2.1"` in sync.
 
 That's it. The workflow will:
 
@@ -45,6 +48,7 @@ That's it. The workflow will:
 | Input | Type | Default | Description |
 |---|---|---|---|
 | `node-version` | string | **required** | Node.js version to install (e.g., `"20"`, `"22"`). Must be 20 or higher. |
+| `gh-manage-ref` | string | **required** | Same value as the `@<ref>` you used in `uses:`. See the note above the Minimal example. |
 | `working-directory` | string | `"."` | Project directory inside the repo. Set this if your TypeScript project lives in a subdirectory. |
 | `install-command` | string | `"pnpm install --frozen-lockfile"` | Dependency install command. |
 | `test-command` | string | `"pnpm test"` | Test command. |
@@ -119,9 +123,10 @@ If your project can't pass `tsc` yet (or you don't want it), disable it:
 ```yaml
 jobs:
   pr-gate:
-    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-typescript.yml@v0.2.0
+    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-typescript.yml@v0.2.1
     with:
       node-version: "20"
+      gh-manage-ref: "v0.2.1"
       type-check: false
 ```
 
@@ -134,9 +139,10 @@ If your tests need a database or filesystem initialization step:
 ```yaml
 jobs:
   pr-gate:
-    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-typescript.yml@v0.2.0
+    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-typescript.yml@v0.2.1
     with:
       node-version: "20"
+      gh-manage-ref: "v0.2.1"
       setup-command: "pnpm exec tsx scripts/init-db.ts"
 ```
 


### PR DESCRIPTION
## Summary

Phase 3 first-external-consumer test (yakkuro/llm-kb) discovered that v0.2.0's self-checkout pattern is **fundamentally broken cross-repo**. This is a CRITICAL hotfix.

## The bug

The reusable workflows used \`github.workflow_ref\` to parse out which gh-manage ref to check out for Layer-2 composite actions. The assumption was that \`github.workflow_ref\` reflects the called reusable workflow's ref. **It does not.** GitHub Actions populates \`github.workflow_ref\` with the **top-level caller's** workflow ref, not the called reusable's ref.

In same-repo dogfood (Phases 1 and 2), the consumer ref happened to coincide with gh-manage's ref, masking the bug. In cross-repo (Phase 3 with llm-kb), the parser returned the consumer's PR merge ref (\`refs/pull/14/merge\`), causing self-checkout to fail with:

\`\`\`
fatal: couldn't find remote ref refs/pull/14/merge
\`\`\`

## The fix

Replace the implicit parser with a new **required input** \`gh-manage-ref\` on both reusable workflows. Consumers must pass the same \`@<ref>\` they used in \`uses:\`. The duplication is required because GitHub Actions does not allow dynamic values in \`uses:\` lines and there is no built-in context variable that exposes the called reusable workflow's own ref.

Consumer-side change (the duplication is the cost of the fix):

\`\`\`yaml
jobs:
  pr-gate:
    uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v0.2.1
    with:
      python-version: "3.12"
      gh-manage-ref: "v0.2.1"  # MUST match the @<ref> on the line above
\`\`\`

## Files changed (7)

1. \`.github/workflows/reusable-pr-gate-python.yml\`: add \`gh-manage-ref\` required input, remove the parser self-ref step
2. \`.github/workflows/reusable-pr-gate-typescript.yml\`: same
3. \`.github/workflows/ci.yml\` (self-dogfood): pass \`gh-manage-ref: \${{ github.sha }}\`
4. \`.github/workflows/smoke-test.yml\`: pass \`gh-manage-ref: \${{ github.sha }}\` on both positive jobs
5. \`docs/usage/python.md\`: update minimal example, Inputs table, all yaml snippets
6. \`docs/usage/typescript.md\`: same
7. \`CHANGELOG-reusable.md\`: \`[0.2.1]\` entry documenting bug, fix, and the related visibility change (gh-manage went public on 2026-04-10)

## Test plan

- [ ] All 7 CI checks green (self-dogfood + 6 smoke-test jobs)
- [ ] After merge, tag v0.2.1 and create release
- [ ] Update llm-kb's ci.yml to pin \`@v0.2.1\` + \`gh-manage-ref: "v0.2.1"\` and verify cross-repo flow works end-to-end

## Why bundled

This is a CRITICAL hotfix that surfaced during Phase 3. Bundling the docs updates with the workflow fix in one PR keeps the v0.2.1 release coherent. Skipping the 4-reviewer protocol on this PR is justifiable as an emergency fix per workflow-review.md spirit, but I will still run all 4 reviewers in parallel since the wall-clock cost is small.

Reported by Codex cross-agent review on PR #3 (the original CRITICAL parser finding was real but addressed the wrong layer — the parser was broken AND its input was wrong; v0.2.0 fixed the former, v0.2.1 fixes the latter).

Generated with [Claude Code](https://claude.ai/code)