### PR TITLE
chore: bump cli version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gh-manage"
-version = "0.2.0"
+version = "0.3.0"
 description = "GitHub-based CI/CD, Issue management, and operational system for yakkuro/* repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gh_manage/__init__.py
+++ b/src/gh_manage/__init__.py
@@ -1,3 +1,3 @@
 """gh-manage: GitHub-based CI/CD, Issue management, and operational system."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -8,7 +8,7 @@ import gh_manage
 def test_package_version_is_defined() -> None:
     assert hasattr(gh_manage, "__version__")
     assert isinstance(gh_manage.__version__, str)
-    assert gh_manage.__version__ == "0.2.0"
+    assert gh_manage.__version__ == "0.3.0"
 
 
 def test_cli_module_is_importable() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "gh-manage"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Phase 6 (#12) shipped \`cli/v0.3.0\` as a git tag + GitHub release but forgot to bump the package version. The wheel metadata still said \`0.2.0\`, so \`gh-manage --version\` printed \`gh-manage, version 0.2.0\` for a CLI tagged \`v0.3.0\` — confusing drift between tag / release notes / wheel metadata.

## Changes (1 line each, 3 files)

- \`pyproject.toml:3\` → wheel metadata
- \`src/gh_manage/__init__.py:3\` → runtime \`__version__\`
- \`tests/test_sanity.py:11\` → regression guard
- \`uv.lock\` → auto-updated by \`uv sync\` (includes the new self-reference)

## Test plan

- [x] \`uv run pytest\` — 189 tests pass (the sanity test asserting \`__version__ == "0.3.0"\` now passes)
- [x] \`uv run ruff check\` — clean
- [x] \`gh-manage --version\` after \`uv sync\` — prints \`gh-manage, version 0.3.0\`

## Follow-up (not in this PR)

After merge, force-update the existing \`cli/v0.3.0\` tag to point at this bump commit so the tag, wheel metadata, and GH release notes all agree. The existing tag was created yesterday and only I have installed from it, so the force-update impact is effectively zero.

## Review scope

This is a single-file-value-change PR (4 lines, no logic). Per \`workflow-review.md\` skip conditions, the full 4-reviewer cross-agent review can be skipped. Merging directly after CI green is fine.

Generated with [Claude Code](https://claude.ai/code)