### PR TITLE
chore: bump cli version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gh-manage"
-version = "0.3.0"
+version = "0.4.0"
 description = "GitHub-based CI/CD, Issue management, and operational system for yakkuro/* repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gh_manage/__init__.py
+++ b/src/gh_manage/__init__.py
@@ -1,3 +1,3 @@
 """gh-manage: GitHub-based CI/CD, Issue management, and operational system."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -8,7 +8,7 @@ import gh_manage
 def test_package_version_is_defined() -> None:
     assert hasattr(gh_manage, "__version__")
     assert isinstance(gh_manage.__version__, str)
-    assert gh_manage.__version__ == "0.3.0"
+    assert gh_manage.__version__ == "0.4.0"
 
 
 def test_cli_module_is_importable() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "gh-manage"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Single-file-value-change prep for the `cli/v0.4.0` release (Phase 7 — `gh manage protection sync/diff`).

Touches the 3 version locations required by `docs/release-checklist.md` plus `uv.lock`:
- `pyproject.toml` → `version = "0.4.0"`
- `src/gh_manage/__init__.py` → `__version__ = "0.4.0"`
- `tests/test_sanity.py` → `test_package_version_is_defined` assertion
- `uv.lock` → self-reference refreshed via `uv sync`

## Why this is a separate PR

Phase 7 feature PR (#16) already merged. Per `docs/release-checklist.md`, the bump runs AFTER the feature PR on a clean `main`, and the `cli/v0.4.0` tag must point at THIS bump commit — not the feature merge commit — so that `gh-manage --version` reports `0.4.0` after `uv tool install git+...@cli/v0.4.0`.

## Review skip

Per `docs/release-checklist.md` and `workflow-review.md` skip conditions, value-only changes without logic can skip the cross-agent review. Direct merge after CI green.

## Test plan

- [ ] CI runs the full gate (pytest, ruff, mypy)
- [ ] Post-merge: tag `cli/v0.4.0` on THIS commit, publish release, run install smoke test

🤖 Generated with [Claude Code](https://claude.ai/code)