### PR TITLE
feat: Phase 8.5 — drift scanner automation (--report-mode issue, --all, cron)

### DIFF
--- a/.github/workflows/drift-scanner.yml
+++ b/.github/workflows/drift-scanner.yml
@@ -1,0 +1,30 @@
+name: Drift Scanner
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'   # Every Monday 00:00 UTC (= 09:00 JST)
+  workflow_dispatch:        # Manual trigger for debugging
+
+permissions:
+  issues: write             # Create/update/close drift Issues
+  contents: read            # Read repos.yml from package data
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install gh-manage
+        run: uv tool install git+https://github.com/yakkuro/gh-manage@cli/v0.6.0
+
+      - name: Run drift scanner
+        run: gh-manage drift --all --report-mode issue --severity low
+        env:
+          GH_TOKEN: ${{ secrets.GH_MANAGE_TOKEN }}

--- a/docs/plans/2026-04-12-phase-8.5-drift-automation.md
+++ b/docs/plans/2026-04-12-phase-8.5-drift-automation.md
@@ -1,0 +1,1644 @@
+# Phase 8.5 — Drift scanner automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--report-mode issue` (auto-create/update/close GitHub Issues), `--all` flag with bundled `repos.yml` for multi-repo scan, and `.github/workflows/drift-scanner.yml` weekly cron. Ship as `cli/v0.6.0`.
+
+**Architecture:** Extends Phase 8's `drift_sync.py` with Issue formatting + state machine logic. New `github_api/issues.py` mirrors `github_api/labels.py` pattern (thin `run_gh_api` wrappers). New `models/repos.py` for `repos.yml` schema. CLI gains `--report-mode issue` and `--all` flag (mutually exclusive with `<path> --profile`).
+
+**Tech Stack:** Python 3.12 + click 8 + pydantic v2 + PyYAML + pytest 8 + pytest-mock + hatchling. Reuses Phase 8 plumbing (`drift_sync.run_all_checks`, `format_markdown_report`, `_filter_by_severity`, `Finding`, `ScanContext`).
+
+**Spec:** [`docs/specs/2026-04-12-phase-8.5-drift-automation-design.md`](../specs/2026-04-12-phase-8.5-drift-automation-design.md)
+
+---
+
+## File Structure
+
+### New source files
+
+| Path | Responsibility | Created in task |
+|---|---|---|
+| `src/gh_manage/github_api/issues.py` | Issue CRUD: `search_drift_issue`, `create_issue`, `update_issue_body`, `add_issue_comment`, `close_issue`, `ensure_drift_label`, `get_issue_comments` | Task 1 |
+| `src/gh_manage/models/repos.py` | `RepoEntry` + `ReposConfig` pydantic schema | Task 2 |
+| `src/gh_manage/data/repos.yml` | Bundled repo list (initial: gh-manage only) | Task 2 |
+| `.github/workflows/drift-scanner.yml` | Weekly cron workflow | Task 9 |
+
+### Modified source files
+
+| Path | Change | Task |
+|---|---|---|
+| `src/gh_manage/drift_sync.py` | Add `format_issue_body`, `format_issue_comment`, `parse_zero_findings_timestamps`, `should_close_issue`, `resolve_drift_issue` | Tasks 3-5 |
+| `src/gh_manage/commands/drift.py` | Add `--report-mode issue` + `--all` flag + `_resolve_repos_path` + `_scan_single_repo` refactor + `_scan_all_repos` | Tasks 6-8 |
+
+### New test files
+
+| Path | Purpose | Task |
+|---|---|---|
+| `tests/unit/github_api/test_issues.py` | subprocess-mocked tests for Issue CRUD | Task 1 |
+| `tests/unit/models/test_repos.py` | pydantic schema validation | Task 2 |
+| `tests/unit/drift/test_issue_report.py` | Issue body/comment format + hidden metadata parse + 24h close logic | Tasks 3-4 |
+
+### Modified test files
+
+| Path | Change | Task |
+|---|---|---|
+| `tests/unit/drift/test_drift_sync.py` | Append state machine tests for `resolve_drift_issue` | Task 5 |
+| `tests/unit/cli/test_drift.py` | Append `--report-mode issue` + `--all` tests | Tasks 6-8 |
+
+---
+
+## Pre-flight checklist
+
+```bash
+cd /home/server160/repos/gh-manage
+git status              # clean
+git checkout docs/phase-8.5-spec
+git pull --ff-only
+git checkout -b feat/phase-8.5-drift-automation
+uv run pytest           # 352 pass baseline
+uv run ruff check src/ tests/   # clean
+```
+
+---
+
+## Task 1: `github_api/issues.py` — Issue CRUD wrapper
+
+**Goal:** Create the thin wrapper for GitHub Issues API. 7 functions mirroring `github_api/labels.py` pattern. All use `run_gh_api` / `run_gh` from `github_client.py`.
+
+**Files:**
+- Create: `src/gh_manage/github_api/issues.py`
+- Create: `tests/unit/github_api/test_issues.py`
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `tests/unit/github_api/test_issues.py`:
+
+```python
+"""Tests for gh_manage.github_api.issues — GitHub Issues API wrapper."""
+
+from __future__ import annotations
+
+import json
+from subprocess import CompletedProcess
+
+import pytest
+from pytest_mock import MockerFixture
+
+from gh_manage.github_api.issues import (
+    add_issue_comment,
+    close_issue,
+    create_issue,
+    ensure_drift_label,
+    get_issue_comments,
+    search_drift_issue,
+    update_issue_body,
+)
+from gh_manage.github_client import GhNotFoundError
+
+
+def _mock_gh_success(mocker: MockerFixture, stdout: str) -> object:
+    return mocker.patch(
+        "subprocess.run",
+        return_value=CompletedProcess(
+            args=[], returncode=0, stdout=stdout, stderr=""
+        ),
+    )
+
+
+def _mock_gh_failure(
+    mocker: MockerFixture, stderr: str, returncode: int = 1
+) -> object:
+    return mocker.patch(
+        "subprocess.run",
+        return_value=CompletedProcess(
+            args=[], returncode=returncode, stdout="", stderr=stderr
+        ),
+    )
+
+
+# search_drift_issue
+def test_search_drift_issue_found(mocker: MockerFixture) -> None:
+    response = [{"number": 42, "title": "[gh-manage drift] yakkuro/gh-manage"}]
+    _mock_gh_success(mocker, json.dumps(response))
+    result = search_drift_issue("yakkuro/gh-manage")
+    assert result is not None
+    assert result["number"] == 42
+
+
+def test_search_drift_issue_not_found(mocker: MockerFixture) -> None:
+    _mock_gh_success(mocker, json.dumps([]))
+    result = search_drift_issue("yakkuro/gh-manage")
+    assert result is None
+
+
+def test_search_drift_issue_uses_label_filter(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, "[]")
+    search_drift_issue("yakkuro/gh-manage")
+    args = mock_run.call_args.args[0]
+    assert "repos/yakkuro/gh-manage/issues" in args
+    assert any("gh-manage:drift" in str(a) for a in args)
+
+
+# create_issue
+def test_create_issue_returns_issue_dict(mocker: MockerFixture) -> None:
+    response = {"number": 42, "html_url": "https://github.com/yakkuro/gh-manage/issues/42"}
+    _mock_gh_success(mocker, json.dumps(response))
+    result = create_issue("yakkuro/gh-manage", "title", "body", ["gh-manage:drift"])
+    assert result["number"] == 42
+
+
+def test_create_issue_sends_body_via_stdin(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, '{"number": 1}')
+    create_issue("yakkuro/gh-manage", "Test", "Body", ["gh-manage:drift"])
+    args = mock_run.call_args.args[0]
+    assert "-X" in args and "POST" in args
+    assert "--input" in args and "-" in args
+    stdin_input = mock_run.call_args.kwargs["input"]
+    parsed = json.loads(stdin_input)
+    assert parsed["title"] == "Test"
+    assert parsed["body"] == "Body"
+    assert parsed["labels"] == ["gh-manage:drift"]
+
+
+# update_issue_body
+def test_update_issue_body_uses_patch(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, "{}")
+    update_issue_body("yakkuro/gh-manage", 42, "new body")
+    args = mock_run.call_args.args[0]
+    assert "repos/yakkuro/gh-manage/issues/42" in args
+    assert "-X" in args and "PATCH" in args
+    stdin_input = mock_run.call_args.kwargs["input"]
+    assert json.loads(stdin_input)["body"] == "new body"
+
+
+# add_issue_comment
+def test_add_issue_comment_posts_to_comments_endpoint(
+    mocker: MockerFixture,
+) -> None:
+    mock_run = _mock_gh_success(mocker, "{}")
+    add_issue_comment("yakkuro/gh-manage", 42, "scan comment")
+    args = mock_run.call_args.args[0]
+    assert "repos/yakkuro/gh-manage/issues/42/comments" in args
+    assert "-X" in args and "POST" in args
+
+
+# close_issue
+def test_close_issue_patches_state_closed(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, "{}")
+    close_issue("yakkuro/gh-manage", 42)
+    stdin_input = mock_run.call_args.kwargs["input"]
+    assert json.loads(stdin_input)["state"] == "closed"
+
+
+# ensure_drift_label
+def test_ensure_drift_label_creates_label(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, "{}")
+    ensure_drift_label("yakkuro/gh-manage")
+    args = mock_run.call_args.args[0]
+    assert "repos/yakkuro/gh-manage/labels" in args
+    assert "-X" in args and "POST" in args
+
+
+def test_ensure_drift_label_ignores_422_already_exists(
+    mocker: MockerFixture,
+) -> None:
+    """422 = label already exists. Should not raise."""
+    _mock_gh_failure(mocker, "HTTP 422: Validation Failed\nalready_exists\n")
+    # Should NOT raise
+    ensure_drift_label("yakkuro/gh-manage")
+
+
+# get_issue_comments
+def test_get_issue_comments_returns_list(mocker: MockerFixture) -> None:
+    comments = [{"id": 1, "body": "hello"}, {"id": 2, "body": "world"}]
+    _mock_gh_success(mocker, json.dumps(comments))
+    result = get_issue_comments("yakkuro/gh-manage", 42, per_page=5)
+    assert len(result) == 2
+    assert result[0]["body"] == "hello"
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/github_api/test_issues.py -v
+```
+
+Expected: collection error (`gh_manage.github_api.issues` doesn't exist).
+
+- [ ] **Step 1.3: Implement `github_api/issues.py`**
+
+Create `src/gh_manage/github_api/issues.py`:
+
+```python
+"""GitHub Issues API helpers for the drift scanner.
+
+Thin wrapper around gh_manage.github_client for Issue-specific operations.
+Mirrors the pattern of github_api/labels.py — each function is a single
+API call with typed arguments and minimal logic.
+
+Phase 8.5 uses these for the drift Issue state machine:
+create/update/close Issues and manage the `gh-manage:drift` label.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gh_manage.github_client import GhError, run_gh_api
+
+
+_DRIFT_LABEL = "gh-manage:drift"
+_DRIFT_LABEL_COLOR = "d4c5f9"
+_DRIFT_LABEL_DESCRIPTION = "Automated drift report from gh-manage scanner"
+
+
+def search_drift_issue(repo: str) -> dict[str, Any] | None:
+    """Search for an open drift Issue on the repo.
+
+    Uses the Issues endpoint with label filter (NOT the search API,
+    which has index delay). Returns the first matching Issue dict,
+    or None if no open drift Issue exists.
+    """
+    result = run_gh_api(
+        f"repos/{repo}/issues?labels={_DRIFT_LABEL}&state=open&per_page=1"
+    )
+    if result is None:
+        return None
+    if isinstance(result, list) and len(result) > 0:
+        return result[0]
+    return None
+
+
+def create_issue(
+    repo: str, title: str, body: str, labels: list[str]
+) -> dict[str, Any]:
+    """POST /repos/{repo}/issues. Returns the created Issue dict."""
+    result = run_gh_api(
+        f"repos/{repo}/issues",
+        method="POST",
+        body={"title": title, "body": body, "labels": labels},
+    )
+    assert isinstance(result, dict), (
+        f"Expected dict from issue creation, got {type(result).__name__}"
+    )
+    return result
+
+
+def update_issue_body(repo: str, issue_number: int, body: str) -> None:
+    """PATCH /repos/{repo}/issues/{number} — update body only."""
+    run_gh_api(
+        f"repos/{repo}/issues/{issue_number}",
+        method="PATCH",
+        body={"body": body},
+    )
+
+
+def add_issue_comment(repo: str, issue_number: int, body: str) -> None:
+    """POST /repos/{repo}/issues/{number}/comments."""
+    run_gh_api(
+        f"repos/{repo}/issues/{issue_number}/comments",
+        method="POST",
+        body={"body": body},
+    )
+
+
+def close_issue(repo: str, issue_number: int) -> None:
+    """PATCH /repos/{repo}/issues/{number} — set state=closed."""
+    run_gh_api(
+        f"repos/{repo}/issues/{issue_number}",
+        method="PATCH",
+        body={"state": "closed"},
+    )
+
+
+def ensure_drift_label(repo: str) -> None:
+    """Ensure the `gh-manage:drift` label exists on the repo.
+
+    Attempts to create it. If the label already exists (HTTP 422),
+    the error is silently ignored. Any other error propagates.
+    """
+    try:
+        run_gh_api(
+            f"repos/{repo}/labels",
+            method="POST",
+            body={
+                "name": _DRIFT_LABEL,
+                "color": _DRIFT_LABEL_COLOR,
+                "description": _DRIFT_LABEL_DESCRIPTION,
+            },
+        )
+    except GhError as e:
+        # 422 = label already exists — expected and harmless
+        if "422" in str(e) or "already_exists" in str(e):
+            return
+        raise
+
+
+def get_issue_comments(
+    repo: str, issue_number: int, per_page: int = 5
+) -> list[dict[str, Any]]:
+    """GET /repos/{repo}/issues/{number}/comments — latest N comments.
+
+    Returns newest first (sort=created, direction=desc).
+    """
+    result = run_gh_api(
+        f"repos/{repo}/issues/{issue_number}/comments"
+        f"?per_page={per_page}&sort=created&direction=desc"
+    )
+    if result is None:
+        return []
+    assert isinstance(result, list), (
+        f"Expected list from comments endpoint, got {type(result).__name__}"
+    )
+    return result
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/github_api/test_issues.py -v
+```
+
+Expected: 11 passed.
+
+- [ ] **Step 1.5: Run full gate**
+
+```bash
+uv run pytest && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+```
+
+Expected: all green (352 + 11 = 363 tests).
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add src/gh_manage/github_api/issues.py tests/unit/github_api/test_issues.py
+git commit -m "$(cat <<'EOF'
+feat(phase-8.5): add github_api/issues.py Issue CRUD wrapper
+
+7 functions mirroring github_api/labels.py pattern:
+- search_drift_issue: finds open Issue with gh-manage:drift label
+  (uses issues endpoint with label filter, NOT search API which has
+  index delay)
+- create_issue: POST with title/body/labels via stdin
+- update_issue_body: PATCH body only
+- add_issue_comment: POST to comments endpoint
+- close_issue: PATCH state=closed
+- ensure_drift_label: creates label, ignores 422 (already exists)
+- get_issue_comments: GET latest N comments (newest first)
+
+11 unit tests with subprocess mock.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `models/repos.py` + `data/repos.yml`
+
+**Goal:** Create the pydantic schema for `repos.yml` and the initial bundled config.
+
+**Files:**
+- Create: `src/gh_manage/models/repos.py`
+- Create: `src/gh_manage/data/repos.yml`
+- Create: `tests/unit/models/test_repos.py`
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Create `tests/unit/models/test_repos.py`:
+
+```python
+"""Tests for gh_manage.models.repos — RepoEntry + ReposConfig."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from gh_manage.models.repos import RepoEntry, ReposConfig
+
+
+def test_repo_entry_valid() -> None:
+    e = RepoEntry(name="yakkuro/gh-manage", profile="python-service")
+    assert e.name == "yakkuro/gh-manage"
+    assert e.profile == "python-service"
+    assert e.enabled is True  # default
+
+
+def test_repo_entry_enabled_false() -> None:
+    e = RepoEntry(name="yakkuro/archived", profile="python-service", enabled=False)
+    assert e.enabled is False
+
+
+def test_repo_entry_rejects_no_slash() -> None:
+    with pytest.raises(ValidationError, match="owner/repo"):
+        RepoEntry(name="just-a-name", profile="python-service")
+
+
+def test_repo_entry_rejects_multiple_slashes() -> None:
+    with pytest.raises(ValidationError, match="owner/repo"):
+        RepoEntry(name="a/b/c", profile="python-service")
+
+
+def test_repo_entry_rejects_empty_parts() -> None:
+    with pytest.raises(ValidationError, match="non-empty"):
+        RepoEntry(name="/repo", profile="python-service")
+
+
+def test_repo_entry_rejects_extra_field() -> None:
+    with pytest.raises(ValidationError):
+        RepoEntry(name="a/b", profile="p", unknown="x")  # type: ignore[call-arg]
+
+
+def test_repos_config_valid() -> None:
+    config = ReposConfig(
+        version=1,
+        repos=[RepoEntry(name="yakkuro/gh-manage", profile="python-service")],
+    )
+    assert len(config.repos) == 1
+
+
+def test_repos_config_rejects_version_2() -> None:
+    with pytest.raises(ValidationError):
+        ReposConfig(
+            version=2,  # type: ignore[arg-type]
+            repos=[],
+        )
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/models/test_repos.py -v
+```
+
+Expected: collection error.
+
+- [ ] **Step 2.3: Implement `models/repos.py`**
+
+Create `src/gh_manage/models/repos.py`:
+
+```python
+"""Pydantic schema for config/repos.yml.
+
+A ReposConfig holds a list of repos to scan with `gh manage drift --all`.
+Each entry specifies the repo name (owner/repo format) and the profile
+to use for scanning.
+
+Phase 8.5 ships with 1 entry (gh-manage itself). Consumer repos are
+added as they are onboarded.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class RepoEntry(BaseModel):
+    """One repo in repos.yml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str       # "owner/repo" full form
+    profile: str    # bundled profile name
+    enabled: bool = True
+
+    @field_validator("name")
+    @classmethod
+    def _validate_owner_repo_format(cls, v: str) -> str:
+        if "/" not in v or v.count("/") != 1:
+            raise ValueError(
+                f"Repo name must be in 'owner/repo' format, got: {v!r}"
+            )
+        owner, repo = v.split("/")
+        if not owner or not repo:
+            raise ValueError(
+                f"Repo name must have non-empty owner and repo parts, got: {v!r}"
+            )
+        return v
+
+
+class ReposConfig(BaseModel):
+    """Top-level schema for config/repos.yml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1]
+    repos: list[RepoEntry]
+```
+
+- [ ] **Step 2.4: Create `data/repos.yml`**
+
+Create `src/gh_manage/data/repos.yml`:
+
+```yaml
+version: 1
+repos:
+  - name: yakkuro/gh-manage
+    profile: python-service
+```
+
+- [ ] **Step 2.5: Add golden load test**
+
+Append to `tests/unit/models/test_repos.py`:
+
+```python
+from importlib.resources import files
+from pathlib import Path
+
+from gh_manage.config import load_config
+
+
+def test_bundled_repos_yml_loads() -> None:
+    """Production repos.yml loads without validation errors."""
+    repos_path = Path(str(files("gh_manage.data") / "repos.yml"))
+    config = load_config(repos_path, ReposConfig)
+    assert len(config.repos) >= 1
+    assert config.repos[0].name == "yakkuro/gh-manage"
+```
+
+- [ ] **Step 2.6: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/models/test_repos.py -v
+```
+
+Expected: 9 passed.
+
+- [ ] **Step 2.7: Run full gate**
+
+```bash
+uv run pytest && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+```
+
+Expected: all green (363 + 9 = 372 tests).
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add src/gh_manage/models/repos.py src/gh_manage/data/repos.yml tests/unit/models/test_repos.py
+git commit -m "$(cat <<'EOF'
+feat(phase-8.5): add models/repos.py + bundled repos.yml
+
+RepoEntry(name: str "owner/repo", profile: str, enabled: bool = True)
+with field_validator enforcing owner/repo format. ReposConfig(version:
+Literal[1], repos: list[RepoEntry]).
+
+Bundled repos.yml ships with gh-manage itself as the initial entry.
+Consumer repos are added as they are onboarded in Phase C.
+
+9 unit tests + golden load test for bundled config.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Issue body + comment formatters
+
+**Goal:** Add `format_issue_body` and `format_issue_comment` to `drift_sync.py`.
+
+**Files:**
+- Modify: `src/gh_manage/drift_sync.py`
+- Create: `tests/unit/drift/test_issue_report.py`
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Create `tests/unit/drift/test_issue_report.py`:
+
+```python
+"""Tests for drift Issue body/comment formatting + metadata parsing."""
+
+from __future__ import annotations
+
+from gh_manage.drift_sync import (
+    Finding,
+    format_issue_body,
+    format_issue_comment,
+)
+
+
+def _f(severity: str = "high", check: str = "labels", field_path: str = "x") -> Finding:
+    return Finding(
+        severity=severity,  # type: ignore[arg-type]
+        check=check,
+        repo="yakkuro/gh-manage",
+        field_path=field_path,
+        current_value=None,
+        desired_value="y",
+        message="test message",
+    )
+
+
+# format_issue_body
+def test_format_issue_body_contains_hidden_metadata() -> None:
+    body = format_issue_body((_f(),), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "<!-- gh-manage:drift:yakkuro/gh-manage -->" in body
+
+
+def test_format_issue_body_contains_scan_timestamp() -> None:
+    body = format_issue_body((_f(),), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "2026-04-12T09:00:00Z" in body
+
+
+def test_format_issue_body_contains_markdown_report() -> None:
+    body = format_issue_body((_f(),), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "# Drift report" in body
+    assert "test message" in body
+
+
+def test_format_issue_body_contains_auto_update_note() -> None:
+    body = format_issue_body((_f(),), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "auto-updated" in body.lower()
+
+
+def test_format_issue_body_zero_findings() -> None:
+    body = format_issue_body((), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "0 findings" in body
+
+
+# format_issue_comment
+def test_format_issue_comment_contains_finding_count_metadata() -> None:
+    comment = format_issue_comment((_f(), _f()), "2026-04-12T09:00:00Z")
+    assert "<!-- scan:finding-count:2 -->" in comment
+
+
+def test_format_issue_comment_zero_findings_has_zero_metadata() -> None:
+    comment = format_issue_comment((), "2026-04-12T09:00:00Z")
+    assert "<!-- scan:zero-findings:2026-04-12T09:00:00Z -->" in comment
+    assert "<!-- scan:finding-count:0 -->" in comment
+
+
+def test_format_issue_comment_nonzero_has_no_zero_findings_tag() -> None:
+    comment = format_issue_comment((_f(),), "2026-04-12T09:00:00Z")
+    assert "scan:zero-findings" not in comment
+    assert "<!-- scan:finding-count:1 -->" in comment
+
+
+def test_format_issue_comment_contains_scan_timestamp() -> None:
+    comment = format_issue_comment((_f(),), "2026-04-12T09:00:00Z")
+    assert "2026-04-12T09:00:00Z" in comment
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/drift/test_issue_report.py -v
+```
+
+Expected: ImportError on `format_issue_body`.
+
+- [ ] **Step 3.3: Implement the formatters**
+
+In `src/gh_manage/drift_sync.py`, add to the Report Formatters section (after `format_markdown_report`):
+
+```python
+def format_issue_body(
+    findings: tuple[Finding, ...], repo: str, scan_time: str
+) -> str:
+    """Format the GitHub Issue body for a drift report.
+
+    Layout:
+      <!-- gh-manage:drift:<repo> -->        (dormant search metadata)
+      <format_markdown_report output>        (the report itself)
+      **Last scan**: <scan_time>
+      > Note: This issue body is auto-updated by gh-manage drift scanner.
+      > Add comments below for manual notes.
+    """
+    markdown = format_markdown_report(findings)
+
+    lines = [
+        f"<!-- gh-manage:drift:{repo} -->",
+        "",
+        markdown,
+        "",
+        f"**Last scan**: {scan_time}",
+        "",
+        "> Note: This issue body is auto-updated by gh-manage drift scanner. "
+        "Add comments below for manual notes.",
+    ]
+    return "\n".join(lines)
+
+
+def format_issue_comment(
+    findings: tuple[Finding, ...], scan_time: str
+) -> str:
+    """Format a scan run comment with hidden metadata.
+
+    Hidden metadata:
+    - <!-- scan:finding-count:N --> — always present
+    - <!-- scan:zero-findings:<ISO8601> --> — only when N=0
+
+    The 24h auto-close logic parses these from comments to determine
+    whether to close the Issue.
+    """
+    count = len(findings)
+    counts = _count_by_severity(findings)
+
+    lines = [
+        f"## Scan run — {scan_time}",
+        "",
+    ]
+
+    if count == 0:
+        lines.append(f"<!-- scan:zero-findings:{scan_time} -->")
+    lines.append(f"<!-- scan:finding-count:{count} -->")
+    lines.append("")
+
+    if count == 0:
+        lines.append("**0 findings** — no drift detected.")
+    else:
+        summary_parts = []
+        for sev in ("critical", "high", "medium", "low"):
+            c = counts.get(sev, 0)
+            if c > 0:
+                summary_parts.append(f"{c} {sev}")
+        lines.append(f"**{count} findings** ({', '.join(summary_parts)})")
+
+    return "\n".join(lines)
+```
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/drift/test_issue_report.py -v
+```
+
+Expected: 9 passed.
+
+- [ ] **Step 3.5: Run full gate**
+
+```bash
+uv run pytest && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+```
+
+Expected: all green (372 + 9 = 381 tests).
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add src/gh_manage/drift_sync.py tests/unit/drift/test_issue_report.py
+git commit -m "$(cat <<'EOF'
+feat(phase-8.5): add format_issue_body + format_issue_comment
+
+format_issue_body: wraps format_markdown_report with hidden metadata
+header (<!-- gh-manage:drift:<repo> -->) and auto-update footer note.
+
+format_issue_comment: scan run comment with hidden metadata for 24h
+close logic. zero-findings → <!-- scan:zero-findings:<ISO8601> -->.
+Always includes <!-- scan:finding-count:N -->.
+
+9 unit tests cover metadata presence, timestamp, zero vs nonzero
+finding paths, auto-update note.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: 24h close logic — `parse_zero_findings_timestamps` + `should_close_issue`
+
+**Goal:** Implement the comment parsing and close decision logic.
+
+**Files:**
+- Modify: `src/gh_manage/drift_sync.py`
+- Modify: `tests/unit/drift/test_issue_report.py`
+
+- [ ] **Step 4.1: Append failing tests**
+
+Append to `tests/unit/drift/test_issue_report.py`:
+
+```python
+from datetime import datetime, timezone
+
+from gh_manage.drift_sync import (
+    parse_zero_findings_timestamps,
+    should_close_issue,
+)
+
+
+def _make_comment(body: str) -> dict:
+    return {"body": body}
+
+
+# parse_zero_findings_timestamps
+def test_parse_zero_findings_extracts_timestamps() -> None:
+    comments = [
+        _make_comment("## Scan\n<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"),
+        _make_comment("## Scan\n<!-- scan:finding-count:3 -->"),
+        _make_comment("## Scan\n<!-- scan:zero-findings:2026-04-05T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"),
+    ]
+    timestamps = parse_zero_findings_timestamps(comments)
+    assert len(timestamps) == 2
+    assert timestamps[0].year == 2026
+    assert timestamps[0].month == 4
+    assert timestamps[0].day == 12
+
+
+def test_parse_zero_findings_empty_comments() -> None:
+    assert parse_zero_findings_timestamps([]) == []
+
+
+def test_parse_zero_findings_no_metadata() -> None:
+    comments = [_make_comment("human comment without metadata")]
+    assert parse_zero_findings_timestamps(comments) == []
+
+
+def test_parse_zero_findings_malformed_timestamp_skipped() -> None:
+    comments = [_make_comment("<!-- scan:zero-findings:not-a-date -->")]
+    # Malformed timestamps are silently skipped (warning in production)
+    assert parse_zero_findings_timestamps(comments) == []
+
+
+# should_close_issue
+def test_should_close_issue_two_consecutive_zero_24h_apart() -> None:
+    comments = [
+        _make_comment("<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"),
+        _make_comment("<!-- scan:zero-findings:2026-04-05T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"),
+    ]
+    assert should_close_issue(comments) is True
+
+
+def test_should_close_issue_only_one_zero_scan() -> None:
+    comments = [
+        _make_comment("<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"),
+    ]
+    assert should_close_issue(comments) is False
+
+
+def test_should_close_issue_two_zero_within_24h() -> None:
+    comments = [
+        _make_comment("<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"),
+        _make_comment("<!-- scan:zero-findings:2026-04-12T08:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"),
+    ]
+    assert should_close_issue(comments) is False
+
+
+def test_should_close_issue_latest_has_findings() -> None:
+    comments = [
+        _make_comment("<!-- scan:finding-count:3 -->"),
+        _make_comment("<!-- scan:zero-findings:2026-04-05T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"),
+    ]
+    assert should_close_issue(comments) is False
+
+
+def test_should_close_issue_empty_comments() -> None:
+    assert should_close_issue([]) is False
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/drift/test_issue_report.py -v -k "parse_zero or should_close"
+```
+
+Expected: ImportError.
+
+- [ ] **Step 4.3: Implement**
+
+In `src/gh_manage/drift_sync.py`, add after the report formatters:
+
+```python
+import re as _re
+from datetime import datetime, timedelta, timezone
+
+
+_ZERO_FINDINGS_RE = _re.compile(
+    r"<!-- scan:zero-findings:(\S+) -->"
+)
+
+
+def parse_zero_findings_timestamps(
+    comments: list[dict[str, Any]],
+) -> list[datetime]:
+    """Parse <!-- scan:zero-findings:<ISO8601> --> from comment bodies.
+
+    Returns a list of datetime objects (newest first, matching the
+    comment order from get_issue_comments which returns newest first).
+    Malformed timestamps are silently skipped.
+    """
+    timestamps: list[datetime] = []
+    for comment in comments:
+        body = comment.get("body", "")
+        match = _ZERO_FINDINGS_RE.search(body)
+        if match:
+            try:
+                ts = datetime.fromisoformat(match.group(1))
+                timestamps.append(ts)
+            except ValueError:
+                # Malformed timestamp — skip
+                continue
+    return timestamps
+
+
+def should_close_issue(comments: list[dict[str, Any]]) -> bool:
+    """Check if the 24h double-check rule is satisfied.
+
+    Rule: the most recent 2 scan comments with zero-findings metadata
+    must have timestamps ≥ 24h apart. If fewer than 2 zero-findings
+    comments exist, or if the gap is < 24h, return False.
+
+    Comments are expected newest-first (from get_issue_comments).
+    """
+    timestamps = parse_zero_findings_timestamps(comments)
+    if len(timestamps) < 2:
+        return False
+    # timestamps[0] is newest, timestamps[1] is second newest
+    gap = timestamps[0] - timestamps[1]
+    return gap >= timedelta(hours=24)
+```
+
+- [ ] **Step 4.4: Run tests**
+
+```bash
+uv run pytest tests/unit/drift/test_issue_report.py -v
+```
+
+Expected: 18 passed (9 from Task 3 + 9 new).
+
+- [ ] **Step 4.5: Run full gate + commit**
+
+```bash
+uv run pytest && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+git add src/gh_manage/drift_sync.py tests/unit/drift/test_issue_report.py
+git commit -m "$(cat <<'EOF'
+feat(phase-8.5): implement 24h close logic (parse + should_close)
+
+parse_zero_findings_timestamps: regex-parses hidden metadata from
+Issue comments, returns datetime list (newest first). Malformed
+timestamps silently skipped (safety: don't close on bad data).
+
+should_close_issue: checks the 24h double-check rule — 2 most recent
+zero-findings scan comments must be ≥24h apart. Returns False if
+fewer than 2 exist or gap is too short.
+
+9 unit tests cover: extraction, empty, no metadata, malformed skip,
+24h apart (close), <24h (no close), only 1 zero, latest has findings.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `resolve_drift_issue` — Issue state machine
+
+**Goal:** Orchestrate the Issue lifecycle: search → create/update body/add comment/close.
+
+**Files:**
+- Modify: `src/gh_manage/drift_sync.py`
+- Modify: `tests/unit/drift/test_drift_sync.py`
+
+- [ ] **Step 5.1: Append failing tests**
+
+Append to `tests/unit/drift/test_drift_sync.py`:
+
+```python
+from gh_manage.drift_sync import resolve_drift_issue
+
+
+def test_resolve_drift_issue_creates_when_no_existing(mocker: Any) -> None:
+    mocker.patch("gh_manage.drift_sync.issues_api.search_drift_issue", return_value=None)
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mock_create = mocker.patch(
+        "gh_manage.drift_sync.issues_api.create_issue",
+        return_value={"number": 42, "html_url": "https://..."},
+    )
+    mock_comment = mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+
+    findings = (Finding("high", "labels", "yakkuro/gh-manage", "x", None, "y", "m"),)
+    result = resolve_drift_issue(findings, "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "Created" in result or "created" in result.lower()
+    mock_create.assert_called_once()
+    mock_comment.assert_called_once()
+
+
+def test_resolve_drift_issue_updates_existing(mocker: Any) -> None:
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue",
+        return_value={"number": 42},
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mock_update = mocker.patch("gh_manage.drift_sync.issues_api.update_issue_body")
+    mock_comment = mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+    mocker.patch("gh_manage.drift_sync.issues_api.get_issue_comments", return_value=[])
+
+    findings = (Finding("high", "labels", "yakkuro/gh-manage", "x", None, "y", "m"),)
+    result = resolve_drift_issue(findings, "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "Updated" in result or "updated" in result.lower()
+    mock_update.assert_called_once()
+    mock_comment.assert_called_once()
+
+
+def test_resolve_drift_issue_closes_on_24h_rule(mocker: Any) -> None:
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue",
+        return_value={"number": 42},
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mocker.patch("gh_manage.drift_sync.issues_api.update_issue_body")
+    mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+    mock_close = mocker.patch("gh_manage.drift_sync.issues_api.close_issue")
+    # Return comments that satisfy 24h rule
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.get_issue_comments",
+        return_value=[
+            {"body": "<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"},
+            {"body": "<!-- scan:zero-findings:2026-04-05T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"},
+        ],
+    )
+
+    result = resolve_drift_issue((), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "Closed" in result or "closed" in result.lower()
+    mock_close.assert_called_once()
+
+
+def test_resolve_drift_issue_noop_zero_findings_no_issue(mocker: Any) -> None:
+    mocker.patch("gh_manage.drift_sync.issues_api.search_drift_issue", return_value=None)
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+
+    result = resolve_drift_issue((), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "No drift" in result or "no drift" in result.lower()
+```
+
+- [ ] **Step 5.2: Verify fail, implement, verify pass**
+
+In `src/gh_manage/drift_sync.py`, add the import and the function:
+
+```python
+from gh_manage.github_api import issues as issues_api
+
+
+_DRIFT_ISSUE_TITLE_TEMPLATE = "[gh-manage drift] {repo}"
+_DRIFT_LABEL = "gh-manage:drift"
+
+
+def resolve_drift_issue(
+    findings: tuple[Finding, ...],
+    repo: str,
+    scan_time: str,
+) -> str:
+    """Issue state machine: search → create/update/close.
+
+    Returns a human-readable status string for CLI output.
+    """
+    issues_api.ensure_drift_label(repo)
+    existing = issues_api.search_drift_issue(repo)
+    has_findings = len(findings) > 0
+
+    if existing is None:
+        # No open Issue
+        if not has_findings:
+            return f"No drift detected for {repo}. No Issue created."
+        # Create new Issue
+        body = format_issue_body(findings, repo, scan_time)
+        comment = format_issue_comment(findings, scan_time)
+        title = _DRIFT_ISSUE_TITLE_TEMPLATE.format(repo=repo)
+        issue = issues_api.create_issue(repo, title, body, [_DRIFT_LABEL])
+        issues_api.add_issue_comment(repo, issue["number"], comment)
+        return f"Created issue #{issue['number']} on {repo} ({len(findings)} findings)"
+
+    issue_number = existing["number"]
+
+    # Update existing Issue
+    body = format_issue_body(findings, repo, scan_time)
+    comment = format_issue_comment(findings, scan_time)
+    issues_api.update_issue_body(repo, issue_number, body)
+    issues_api.add_issue_comment(repo, issue_number, comment)
+
+    if not has_findings:
+        # Check 24h close rule
+        comments = issues_api.get_issue_comments(repo, issue_number, per_page=5)
+        if should_close_issue(comments):
+            issues_api.close_issue(repo, issue_number)
+            issues_api.add_issue_comment(
+                repo,
+                issue_number,
+                f"## Auto-closed — {scan_time}\n\n"
+                f"Zero drift detected on 2 consecutive scans ≥24h apart. "
+                f"If drift recurs, a new Issue will be created.",
+            )
+            return f"Closed issue #{issue_number} on {repo} (zero drift, 24h rule satisfied)"
+
+    return f"Updated issue #{issue_number} on {repo} ({len(findings)} findings)"
+```
+
+- [ ] **Step 5.3: Run tests + gate + commit**
+
+```bash
+uv run pytest && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+git add src/gh_manage/drift_sync.py tests/unit/drift/test_drift_sync.py
+git commit -m "$(cat <<'EOF'
+feat(phase-8.5): implement resolve_drift_issue state machine
+
+Issue lifecycle orchestrator:
+- No Issue + no findings → noop ("No drift detected")
+- No Issue + findings → create Issue + add scan comment
+- Issue open + findings → update body + add scan comment
+- Issue open + zero findings → update body + add comment + check 24h
+  close rule. If 2 consecutive zero-findings scans ≥24h apart → close
+  with closing comment. Otherwise → keep open.
+
+Auto-close does NOT reopen closed Issues. If drift recurs after close,
+a new Issue is created (per spec-critique fix).
+
+4 state machine tests cover all 4 paths.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `--report-mode issue` in CLI (single-repo mode)
+
+**Goal:** Wire the Issue state machine into the CLI.
+
+**Files:**
+- Modify: `src/gh_manage/commands/drift.py`
+- Modify: `tests/unit/cli/test_drift.py`
+
+- [ ] **Step 6.1: Append failing tests**
+
+Append to `tests/unit/cli/test_drift.py`:
+
+```python
+def test_drift_issue_mode_creates_issue(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    _patch_git_and_repo(mocker)
+    _patch_run_all_checks(mocker, (_sample_finding(),))
+    mock_resolve = mocker.patch(
+        "gh_manage.commands.drift.drift_sync.resolve_drift_issue",
+        return_value="Created issue #42 on yakkuro/gh-manage (1 findings)",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "drift",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--report-mode",
+            "issue",
+        ],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Created issue #42" in result.output
+    mock_resolve.assert_called_once()
+
+
+def test_drift_issue_mode_zero_findings(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    _patch_git_and_repo(mocker)
+    _patch_run_all_checks(mocker, ())
+    mock_resolve = mocker.patch(
+        "gh_manage.commands.drift.drift_sync.resolve_drift_issue",
+        return_value="No drift detected for yakkuro/gh-manage. No Issue created.",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "drift",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--report-mode",
+            "issue",
+        ],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0
+    assert "No drift" in result.output
+```
+
+- [ ] **Step 6.2: Modify CLI to support `--report-mode issue`**
+
+In `src/gh_manage/commands/drift.py`:
+
+1. Add `"issue"` to the `click.Choice` for `--report-mode`
+2. Add an `"issue"` case in the match statement:
+
+```python
+        case "issue":
+            from datetime import datetime, timezone
+            status = drift_sync.resolve_drift_issue(
+                filtered,
+                owner_repo,
+                datetime.now(timezone.utc).isoformat(),
+            )
+            click.echo(status)
+            return
+```
+
+- [ ] **Step 6.3: Run tests + gate + commit**
+
+```bash
+uv run pytest && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+git add src/gh_manage/commands/drift.py tests/unit/cli/test_drift.py
+git commit -m "$(cat <<'EOF'
+feat(phase-8.5): add --report-mode issue to drift CLI
+
+Adds "issue" to the --report-mode click.Choice. When selected, calls
+drift_sync.resolve_drift_issue which handles the full Issue lifecycle
+(create/update/close). Prints a 1-line status to stdout.
+
+2 CLI tests: issue creation with findings, noop with zero findings.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `--all` flag + `_scan_single_repo` refactor
+
+**Goal:** Add `--all` flag, refactor scan logic into reusable `_scan_single_repo`, implement `_scan_all_repos` with partial continue.
+
+**Files:**
+- Modify: `src/gh_manage/commands/drift.py`
+- Modify: `tests/unit/cli/test_drift.py`
+
+- [ ] **Step 7.1: Append failing tests**
+
+Append to `tests/unit/cli/test_drift.py`:
+
+```python
+def test_drift_all_scans_repos_from_config(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch(
+        "gh_manage.commands.drift.repo_info.get_default_branch",
+        return_value="main",
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.drift_sync.run_all_checks",
+        return_value=(),
+    )
+    # Mock labels_api and protection_api so production checks don't hit real API
+    mocker.patch("gh_manage.drift_sync.labels_api.list_labels", return_value=[])
+    mocker.patch(
+        "gh_manage.drift_sync.protection_api.get_branch_protection",
+        return_value={},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["drift", "--all", "--report-mode", "stdout"],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0, result.output
+    assert "yakkuro/gh-manage" in result.output or "Scan complete" in result.output
+
+
+def test_drift_all_and_path_are_mutually_exclusive(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "drift",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--all",
+        ],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower() or "cannot use" in result.output.lower()
+
+
+def test_drift_all_skips_disabled_repos(
+    mocker: MockerFixture,
+) -> None:
+    from gh_manage.models.repos import RepoEntry, ReposConfig
+
+    mocker.patch(
+        "gh_manage.commands.drift.load_config",
+        return_value=ReposConfig(
+            version=1,
+            repos=[
+                RepoEntry(name="yakkuro/gh-manage", profile="python-service", enabled=True),
+                RepoEntry(name="yakkuro/disabled", profile="python-service", enabled=False),
+            ],
+        ),
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.repo_info.get_default_branch",
+        return_value="main",
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.drift_sync.run_all_checks",
+        return_value=(),
+    )
+    mocker.patch("gh_manage.drift_sync.labels_api.list_labels", return_value=[])
+    mocker.patch(
+        "gh_manage.drift_sync.protection_api.get_branch_protection",
+        return_value={},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["drift", "--all", "--report-mode", "stdout"],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0
+    assert "SKIPPED" in result.output or "skipped" in result.output.lower()
+```
+
+- [ ] **Step 7.2: Implement `--all` in CLI**
+
+Major refactor of `commands/drift.py`:
+
+1. Make `path` and `--profile` optional (not required when `--all` is used)
+2. Add `--all` flag
+3. Refactor scan logic into `_scan_single_repo(owner_repo, profile_name, ...)` helper
+4. Add `_scan_all_repos(severity, report_mode, output)` that loops over `repos.yml`
+5. `_scan_all_repos` uses partial continue (try/except per repo), prints structured summary to stderr
+6. `--all` skips `check_profile_files` — set `ctx.path` to a dummy empty dir
+
+This is a significant refactor. Read the plan's spec Section 3 for the CLI interface details. The subagent should read the existing `commands/drift.py` and refactor incrementally.
+
+Key changes to the click decorator:
+- `path` argument becomes optional with `default=None`
+- `--profile` becomes optional (required unless `--all` is set)
+- `--all` is a new flag
+- Validation: `--all` XOR (`path` + `--profile`) — raise UsageError if both or neither
+
+- [ ] **Step 7.3: Run tests + gate + commit**
+
+```bash
+uv run pytest && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+git add src/gh_manage/commands/drift.py tests/unit/cli/test_drift.py
+git commit -m "$(cat <<'EOF'
+feat(phase-8.5): add --all flag for multi-repo drift scan
+
+Refactors commands/drift.py:
+- _scan_single_repo(): extracted scan logic (path + profile → findings)
+- --all flag: loads bundled repos.yml, loops enabled repos, calls
+  _scan_single_repo per repo with check_profile_files skipped (no
+  local clone). Partial continue: per-repo GhError → warning + skip.
+- Structured summary on stderr: scanned/skipped/failed counts +
+  per-repo results table.
+- --all and path+profile are mutually exclusive (UsageError).
+- Disabled repos in repos.yml are skipped with SKIPPED note.
+
+3 CLI tests: happy path, mutual exclusion, disabled skip.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `--all --report-mode issue` integration
+
+**Goal:** Ensure `--all` + `--report-mode issue` calls `resolve_drift_issue` per repo.
+
+**Files:**
+- Modify: `tests/unit/cli/test_drift.py`
+
+- [ ] **Step 8.1: Write test**
+
+Append to `tests/unit/cli/test_drift.py`:
+
+```python
+def test_drift_all_issue_mode_calls_resolve_per_repo(
+    mocker: MockerFixture,
+) -> None:
+    from gh_manage.models.repos import RepoEntry, ReposConfig
+
+    mocker.patch(
+        "gh_manage.commands.drift.load_config",
+        return_value=ReposConfig(
+            version=1,
+            repos=[
+                RepoEntry(name="yakkuro/gh-manage", profile="python-service"),
+                RepoEntry(name="yakkuro/port-registry", profile="python-service"),
+            ],
+        ),
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.repo_info.get_default_branch",
+        return_value="main",
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.drift_sync.run_all_checks",
+        return_value=(),
+    )
+    mocker.patch("gh_manage.drift_sync.labels_api.list_labels", return_value=[])
+    mocker.patch(
+        "gh_manage.drift_sync.protection_api.get_branch_protection",
+        return_value={},
+    )
+    mock_resolve = mocker.patch(
+        "gh_manage.commands.drift.drift_sync.resolve_drift_issue",
+        return_value="No drift",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["drift", "--all", "--report-mode", "issue"],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0
+    # resolve_drift_issue called for each enabled repo
+    assert mock_resolve.call_count == 2
+```
+
+- [ ] **Step 8.2: Verify test passes (no code change needed if Task 7 implemented correctly)**
+
+The `--all` loop should already call `resolve_drift_issue` when `report_mode == "issue"`. If the test fails, fix the `_scan_all_repos` function.
+
+- [ ] **Step 8.3: Run gate + commit**
+
+```bash
+uv run pytest && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+git add tests/unit/cli/test_drift.py
+git commit -m "$(cat <<'EOF'
+test(phase-8.5): add --all + issue mode integration test
+
+Verifies that --all --report-mode issue calls resolve_drift_issue
+once per enabled repo. 2 repos in config → 2 resolve calls.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `.github/workflows/drift-scanner.yml`
+
+**Goal:** Create the weekly cron workflow.
+
+**Files:**
+- Create: `.github/workflows/drift-scanner.yml`
+
+- [ ] **Step 9.1: Create the workflow file**
+
+Create `.github/workflows/drift-scanner.yml`:
+
+```yaml
+name: Drift Scanner
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'   # Every Monday 00:00 UTC (= 09:00 JST)
+  workflow_dispatch:        # Manual trigger for debugging
+
+permissions:
+  issues: write             # Create/update/close drift Issues
+  contents: read            # Read repos.yml from package data
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install gh-manage
+        run: uv tool install git+https://github.com/yakkuro/gh-manage@cli/v0.6.0
+
+      - name: Run drift scanner
+        run: gh-manage drift --all --report-mode issue --severity low
+        env:
+          GH_TOKEN: ${{ secrets.GH_MANAGE_TOKEN }}
+```
+
+- [ ] **Step 9.2: Commit**
+
+```bash
+git add .github/workflows/drift-scanner.yml
+git commit -m "$(cat <<'EOF'
+ci(phase-8.5): add drift-scanner.yml weekly cron workflow
+
+Runs every Monday 00:00 UTC (09:00 JST) + manual workflow_dispatch.
+
+- Installs gh-manage from cli/v0.6.0 tag (immutable pin)
+- Runs: gh-manage drift --all --report-mode issue --severity low
+- GH_MANAGE_TOKEN secret required (Fine-grained PAT with
+  issues:write + contents:read + metadata:read)
+
+Phase 8.5 deferred items (rate limit retry, partial failure
+notification) are filed as separate Issues.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Final gate + dogfood smoke test
+
+**Goal:** Full gate, dogfood, push branch.
+
+- [ ] **Step 10.1: Full test suite**
+
+```bash
+uv run pytest 2>&1 | tail -10
+```
+
+Expected: ~388 tests pass (352 + ~36 new).
+
+- [ ] **Step 10.2: Lint + format**
+
+```bash
+uv run ruff check src/ tests/ && uvx ruff@0.8.0 format --check . 2>&1 | tail -5
+```
+
+Expected: clean.
+
+- [ ] **Step 10.3: Dogfood — single-repo issue mode**
+
+```bash
+uv run gh-manage drift . --profile python-service --report-mode issue 2>&1
+echo "exit=$?"
+```
+
+Expected: either creates an Issue on gh-manage or prints "No drift" (depending on current state). Exit 0.
+
+- [ ] **Step 10.4: Dogfood — --all stdout mode**
+
+```bash
+uv run gh-manage drift --all --report-mode stdout 2>&1
+echo "exit=$?"
+```
+
+Expected: scans all repos in repos.yml (currently just gh-manage), prints findings. Exit 0.
+
+- [ ] **Step 10.5: Push branch**
+
+```bash
+git push -u origin feat/phase-8.5-drift-automation 2>&1 | tail -5
+```
+
+---
+
+## Self-Review Notes
+
+### Spec coverage
+
+| Spec requirement | Task |
+|---|---|
+| `--report-mode issue` creates Issue | Task 6 |
+| Re-run updates existing Issue | Task 5 (resolve_drift_issue, update path) |
+| 24h auto-close on 2 consecutive zero scans | Task 4 (should_close_issue) + Task 5 (close path) |
+| Issue title `[gh-manage drift] <repo>`, label `gh-manage:drift` | Task 5 (_DRIFT_ISSUE_TITLE_TEMPLATE, ensure_drift_label) |
+| Issue body = markdown report + auto-update note | Task 3 (format_issue_body) |
+| Each scan adds comment with hidden metadata | Task 3 (format_issue_comment) |
+| `--all` loads repos.yml, scans enabled repos | Task 7 |
+| `--all` + path mutually exclusive | Task 7 |
+| `--all` skips check_profile_files | Task 7 |
+| `--all` partial continue | Task 7 |
+| repos.yml pydantic schema | Task 2 |
+| `owner/repo` name validation | Task 2 |
+| github_api/issues.py CRUD | Task 1 |
+| drift-scanner.yml weekly cron | Task 9 |
+| `--all --report-mode issue` per-repo | Task 8 |
+
+### Test count progression
+
+| After task | Count | Delta |
+|---|---|---|
+| Phase 8 baseline | 352 | — |
+| Task 1 (issues.py) | 363 | +11 |
+| Task 2 (repos.py) | 372 | +9 |
+| Task 3 (issue formatters) | 381 | +9 |
+| Task 4 (24h close) | 390 | +9 |
+| Task 5 (state machine) | 394 | +4 |
+| Task 6 (CLI issue mode) | 396 | +2 |
+| Task 7 (--all) | 399 | +3 |
+| Task 8 (integration) | 400 | +1 |
+| Task 9 (cron) | 400 | — |
+| Task 10 (smoke) | 400 | — |
+
+**Target: 352 → ~400 (+~48 tests)**

--- a/docs/specs/2026-04-12-phase-8.5-drift-automation-design.md
+++ b/docs/specs/2026-04-12-phase-8.5-drift-automation-design.md
@@ -157,6 +157,7 @@ class ReposConfig(BaseModel):
 - 先頭 HTML comment: 将来の検索 backup 用（dormant metadata、コスト 0）
 - body 全体は `format_markdown_report()` の出力 + scan metadata ヘッダ
 - body は毎回 **全文上書き**（最新 snapshot）
+- **ユーザー編集に関する注意**: body は scan ごとに上書きされるため、ユーザーが body を手動編集しても次の scan で消える。永続的なメモは **comment** に書くこと。Issue body の末尾に `> Note: This issue body is auto-updated by gh-manage drift scanner. Add comments below for manual notes.` を付記して POLA 違反を軽減する
 
 ### Issue comment template (`format_issue_comment`)
 
@@ -198,6 +199,26 @@ class ReposConfig(BaseModel):
 
 **5 comments に限定する理由**: 人間が途中に comment を挟んでも、scan comment は hidden metadata で識別可能。5 件あれば直近 2 scan を拾うのに十分（weekly cron なら 5 週分）。
 
+### 24h close の補足ルール (spec-critique fixes)
+
+- **タイムスタンプは UTC**: hidden metadata の `<timestamp>` は ISO8601 UTC 固定（`datetime.now(timezone.utc).isoformat()`）。ローカル TZ による誤判定を防ぐ
+- **"連続" の定義**: scan comment のうち hidden metadata `<!-- scan:finding-count:N -->` を持つもの**のみ**を対象にカウントする。人間の comment は「連続」判定に影響しない
+- **Reopen はしない**: auto-close 後に drift が再発した場合、**新 Issue を作成**する（closed Issue を reopen しない）。理由: 過去の scan 履歴（comment chain）と新しい drift を分離する方が時系列として読みやすい
+- **Malformed metadata**: parse に失敗した comment は skip + warning。close 判定は安全側（close しない）
+- **Issue が手動で close された場合**: scanner は open Issue を検索するので、手動 close 後は「Issue なし」扱いになる。次に findings > 0 なら新 Issue 作成。これは意図的な挙動（ユーザーが「この drift は許容」と判断して close した場合を尊重）
+
+### Feature 依存関係 (spec-critique CRITICAL response)
+
+Phase 8.5 は 2 つの feature を含む:
+1. **Issue state machine** (`--report-mode issue`, resolve_drift_issue, auto-close)
+2. **Multi-repo scan** (`--all`, repos.yml)
+
+これらは `--all --report-mode issue` の組み合わせで初めて production 価値を発揮する。ただし実装上は独立している:
+- Issue state machine は single-repo mode でも動く (`<path> --profile <name> --report-mode issue`)
+- `--all` は `--report-mode stdout` でも動く (`--all --report-mode stdout`)
+
+**実装順序**: Issue state machine (Tasks 1-6) → repos.yml + --all (Tasks 7-9) → cron workflow (Task 10) → integration test (Task 11)。Issue state machine が先に complete し、単体テスト可能。
+
 ---
 
 ## CLI Interface
@@ -230,7 +251,17 @@ gh manage drift --all
 - `--all` は bundled `repos.yml` をロード、`enabled: true` の repo を順に scan
 - 各 repo: `get_default_branch(repo_entry.name)` で branch 解決、labels + protection check を実行
 - `check_profile_files` は **skip**（ローカル clone なし）。stdout に `Note: check_profile_files skipped in --all mode (no local clone)` を出力
-- **partial continue**: 1 repo の API エラー → warning 出力 + 次の repo へ。最後に failed repos summary
+- **partial continue**: 1 repo の API エラー → warning 出力 + 次の repo へ。最後に structured summary:
+  ```
+  Scan complete: 3 repos scanned, 1 skipped, 1 failed
+
+  Results:
+    yakkuro/gh-manage       — 0 findings
+    yakkuro/port-registry   — 2 findings (1 critical, 1 high)
+    yakkuro/some-repo       — SKIPPED (enabled: false)
+    yakkuro/broken-repo     — FAILED (GhNotFoundError: repository not found)
+  ```
+  この summary は `--report-mode` に関係なく常に stderr に出力（stdout はレポート本体に使うため）
 
 ### `--all` + `--report-mode issue` の組み合わせ
 

--- a/docs/specs/2026-04-12-phase-8.5-drift-automation-design.md
+++ b/docs/specs/2026-04-12-phase-8.5-drift-automation-design.md
@@ -1,0 +1,366 @@
+# Phase 8.5 — Drift scanner automation design
+
+**Date:** 2026-04-12
+**Size:** Medium (4 new files, 2 modified, ~31 new tests, CI workflow)
+**Sizing Rationale:** 4 new source/config files + cron workflow + Issue state machine logic. Design judgments on state machine, partial failure, 24h close rule. Single implementation plan.
+**Target:** `yakkuro/gh-manage`
+**Goal:** Add `--report-mode issue` (auto-create/update/close GitHub Issues per repo), `--all` flag with bundled `repos.yml` for multi-repo scan, and `.github/workflows/drift-scanner.yml` weekly cron. Tag `cli/v0.6.0`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `gh manage drift <path> --profile <name> --report-mode issue` creates a GitHub Issue on the scanned repo with drift findings
+- [ ] Re-running the same command updates the existing Issue body + adds a scan comment (does NOT create a duplicate)
+- [ ] When findings drop to 0 on two consecutive scans 24h+ apart, the Issue is auto-closed with a closing comment
+- [ ] Issue title follows pattern `[gh-manage drift] <owner/repo>`, label `gh-manage:drift` is auto-created if missing
+- [ ] Issue body = latest summary (full `format_markdown_report` output), each scan adds a comment with finding count + hidden metadata
+- [ ] `gh manage drift --all` loads bundled `repos.yml`, scans all `enabled: true` repos
+- [ ] `--all` and `[<path>] --profile <name>` are mutually exclusive (`UsageError`)
+- [ ] `--all` skips `check_profile_files` (no local clone available) with a stdout note
+- [ ] `--all` continues on single-repo failure (skip + warning), reports failed repos in summary
+- [ ] `repos.yml` pydantic schema: `RepoEntry(name: str "owner/repo", profile: str, enabled: bool = True)`, `ReposConfig(version: Literal[1], repos: list[RepoEntry])`
+- [ ] `repos.yml` name field validated as `owner/repo` format
+- [ ] `github_api/issues.py` provides: `search_drift_issue`, `create_issue`, `update_issue_body`, `add_issue_comment`, `close_issue`, `ensure_drift_label`
+- [ ] `.github/workflows/drift-scanner.yml` runs weekly Monday 00:00 UTC with `workflow_dispatch`
+- [ ] `GH_MANAGE_TOKEN` secret used for auth in cron workflow
+- [ ] Tag `cli/v0.6.0` published with GitHub release
+- [ ] ~31 new tests (352 → ~383), all pass
+- [ ] Phase 8.5 deferred items (8 件) filed as GitHub Issues post-merge
+
+---
+
+## Scope
+
+### In scope
+
+- `--report-mode issue`: Issue state machine (create/update body/add comment/close)
+- `--all` flag with bundled `repos.yml`
+- `github_api/issues.py`: Issue CRUD via `gh api`
+- `models/repos.py`: pydantic schema for `repos.yml`
+- `src/gh_manage/data/repos.yml`: initial bundled config (gh-manage only)
+- `.github/workflows/drift-scanner.yml`: weekly cron
+- Issue body/comment formatters in `drift_sync.py`
+- 24h double-check auto-close logic
+- `gh-manage:drift` label auto-creation
+- `--all` partial continue on per-repo failure
+
+### Out of scope (deferred to Phase 8.6+)
+
+See [Out of Scope](#out-of-scope--deferred-to-phase-86) section below.
+
+---
+
+## Architecture
+
+Phase 8 の `drift_sync.py` に Issue 管理層を追加。新規ファイルは最小限:
+
+```
+既存 (modified):
+  drift_sync.py      → format_issue_body(), format_issue_comment(),
+                        resolve_drift_issue(), parse_zero_findings_timestamps()
+  commands/drift.py  → --report-mode issue + --all flag
+
+新規:
+  src/gh_manage/github_api/issues.py     — Issue CRUD wrapper
+  src/gh_manage/models/repos.py          — RepoEntry + ReposConfig pydantic schema
+  src/gh_manage/data/repos.yml           — bundled repo list
+  .github/workflows/drift-scanner.yml    — weekly cron workflow
+```
+
+### Layer diagram
+
+```
+commands/drift.py (CLI)
+    ↓
+drift_sync.py (engine)
+    ├── run_all_checks()              ← Phase 8 既存
+    ├── _filter_by_severity()         ← Phase 8 既存
+    ├── format_*_report()             ← Phase 8 既存 (stdout/json/markdown)
+    ├── format_issue_body()           ← 新規 (markdown report + scan metadata header)
+    ├── format_issue_comment()        ← 新規 (finding count + hidden metadata)
+    ├── parse_zero_findings_timestamps() ← 新規 (comment hidden metadata → datetime list)
+    └── resolve_drift_issue()         ← 新規 (Issue state machine)
+    ↓
+github_api/issues.py (Issue CRUD)     ← 新規
+models/repos.py (repos.yml schema)    ← 新規
+```
+
+`github_api/issues.py` は `github_api/labels.py` と同じパターン — `run_gh_api` / `run_gh` の薄い wrapper。Issue 固有のロジック（state machine、24h 判定）は `drift_sync.py` 側。
+
+### `drift_sync.py` サイズ
+
+Phase 8 時点 ~500 LOC。Issue 層追加で ~700 LOC 見込み。800 LOC を超えたら Phase 8.6+ でサブモジュール化する。
+
+---
+
+## Data Model
+
+### `repos.yml` schema
+
+```yaml
+version: 1
+repos:
+  - name: yakkuro/gh-manage
+    profile: python-service
+    enabled: true
+  - name: yakkuro/port-registry
+    profile: python-service
+```
+
+```python
+class RepoEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str           # "owner/repo" full form
+    profile: str        # bundled profile name
+    enabled: bool = True
+
+    @field_validator("name")
+    @classmethod
+    def _validate_owner_repo_format(cls, v: str) -> str:
+        if "/" not in v or v.count("/") != 1:
+            raise ValueError(
+                f"Repo name must be in 'owner/repo' format, got: {v!r}"
+            )
+        owner, repo = v.split("/")
+        if not owner or not repo:
+            raise ValueError(
+                f"Repo name must have non-empty owner and repo parts, got: {v!r}"
+            )
+        return v
+
+
+class ReposConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1]
+    repos: list[RepoEntry]
+```
+
+### Issue body template (`format_issue_body`)
+
+```markdown
+<!-- gh-manage:drift:yakkuro/port-registry -->
+
+# Drift report — `yakkuro/port-registry`
+
+**Last scan**: 2026-04-12T09:00:00Z
+**Findings**: 2 critical, 1 high, 0 medium, 0 low — 3 total
+
+## Critical
+
+### `protection/enforce_admins`
+...
+```
+
+- 先頭 HTML comment: 将来の検索 backup 用（dormant metadata、コスト 0）
+- body 全体は `format_markdown_report()` の出力 + scan metadata ヘッダ
+- body は毎回 **全文上書き**（最新 snapshot）
+
+### Issue comment template (`format_issue_comment`)
+
+```markdown
+## Scan run — 2026-04-12T09:00:00Z
+
+<!-- scan:zero-findings:2026-04-12T09:00:00Z -->
+<!-- scan:finding-count:3 -->
+
+**3 findings** (2 critical, 1 high)
+```
+
+- hidden metadata で **zero-findings タイムスタンプ** と **finding count** を埋め込み
+- zero findings の場合: `<!-- scan:zero-findings:<ISO8601> -->` + `<!-- scan:finding-count:0 -->`
+- findings > 0 の場合: `<!-- scan:finding-count:N -->` のみ（`scan:zero-findings` 行は emit しない）
+
+### Issue state machine
+
+```
+[Issue なし] ──findings > 0──→ CREATE Issue (body + comment)
+             ──findings = 0──→ 何もしない (drift なしなので Issue 不要)
+
+[Issue open] ──findings > 0──→ UPDATE body + ADD comment
+             ──findings = 0──→ UPDATE body("0 findings") + ADD comment(zero-findings metadata)
+                                  ↓
+                               24h close 判定:
+                                 直近 2 scan comment が両方 zero-findings
+                                 かつ timestamp 差 ≥ 24h → CLOSE + closing comment
+                                 それ以外 → open のまま（次の run を待つ）
+```
+
+### 24h close 判定の具体ロジック
+
+1. open Issue の最新 5 comments を `gh api repos/{repo}/issues/{number}/comments?per_page=5&sort=created&direction=desc` で取得
+2. 各 comment body から `<!-- scan:zero-findings:<timestamp> -->` を regex parse
+3. scan comment のうち zero-findings metadata を持つものを時系列で並べる
+4. 直近 2 つが **連続して** zero-findings で、かつ 2 つの timestamp 差 ≥ 24h → close
+5. 条件不成立 → open のまま
+
+**5 comments に限定する理由**: 人間が途中に comment を挟んでも、scan comment は hidden metadata で識別可能。5 件あれば直近 2 scan を拾うのに十分（weekly cron なら 5 週分）。
+
+---
+
+## CLI Interface
+
+### `--report-mode issue` 追加
+
+```
+gh manage drift [<path>] --profile <name>
+                [--severity <critical|high|medium|low>]
+                [--report-mode <stdout|json|markdown-file|issue>]
+                [--output <path>]
+```
+
+`--report-mode issue` のとき:
+- `--output` は無視（Issue が destination）
+- path 引数は必須（git origin 解決用）
+- scan → findings → Issue state machine
+- stdout に 1 行サマリ: `Created issue #42` / `Updated issue #42 (3 findings)` / `Closed issue #42 (zero drift)`
+
+### `--all` flag 追加
+
+```
+gh manage drift --all
+                [--severity <critical|high|medium|low>]
+                [--report-mode <stdout|json|markdown-file|issue>]
+                [--output <path>]
+```
+
+- `--all` と `[<path>] --profile <name>` は **排他** (`click.UsageError`)
+- `--all` は bundled `repos.yml` をロード、`enabled: true` の repo を順に scan
+- 各 repo: `get_default_branch(repo_entry.name)` で branch 解決、labels + protection check を実行
+- `check_profile_files` は **skip**（ローカル clone なし）。stdout に `Note: check_profile_files skipped in --all mode (no local clone)` を出力
+- **partial continue**: 1 repo の API エラー → warning 出力 + 次の repo へ。最後に failed repos summary
+
+### `--all` + `--report-mode issue` の組み合わせ
+
+repo ごとに Issue state machine を独立実行。repo A の Issue 作成失敗が repo B に影響しない（partial continue）。
+
+### Exit codes
+
+| Code | 条件 |
+|---|---|
+| 0 | scan 完了（findings の有無を問わない。`--all` で partial failure があっても exit 0） |
+| 1 | domain error (single-repo mode のみ。`--all` mode は partial continue で exit 0) |
+| 2 | click UsageError |
+
+---
+
+## `drift-scanner.yml` cron workflow
+
+```yaml
+name: Drift Scanner
+on:
+  schedule:
+    - cron: '0 0 * * 1'   # 毎週月曜 00:00 UTC (= 09:00 JST)
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+      - run: uv tool install git+https://github.com/yakkuro/gh-manage@cli/v0.6.0
+      - run: gh-manage drift --all --report-mode issue --severity low
+        env:
+          GH_TOKEN: ${{ secrets.GH_MANAGE_TOKEN }}
+```
+
+- `GH_MANAGE_TOKEN`: Fine-grained PAT（`issues: write` + `contents: read` + `metadata: read`）
+- `--severity low`: 全 severity を Issue に含める
+- `cli/v0.6.0` pin（immutable tag）
+- `workflow_dispatch` で手動実行可
+- gh-manage 本体リポに配置（consumer repo には不要）
+
+---
+
+## Error Handling
+
+**新規エラー型は追加しない**。既存の `DriftError` + `GhError` で十分。
+
+| パス | 扱い |
+|---|---|
+| `repos.yml` parse 失敗 | `ConfigError` → ClickException (exit 1) |
+| `repos.yml` に unknown repo | `GhNotFoundError` → skip + warning（`--all` 時） |
+| Issue 作成/更新失敗 | `GhError` → single-repo: ClickException (exit 1) / `--all`: skip + warning |
+| ラベル `gh-manage:drift` 作成失敗 | `GhError` → ClickException (exit 1) |
+| Issue comment parse 失敗 (malformed metadata) | warning 出力 + close 判定 skip（安全側: Issue を open のまま） |
+| `--all` で 1 repo 失敗 | skip + stderr warning + 次の repo へ。最後に failed repos summary。exit 0 |
+
+### Silent failure 禁止
+
+Phase 8 と同じ原則。bare `except:` 禁止。`OSError` は具体メッセージ付きで re-raise。
+
+### Fail-fast vs partial continue
+
+| Mode | 方針 |
+|---|---|
+| single-repo (`<path> --profile <name>`) | fail-fast（Phase 8 と同じ） |
+| `--all` | partial continue（1 repo 失敗で全体を止めない） |
+
+`--all` で partial continue にする理由: cron が 1 repo の 403 で全停止すると運用に耐えない。他 repo の drift 検出が遅れるリスクの方が大きい。
+
+---
+
+## Testing Strategy
+
+TDD 必須。カバレッジ目標: `drift_sync.py` 90%+, `commands/drift.py` 85%+。
+
+| Layer | File | Count | 内容 |
+|---|---|---|---|
+| models | `test_repos.py` | ~5 | RepoEntry/ReposConfig validation, enabled default, name format |
+| github_api | `test_issues.py` | ~8 | search, create, update body, add comment, close, ensure_label — subprocess mock |
+| Issue format | `test_issue_report.py` | ~6 | format_issue_body, format_issue_comment, hidden metadata parse, zero-findings 判定 |
+| State machine | `test_drift_sync.py` 追記 | ~5 | resolve_drift_issue 4 パス + 24h 判定 |
+| CLI | `test_drift.py` 追記 | ~6 | `--report-mode issue` happy, `--all` happy, 排他, partial failure, repos.yml not found |
+| Golden | `test_drift_sync.py` 追記 | ~1 | `--all` + repos.yml full scan (mock API) |
+
+**合計: ~31 new tests** (352 → ~383)
+
+### Mock boundaries
+
+- `github_api/issues.py` の各関数 → subprocess mock（`run_gh_api` / `run_gh`）
+- `resolve_drift_issue` → `github_api.issues` の関数を module-attribute mock
+- `--all` mode → bundled `repos.yml` を実際にロード（package data 経由）
+- `--all` の各 repo scan → `labels_api` / `protection_api` / `repo_info` を mock
+
+---
+
+## Release Plan
+
+1. Phase 8.5 feature PR: `feat/phase-8.5-drift-automation` → `main`
+2. `chore/bump-cli-v0.6.0` PR（3 箇所 + uv.lock）
+3. Tag `cli/v0.6.0` on bump commit
+4. GitHub release
+5. Install smoke test: `gh-manage drift --all --report-mode issue` on gh-manage repo
+6. Deferred items (8 件) を GitHub Issues として起票
+
+---
+
+## Out of Scope — Deferred to Phase 8.6+
+
+| # | Item | 延期理由 |
+|---|---|---|
+| 1 | `check_workflow_pinning` | Phase 8 deferred のまま。Issue mode と独立 |
+| 2 | `--fix` interactive mode | 同上 |
+| 3 | Rate limit retry (scheduled) | weekly 1 回で rate limit に当たる確率極低 |
+| 4 | Finding-level diff in comment | MVP は count 増減のみ。finding 単位の resolved/new は Phase 8.6+ |
+| 5 | `--all` + `check_profile_files` (clone/API) | Section 3 合意。skip + 注記 |
+| 6 | Issue body テンプレートカスタマイズ | YAGNI |
+| 7 | multi-org support | repos.yml は owner/repo full form で対応済み。CLI 分岐不要 |
+| 8 | `--continue-on-error` explicit flag | `--all` は暗黙 partial continue。flag は不要 |
+
+## Related documents
+
+- Phase 8 drift spec: `docs/specs/2026-04-11-phase-8-drift-design.md`
+- Phase 8 drift plan: `docs/plans/2026-04-11-phase-8-drift.md`
+- Master design: `docs/specs/2026-04-10-gh-manage-design.md` — Phase 8 section (line 883+)
+- Release checklist: `docs/release-checklist.md`

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -102,6 +102,162 @@ def _resolve_branch_protection_path() -> Path:
     return Path(str(files("gh_manage.data") / "branch-protection.yml"))
 
 
+def _resolve_repos_path() -> Path:
+    """Resolve the bundled repos.yml path."""
+    return Path(str(files("gh_manage.data") / "repos.yml"))
+
+
+def _scan_single_repo(
+    owner_repo: str,
+    profile_name: str,
+    severity: str,
+    report_mode: str,
+    output: Path | None,
+    skip_profile_check: bool = False,
+) -> str:
+    """Scan a single repo and return the result/status string.
+
+    Args:
+        owner_repo: Repository in "owner/repo" format.
+        profile_name: Profile name to use.
+        severity: Minimum severity to report.
+        report_mode: Output mode (stdout, json, markdown-file, issue).
+        output: Output file path (for markdown-file mode).
+        skip_profile_check: If True, don't check profile files locally
+            (used in --all mode with no local clone).
+
+    Returns:
+        Status/result string for the repo.
+    """
+    # Get default branch
+    default_branch = repo_info.get_default_branch(owner_repo)
+
+    # Load profile and configs
+    profile = load_config(_resolve_profile_path(profile_name), ProfileSpec)
+    labels_config = load_config(_resolve_default_labels_path(), LabelsConfig)
+
+    bp_config: BranchProtectionConfig | None = None
+    if profile.protection_policy is not None:
+        bp_config = load_config(
+            _resolve_branch_protection_path(), BranchProtectionConfig
+        )
+        if profile.protection_policy not in bp_config.policies:
+            from gh_manage.protection_sync import ProtectionPolicyNotFoundError
+
+            raise ProtectionPolicyNotFoundError(
+                f"Policy {profile.protection_policy!r} not found in "
+                f"branch-protection.yml. Available policies: "
+                f"{sorted(bp_config.policies.keys())}."
+            )
+
+    # In --all mode, use a dummy empty path (skip_profile_check=True)
+    # In normal mode, use the actual path
+    if skip_profile_check:
+        import tempfile
+
+        scan_path = (
+            Path(tempfile.gettempdir())
+            / f"gh-manage-scan-{owner_repo.replace('/', '-')}"
+        )
+        scan_path.mkdir(exist_ok=True)
+    else:
+        scan_path = Path.cwd().resolve()
+
+    ctx = ScanContext(
+        path=scan_path,
+        repo=owner_repo,
+        default_branch=default_branch,
+        profile=profile,
+        labels_config=labels_config,
+        bp_config=bp_config,
+    )
+
+    all_findings = drift_sync.run_all_checks(ctx)
+    filtered = drift_sync._filter_by_severity(all_findings, severity)  # type: ignore[arg-type]
+
+    match report_mode:
+        case "stdout":
+            rendered = drift_sync.format_stdout_report(filtered)
+            return rendered
+        case "json":
+            rendered = drift_sync.format_json_report(filtered)
+            return rendered
+        case "markdown-file":
+            rendered = drift_sync.format_markdown_report(filtered)
+            if output is not None:
+                try:
+                    output.write_text(rendered, encoding="utf-8")
+                except OSError as e:
+                    raise DriftOutputError(
+                        f"Cannot write drift report to {output}: {e}. "
+                        f"Check disk space, write permissions, and that the parent "
+                        f"directory exists."
+                    ) from e
+            return f"Report written to {output}"
+        case "issue":
+            from datetime import datetime, timezone
+
+            status = drift_sync.resolve_drift_issue(
+                filtered,
+                owner_repo,
+                datetime.now(timezone.utc).isoformat(),
+            )
+            return status
+        case _:
+            raise ValueError(f"Unknown report mode: {report_mode!r}")
+
+
+def _scan_all_repos(
+    severity: str,
+    report_mode: str,
+    output: Path | None,
+) -> None:
+    """Scan all enabled repos from repos.yml.
+
+    Prints a structured summary to stderr with scan counts and results.
+    """
+    from gh_manage.models.repos import ReposConfig
+
+    repos_path = _resolve_repos_path()
+    config = load_config(repos_path, ReposConfig)
+
+    results = []
+    skipped = 0
+    failed = 0
+
+    for entry in config.repos:
+        if not entry.enabled:
+            results.append(f"  {entry.name}: SKIPPED (disabled)")
+            skipped += 1
+            continue
+
+        try:
+            result_str = _scan_single_repo(
+                entry.name,
+                entry.profile,
+                severity,
+                report_mode,
+                output,
+                skip_profile_check=True,
+            )
+            # For stdout/json/markdown mode, print the result
+            if report_mode in ("stdout", "json", "markdown-file"):
+                click.echo(result_str)
+            results.append(f"  {entry.name}: OK")
+        except GhError as e:
+            results.append(f"  {entry.name}: FAILED ({e})")
+            failed += 1
+
+    # Print summary to stderr
+    scanned = len(config.repos) - skipped
+    click.echo(
+        f"\n--- Scan Summary ---\nScanned: {scanned}, Skipped: {skipped}, Failed: {failed}",
+        err=True,
+    )
+    for result in results:
+        click.echo(result, err=True)
+
+
 @click.command(
     "drift",
     help=(
@@ -111,14 +267,21 @@ def _resolve_branch_protection_path() -> Path:
 )
 @click.argument(
     "path",
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-    default=".",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    required=False,
 )
 @click.option(
     "--profile",
     "profile_name",
-    required=True,
+    default=None,
     help="Profile name (resolves to bundled profiles/<name>.yml).",
+)
+@click.option(
+    "--all",
+    "scan_all",
+    is_flag=True,
+    help="Scan all enabled repos from repos.yml instead of a single path.",
 )
 @click.option(
     "--severity",
@@ -140,76 +303,51 @@ def _resolve_branch_protection_path() -> Path:
 )
 @_handle_errors
 def drift(
-    path: Path,
-    profile_name: str,
+    path: Path | None,
+    profile_name: str | None,
+    scan_all: bool,
     severity: str,
     report_mode: str,
     output: Path | None,
 ) -> None:
-    """Scan `path` for drift against the named profile."""
-    target = path.resolve()
-    owner_repo = git_cli.get_origin_owner_repo(target)
-    default_branch = repo_info.get_default_branch(owner_repo)
-
-    profile = load_config(_resolve_profile_path(profile_name), ProfileSpec)
-    labels_config = load_config(_resolve_default_labels_path(), LabelsConfig)
-
-    bp_config: BranchProtectionConfig | None = None
-    if profile.protection_policy is not None:
-        bp_config = load_config(
-            _resolve_branch_protection_path(), BranchProtectionConfig
-        )
-        if profile.protection_policy not in bp_config.policies:
-            from gh_manage.protection_sync import ProtectionPolicyNotFoundError
-
-            raise ProtectionPolicyNotFoundError(
-                f"Policy {profile.protection_policy!r} not found in "
-                f"branch-protection.yml. Available policies: "
-                f"{sorted(bp_config.policies.keys())}."
+    """Scan for drift against the named profile."""
+    # Validation: --all XOR (path + profile)
+    if scan_all:
+        if path is not None or profile_name is not None:
+            raise click.UsageError(
+                "--all and path/--profile are mutually exclusive. "
+                "Use either '--all' (scans all repos) or 'path --profile' (single repo)."
             )
+        _scan_all_repos(severity, report_mode, output)
+        return
 
-    ctx = ScanContext(
-        path=target,
-        repo=owner_repo,
-        default_branch=default_branch,
-        profile=profile,
-        labels_config=labels_config,
-        bp_config=bp_config,
+    # Single-repo mode
+    if path is None or profile_name is None:
+        raise click.UsageError(
+            "--profile is required when not using --all. "
+            "Provide both 'path' and '--profile', or use '--all' to scan all repos."
+        )
+
+    # Check that path exists
+    target = path.resolve()
+    if not target.exists():
+        raise click.UsageError(f"Path does not exist: {target}")
+
+    owner_repo = git_cli.get_origin_owner_repo(target)
+    result = _scan_single_repo(
+        owner_repo,
+        profile_name,
+        severity,
+        report_mode,
+        output,
+        skip_profile_check=False,
     )
 
-    all_findings = drift_sync.run_all_checks(ctx)
-    filtered = drift_sync._filter_by_severity(all_findings, severity)  # type: ignore[arg-type]
-
-    match report_mode:
-        case "stdout":
-            rendered = drift_sync.format_stdout_report(filtered)
-        case "json":
-            rendered = drift_sync.format_json_report(filtered)
-        case "markdown-file":
-            rendered = drift_sync.format_markdown_report(filtered)
-        case "issue":
-            from datetime import datetime, timezone
-
-            status = drift_sync.resolve_drift_issue(
-                filtered,
-                owner_repo,
-                datetime.now(timezone.utc).isoformat(),
-            )
-            click.echo(status)
-            return
-        case _:
-            # click.Choice prevents this
-            raise ValueError(f"Unknown report mode: {report_mode!r}")
-
-    if output is None:
-        click.echo(rendered)
+    # For issue mode, result is already printed by resolve_drift_issue
+    # For other modes, we need to print or write the result
+    if report_mode == "issue":
+        click.echo(result)
+    elif report_mode == "markdown-file":
+        click.echo(result)
     else:
-        try:
-            output.write_text(rendered, encoding="utf-8")
-        except OSError as e:
-            raise DriftOutputError(
-                f"Cannot write drift report to {output}: {e}. "
-                f"Check disk space, write permissions, and that the parent "
-                f"directory exists."
-            ) from e
-        click.echo(f"Report written to {output}")
+        click.echo(result)

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -128,7 +128,7 @@ def _resolve_branch_protection_path() -> Path:
 )
 @click.option(
     "--report-mode",
-    type=click.Choice(["stdout", "json", "markdown-file"]),
+    type=click.Choice(["stdout", "json", "markdown-file", "issue"]),
     default="stdout",
     help="Report format. Destination is --output (defaults to stdout).",
 )
@@ -187,6 +187,16 @@ def drift(
             rendered = drift_sync.format_json_report(filtered)
         case "markdown-file":
             rendered = drift_sync.format_markdown_report(filtered)
+        case "issue":
+            from datetime import datetime, timezone
+
+            status = drift_sync.resolve_drift_issue(
+                filtered,
+                owner_repo,
+                datetime.now(timezone.utc).isoformat(),
+            )
+            click.echo(status)
+            return
         case _:
             # click.Choice prevents this
             raise ValueError(f"Unknown report mode: {report_mode!r}")

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -244,7 +244,14 @@ def _scan_all_repos(
             if report_mode in ("stdout", "json", "markdown-file"):
                 click.echo(result_str)
             results.append(f"  {entry.name}: OK")
-        except GhError as e:
+        except (
+            GhError,
+            ConfigError,
+            GitError,
+            ProfileError,
+            ProtectionError,
+            DriftError,
+        ) as e:
             results.append(f"  {entry.name}: FAILED ({e})")
             failed += 1
 

--- a/src/gh_manage/data/repos.yml
+++ b/src/gh_manage/data/repos.yml
@@ -1,0 +1,4 @@
+version: 1
+repos:
+  - name: yakkuro/gh-manage
+    profile: python-service

--- a/src/gh_manage/drift_sync.py
+++ b/src/gh_manage/drift_sync.py
@@ -165,6 +165,7 @@ def _filter_by_severity(
 
 # ========== Adapters ==========
 
+from gh_manage.github_api import issues as issues_api  # noqa: E402
 from gh_manage.github_api import labels as labels_api  # noqa: E402
 from gh_manage.labels_sync import (  # noqa: E402
     LabelsDiff,
@@ -738,3 +739,57 @@ def should_close_issue(comments: list[dict[str, Any]]) -> bool:
     # timestamps[0] is newest, timestamps[1] is second newest
     gap = timestamps[0] - timestamps[1]
     return gap >= timedelta(hours=24)
+
+
+_DRIFT_ISSUE_TITLE_TEMPLATE = "[gh-manage drift] {repo}"
+_DRIFT_LABEL = "gh-manage:drift"
+
+
+def resolve_drift_issue(
+    findings: tuple[Finding, ...],
+    repo: str,
+    scan_time: str,
+) -> str:
+    """Issue state machine: search → create/update/close.
+
+    Returns a human-readable status string for CLI output.
+    """
+    issues_api.ensure_drift_label(repo)
+    existing = issues_api.search_drift_issue(repo)
+    has_findings = len(findings) > 0
+
+    if existing is None:
+        # No open Issue
+        if not has_findings:
+            return f"No drift detected for {repo}. No Issue created."
+        # Create new Issue
+        body = format_issue_body(findings, repo, scan_time)
+        comment = format_issue_comment(findings, scan_time)
+        title = _DRIFT_ISSUE_TITLE_TEMPLATE.format(repo=repo)
+        issue = issues_api.create_issue(repo, title, body, [_DRIFT_LABEL])
+        issues_api.add_issue_comment(repo, issue["number"], comment)
+        return f"Created issue #{issue['number']} on {repo} ({len(findings)} findings)"
+
+    issue_number = existing["number"]
+
+    # Update existing Issue
+    body = format_issue_body(findings, repo, scan_time)
+    comment = format_issue_comment(findings, scan_time)
+    issues_api.update_issue_body(repo, issue_number, body)
+    issues_api.add_issue_comment(repo, issue_number, comment)
+
+    if not has_findings:
+        # Check 24h close rule
+        comments = issues_api.get_issue_comments(repo, issue_number, per_page=5)
+        if should_close_issue(comments):
+            issues_api.close_issue(repo, issue_number)
+            issues_api.add_issue_comment(
+                repo,
+                issue_number,
+                f"## Auto-closed — {scan_time}\n\n"
+                f"Zero drift detected on 2 consecutive scans ≥24h apart. "
+                f"If drift recurs, a new Issue will be created.",
+            )
+            return f"Closed issue #{issue_number} on {repo} (zero drift, 24h rule satisfied)"
+
+    return f"Updated issue #{issue_number} on {repo} ({len(findings)} findings)"

--- a/src/gh_manage/drift_sync.py
+++ b/src/gh_manage/drift_sync.py
@@ -40,8 +40,10 @@ from __future__ import annotations
 
 import hashlib
 import json as _json
+import re as _re
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from importlib.resources import files as _package_files
 from itertools import chain
 from pathlib import Path
@@ -693,3 +695,46 @@ def format_issue_comment(findings: tuple[Finding, ...], scan_time: str) -> str:
         lines.append(f"**{count} findings** ({', '.join(summary_parts)})")
 
     return "\n".join(lines)
+
+
+_ZERO_FINDINGS_RE = _re.compile(r"<!-- scan:zero-findings:(\S+) -->")
+
+
+def parse_zero_findings_timestamps(
+    comments: list[dict[str, Any]],
+) -> list[datetime]:
+    """Parse <!-- scan:zero-findings:<ISO8601> --> from comment bodies.
+
+    Returns a list of datetime objects (newest first, matching the
+    comment order from get_issue_comments which returns newest first).
+    Malformed timestamps are silently skipped.
+    """
+    timestamps: list[datetime] = []
+    for comment in comments:
+        body = comment.get("body", "")
+        match = _ZERO_FINDINGS_RE.search(body)
+        if match:
+            try:
+                ts = datetime.fromisoformat(match.group(1))
+                timestamps.append(ts)
+            except ValueError:
+                # Malformed timestamp — skip
+                continue
+    return timestamps
+
+
+def should_close_issue(comments: list[dict[str, Any]]) -> bool:
+    """Check if the 24h double-check rule is satisfied.
+
+    Rule: the most recent 2 scan comments with zero-findings metadata
+    must have timestamps ≥ 24h apart. If fewer than 2 zero-findings
+    comments exist, or if the gap is < 24h, return False.
+
+    Comments are expected newest-first (from get_issue_comments).
+    """
+    timestamps = parse_zero_findings_timestamps(comments)
+    if len(timestamps) < 2:
+        return False
+    # timestamps[0] is newest, timestamps[1] is second newest
+    gap = timestamps[0] - timestamps[1]
+    return gap >= timedelta(hours=24)

--- a/src/gh_manage/drift_sync.py
+++ b/src/gh_manage/drift_sync.py
@@ -632,3 +632,64 @@ def format_markdown_report(findings: tuple[Finding, ...]) -> str:
             lines.append("")
 
     return "\n".join(lines)
+
+
+def format_issue_body(findings: tuple[Finding, ...], repo: str, scan_time: str) -> str:
+    """Format the GitHub Issue body for a drift report.
+
+    Layout:
+      <!-- gh-manage:drift:<repo> -->        (dormant search metadata)
+      <format_markdown_report output>        (the report itself)
+      **Last scan**: <scan_time>
+      > Note: This issue body is auto-updated by gh-manage drift scanner.
+      > Add comments below for manual notes.
+    """
+    markdown = format_markdown_report(findings)
+
+    lines = [
+        f"<!-- gh-manage:drift:{repo} -->",
+        "",
+        markdown,
+        "",
+        f"**Last scan**: {scan_time}",
+        "",
+        "> Note: This issue body is auto-updated by gh-manage drift scanner. "
+        "Add comments below for manual notes.",
+    ]
+    return "\n".join(lines)
+
+
+def format_issue_comment(findings: tuple[Finding, ...], scan_time: str) -> str:
+    """Format a scan run comment with hidden metadata.
+
+    Hidden metadata:
+    - <!-- scan:finding-count:N --> — always present
+    - <!-- scan:zero-findings:<ISO8601> --> — only when N=0
+
+    The 24h auto-close logic parses these from comments to determine
+    whether to close the Issue.
+    """
+    count = len(findings)
+    counts = _count_by_severity(findings)
+
+    lines = [
+        f"## Scan run — {scan_time}",
+        "",
+    ]
+
+    if count == 0:
+        lines.append(f"<!-- scan:zero-findings:{scan_time} -->")
+    lines.append(f"<!-- scan:finding-count:{count} -->")
+    lines.append("")
+
+    if count == 0:
+        lines.append("**0 findings** — no drift detected.")
+    else:
+        summary_parts = []
+        for sev in ("critical", "high", "medium", "low"):
+            c = counts.get(sev, 0)
+            if c > 0:
+                summary_parts.append(f"{c} {sev}")
+        lines.append(f"**{count} findings** ({', '.join(summary_parts)})")
+
+    return "\n".join(lines)

--- a/src/gh_manage/drift_sync.py
+++ b/src/gh_manage/drift_sync.py
@@ -689,8 +689,8 @@ def format_issue_comment(findings: tuple[Finding, ...], scan_time: str) -> str:
         lines.append("**0 findings** — no drift detected.")
     else:
         summary_parts = []
-        for sev in ("critical", "high", "medium", "low"):
-            c = counts.get(sev, 0)
+        for sev in _SEVERITY_ORDER:
+            c = counts[sev]
             if c > 0:
                 summary_parts.append(f"{c} {sev}")
         lines.append(f"**{count} findings** ({', '.join(summary_parts)})")

--- a/src/gh_manage/github_api/issues.py
+++ b/src/gh_manage/github_api/issues.py
@@ -44,9 +44,9 @@ def create_issue(repo: str, title: str, body: str, labels: list[str]) -> dict[st
         method="POST",
         body={"title": title, "body": body, "labels": labels},
     )
-    assert isinstance(result, dict), (
-        f"Expected dict from issue creation, got {type(result).__name__}"
-    )
+    assert isinstance(
+        result, dict
+    ), f"Expected dict from issue creation, got {type(result).__name__}"
     return result
 
 
@@ -113,7 +113,7 @@ def get_issue_comments(
     )
     if result is None:
         return []
-    assert isinstance(result, list), (
-        f"Expected list from comments endpoint, got {type(result).__name__}"
-    )
+    assert isinstance(
+        result, list
+    ), f"Expected list from comments endpoint, got {type(result).__name__}"
     return result

--- a/src/gh_manage/github_api/issues.py
+++ b/src/gh_manage/github_api/issues.py
@@ -1,0 +1,119 @@
+"""GitHub Issues API helpers for the drift scanner.
+
+Thin wrapper around gh_manage.github_client for Issue-specific operations.
+Mirrors the pattern of github_api/labels.py — each function is a single
+API call with typed arguments and minimal logic.
+
+Phase 8.5 uses these for the drift Issue state machine:
+create/update/close Issues and manage the `gh-manage:drift` label.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gh_manage.github_client import GhError, run_gh_api
+
+
+_DRIFT_LABEL = "gh-manage:drift"
+_DRIFT_LABEL_COLOR = "d4c5f9"
+_DRIFT_LABEL_DESCRIPTION = "Automated drift report from gh-manage scanner"
+
+
+def search_drift_issue(repo: str) -> dict[str, Any] | None:
+    """Search for an open drift Issue on the repo.
+
+    Uses the Issues endpoint with label filter (NOT the search API,
+    which has index delay). Returns the first matching Issue dict,
+    or None if no open drift Issue exists.
+    """
+    result = run_gh_api(
+        f"repos/{repo}/issues?labels={_DRIFT_LABEL}&state=open&per_page=1"
+    )
+    if result is None:
+        return None
+    if isinstance(result, list) and len(result) > 0:
+        return result[0]
+    return None
+
+
+def create_issue(repo: str, title: str, body: str, labels: list[str]) -> dict[str, Any]:
+    """POST /repos/{repo}/issues. Returns the created Issue dict."""
+    result = run_gh_api(
+        f"repos/{repo}/issues",
+        method="POST",
+        body={"title": title, "body": body, "labels": labels},
+    )
+    assert isinstance(result, dict), (
+        f"Expected dict from issue creation, got {type(result).__name__}"
+    )
+    return result
+
+
+def update_issue_body(repo: str, issue_number: int, body: str) -> None:
+    """PATCH /repos/{repo}/issues/{number} — update body only."""
+    run_gh_api(
+        f"repos/{repo}/issues/{issue_number}",
+        method="PATCH",
+        body={"body": body},
+    )
+
+
+def add_issue_comment(repo: str, issue_number: int, body: str) -> None:
+    """POST /repos/{repo}/issues/{number}/comments."""
+    run_gh_api(
+        f"repos/{repo}/issues/{issue_number}/comments",
+        method="POST",
+        body={"body": body},
+    )
+
+
+def close_issue(repo: str, issue_number: int) -> None:
+    """PATCH /repos/{repo}/issues/{number} — set state=closed."""
+    run_gh_api(
+        f"repos/{repo}/issues/{issue_number}",
+        method="PATCH",
+        body={"state": "closed"},
+    )
+
+
+def ensure_drift_label(repo: str) -> None:
+    """Ensure the `gh-manage:drift` label exists on the repo.
+
+    Attempts to create it. If the label already exists (HTTP 422),
+    the error is silently ignored. Any other error propagates.
+    """
+    try:
+        run_gh_api(
+            f"repos/{repo}/labels",
+            method="POST",
+            body={
+                "name": _DRIFT_LABEL,
+                "color": _DRIFT_LABEL_COLOR,
+                "description": _DRIFT_LABEL_DESCRIPTION,
+            },
+        )
+    except GhError as e:
+        # 422 = label already exists — expected and harmless
+        if "422" in str(e) or "already_exists" in str(e):
+            return
+        raise
+
+
+def get_issue_comments(
+    repo: str, issue_number: int, per_page: int = 5
+) -> list[dict[str, Any]]:
+    """GET /repos/{repo}/issues/{number}/comments — latest N comments.
+
+    Returns newest first (sort=created, direction=desc).
+    """
+    result = run_gh_api(
+        f"repos/{repo}/issues/{issue_number}/comments"
+        f"?per_page={per_page}&sort=created&direction=desc"
+    )
+    if result is None:
+        return []
+    assert isinstance(result, list), (
+        f"Expected list from comments endpoint, got {type(result).__name__}"
+    )
+    return result

--- a/src/gh_manage/github_api/protection.py
+++ b/src/gh_manage/github_api/protection.py
@@ -31,9 +31,9 @@ def get_branch_protection(repo: str, branch: str = "main") -> dict[str, Any]:
     result = run_gh_api(f"repos/{repo}/branches/{branch}/protection")
     if result is None:
         return {}
-    assert isinstance(
-        result, dict
-    ), f"Expected dict response, got {type(result).__name__}"
+    assert isinstance(result, dict), (
+        f"Expected dict response, got {type(result).__name__}"
+    )
     return result
 
 

--- a/src/gh_manage/github_api/protection.py
+++ b/src/gh_manage/github_api/protection.py
@@ -31,9 +31,9 @@ def get_branch_protection(repo: str, branch: str = "main") -> dict[str, Any]:
     result = run_gh_api(f"repos/{repo}/branches/{branch}/protection")
     if result is None:
         return {}
-    assert isinstance(result, dict), (
-        f"Expected dict response, got {type(result).__name__}"
-    )
+    assert isinstance(
+        result, dict
+    ), f"Expected dict response, got {type(result).__name__}"
     return result
 
 

--- a/src/gh_manage/models/repos.py
+++ b/src/gh_manage/models/repos.py
@@ -1,0 +1,46 @@
+"""Pydantic schema for config/repos.yml.
+
+A ReposConfig holds a list of repos to scan with `gh manage drift --all`.
+Each entry specifies the repo name (owner/repo format) and the profile
+to use for scanning.
+
+Phase 8.5 ships with 1 entry (gh-manage itself). Consumer repos are
+added as they are onboarded.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class RepoEntry(BaseModel):
+    """One repo in repos.yml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str  # "owner/repo" full form
+    profile: str  # bundled profile name
+    enabled: bool = True
+
+    @field_validator("name")
+    @classmethod
+    def _validate_owner_repo_format(cls, v: str) -> str:
+        if "/" not in v or v.count("/") != 1:
+            raise ValueError(f"Repo name must be in 'owner/repo' format, got: {v!r}")
+        owner, repo = v.split("/")
+        if not owner or not repo:
+            raise ValueError(
+                f"Repo name must have non-empty owner and repo parts, got: {v!r}"
+            )
+        return v
+
+
+class ReposConfig(BaseModel):
+    """Top-level schema for config/repos.yml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1]
+    repos: list[RepoEntry]

--- a/tests/unit/cli/test_drift.py
+++ b/tests/unit/cli/test_drift.py
@@ -230,3 +230,56 @@ def test_drift_output_path_write_failure_raises(
     )
     assert result.exit_code == 1
     assert "Cannot write" in result.output or "cannot write" in result.output.lower()
+
+
+# Task 6: --report-mode issue
+
+
+def test_drift_issue_mode_creates_issue(mocker: MockerFixture, tmp_path: Path) -> None:
+    _patch_git_and_repo(mocker)
+    _patch_run_all_checks(mocker, (_sample_finding(),))
+    mock_resolve = mocker.patch(
+        "gh_manage.commands.drift.drift_sync.resolve_drift_issue",
+        return_value="Created issue #42 on yakkuro/gh-manage (1 findings)",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "drift",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--report-mode",
+            "issue",
+        ],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Created issue #42" in result.output
+    mock_resolve.assert_called_once()
+
+
+def test_drift_issue_mode_zero_findings(mocker: MockerFixture, tmp_path: Path) -> None:
+    _patch_git_and_repo(mocker)
+    _patch_run_all_checks(mocker, ())
+    mock_resolve = mocker.patch(
+        "gh_manage.commands.drift.drift_sync.resolve_drift_issue",
+        return_value="No drift detected for yakkuro/gh-manage. No Issue created.",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "drift",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--report-mode",
+            "issue",
+        ],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0
+    assert "No drift" in result.output
+    mock_resolve.assert_called_once()

--- a/tests/unit/cli/test_drift.py
+++ b/tests/unit/cli/test_drift.py
@@ -283,3 +283,114 @@ def test_drift_issue_mode_zero_findings(mocker: MockerFixture, tmp_path: Path) -
     assert result.exit_code == 0
     assert "No drift" in result.output
     mock_resolve.assert_called_once()
+
+
+# Task 7: --all flag
+
+
+def test_drift_all_scans_repos_from_config(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    mocker.patch(
+        "gh_manage.commands.drift.repo_info.get_default_branch",
+        return_value="main",
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.drift_sync.run_all_checks",
+        return_value=(),
+    )
+    # Mock labels_api and protection_api so production checks don't hit real API
+    mocker.patch("gh_manage.drift_sync.labels_api.list_labels", return_value=[])
+    mocker.patch(
+        "gh_manage.drift_sync.protection_api.get_branch_protection",
+        return_value={},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["drift", "--all", "--report-mode", "stdout"],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0, result.output
+    assert "yakkuro/gh-manage" in result.output or "Scan complete" in result.output
+
+
+def test_drift_all_and_path_are_mutually_exclusive(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "drift",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--all",
+        ],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code != 0
+    assert (
+        "mutually exclusive" in result.output.lower()
+        or "cannot use" in result.output.lower()
+    )
+
+
+def test_drift_all_skips_disabled_repos(
+    mocker: MockerFixture,
+) -> None:
+    from gh_manage.models.repos import RepoEntry, ReposConfig
+
+    # Mock load_config to return ReposConfig for repos.yml, ProfileSpec for profile
+    def mock_load_config_side_effect(path, config_type):
+        from gh_manage.models.profiles import ProfileSpec
+
+        if config_type == ReposConfig:
+            return ReposConfig(
+                version=1,
+                repos=[
+                    RepoEntry(
+                        name="yakkuro/gh-manage", profile="python-service", enabled=True
+                    ),
+                    RepoEntry(
+                        name="yakkuro/disabled", profile="python-service", enabled=False
+                    ),
+                ],
+            )
+        # For ProfileSpec, return a minimal valid profile
+        return ProfileSpec(
+            version=1,
+            name="python-service",
+            description="Python service",
+            files=[],
+            protection_policy=None,
+        )
+
+    mocker.patch(
+        "gh_manage.commands.drift.load_config",
+        side_effect=mock_load_config_side_effect,
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.repo_info.get_default_branch",
+        return_value="main",
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.drift_sync.run_all_checks",
+        return_value=(),
+    )
+    mocker.patch("gh_manage.drift_sync.labels_api.list_labels", return_value=[])
+    mocker.patch(
+        "gh_manage.drift_sync.protection_api.get_branch_protection",
+        return_value={},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["drift", "--all", "--report-mode", "stdout"],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0
+    assert "SKIPPED" in result.output or "skipped" in result.output.lower()

--- a/tests/unit/cli/test_drift.py
+++ b/tests/unit/cli/test_drift.py
@@ -394,3 +394,64 @@ def test_drift_all_skips_disabled_repos(
     )
     assert result.exit_code == 0
     assert "SKIPPED" in result.output or "skipped" in result.output.lower()
+
+
+# Task 8: --all + issue mode integration
+
+
+def test_drift_all_issue_mode_calls_resolve_per_repo(
+    mocker: MockerFixture,
+) -> None:
+    from gh_manage.models.repos import RepoEntry, ReposConfig
+
+    def mock_load_config_side_effect(path, config_type):
+        from gh_manage.models.profiles import ProfileSpec
+
+        if config_type == ReposConfig:
+            return ReposConfig(
+                version=1,
+                repos=[
+                    RepoEntry(name="yakkuro/gh-manage", profile="python-service"),
+                    RepoEntry(name="yakkuro/port-registry", profile="python-service"),
+                ],
+            )
+        # For ProfileSpec and other configs, return a minimal valid profile
+        return ProfileSpec(
+            version=1,
+            name="python-service",
+            description="Python service",
+            files=[],
+            protection_policy=None,
+        )
+
+    mocker.patch(
+        "gh_manage.commands.drift.load_config",
+        side_effect=mock_load_config_side_effect,
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.repo_info.get_default_branch",
+        return_value="main",
+    )
+    mocker.patch(
+        "gh_manage.commands.drift.drift_sync.run_all_checks",
+        return_value=(),
+    )
+    mocker.patch("gh_manage.drift_sync.labels_api.list_labels", return_value=[])
+    mocker.patch(
+        "gh_manage.drift_sync.protection_api.get_branch_protection",
+        return_value={},
+    )
+    mock_resolve = mocker.patch(
+        "gh_manage.commands.drift.drift_sync.resolve_drift_issue",
+        return_value="No drift",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["drift", "--all", "--report-mode", "issue"],
+        prog_name="gh-manage",
+    )
+    assert result.exit_code == 0
+    # resolve_drift_issue called for each enabled repo
+    assert mock_resolve.call_count == 2

--- a/tests/unit/drift/test_drift_sync.py
+++ b/tests/unit/drift/test_drift_sync.py
@@ -18,6 +18,7 @@ from gh_manage.drift_sync import (
     _labels_diff_to_findings,
     check_labels,
     register_check,
+    resolve_drift_issue,
     run_all_checks,
 )
 from gh_manage.github_api.labels import Label, Label as LabelInfo
@@ -433,9 +434,9 @@ def test_scenario(
     )
     for expected in scenario.expected_findings:
         matches = [f for f in findings if _matches(f, expected)]
-        assert (
-            matches
-        ), f"No finding matches expected {expected}; got: {[str(f) for f in findings]}"
+        assert matches, (
+            f"No finding matches expected {expected}; got: {[str(f) for f in findings]}"
+        )
 
 
 # Task 6: _protection_diff_to_findings adapter
@@ -497,6 +498,81 @@ def test_protection_diff_to_findings_empty_diff() -> None:
 
 
 # Task 9: Golden test (self-dogfood)
+
+
+# Task 5: resolve_drift_issue state machine
+
+
+def test_resolve_drift_issue_creates_when_no_existing(mocker: Any) -> None:
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue", return_value=None
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mock_create = mocker.patch(
+        "gh_manage.drift_sync.issues_api.create_issue",
+        return_value={"number": 42, "html_url": "https://..."},
+    )
+    mock_comment = mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+
+    findings = (Finding("high", "labels", "yakkuro/gh-manage", "x", None, "y", "m"),)
+    result = resolve_drift_issue(findings, "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "Created" in result or "created" in result.lower()
+    mock_create.assert_called_once()
+    mock_comment.assert_called_once()
+
+
+def test_resolve_drift_issue_updates_existing(mocker: Any) -> None:
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue",
+        return_value={"number": 42},
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mock_update = mocker.patch("gh_manage.drift_sync.issues_api.update_issue_body")
+    mock_comment = mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+    mocker.patch("gh_manage.drift_sync.issues_api.get_issue_comments", return_value=[])
+
+    findings = (Finding("high", "labels", "yakkuro/gh-manage", "x", None, "y", "m"),)
+    result = resolve_drift_issue(findings, "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "Updated" in result or "updated" in result.lower()
+    mock_update.assert_called_once()
+    mock_comment.assert_called_once()
+
+
+def test_resolve_drift_issue_closes_on_24h_rule(mocker: Any) -> None:
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue",
+        return_value={"number": 42},
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mocker.patch("gh_manage.drift_sync.issues_api.update_issue_body")
+    mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+    mock_close = mocker.patch("gh_manage.drift_sync.issues_api.close_issue")
+    # Return comments that satisfy 24h rule
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.get_issue_comments",
+        return_value=[
+            {
+                "body": "<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+            },
+            {
+                "body": "<!-- scan:zero-findings:2026-04-05T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+            },
+        ],
+    )
+
+    result = resolve_drift_issue((), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "Closed" in result or "closed" in result.lower()
+    mock_close.assert_called_once()
+
+
+def test_resolve_drift_issue_noop_zero_findings_no_issue(mocker: Any) -> None:
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue", return_value=None
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+
+    result = resolve_drift_issue((), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "No drift" in result or "no drift" in result.lower()
 
 
 def test_golden_production_data_zero_drift(mocker: Any, tmp_path: Path) -> None:

--- a/tests/unit/drift/test_drift_sync.py
+++ b/tests/unit/drift/test_drift_sync.py
@@ -434,9 +434,9 @@ def test_scenario(
     )
     for expected in scenario.expected_findings:
         matches = [f for f in findings if _matches(f, expected)]
-        assert matches, (
-            f"No finding matches expected {expected}; got: {[str(f) for f in findings]}"
-        )
+        assert (
+            matches
+        ), f"No finding matches expected {expected}; got: {[str(f) for f in findings]}"
 
 
 # Task 6: _protection_diff_to_findings adapter

--- a/tests/unit/drift/test_issue_report.py
+++ b/tests/unit/drift/test_issue_report.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+
 from gh_manage.drift_sync import (
     Finding,
     format_issue_body,
     format_issue_comment,
+    parse_zero_findings_timestamps,
+    should_close_issue,
 )
 
 
@@ -69,3 +72,88 @@ def test_format_issue_comment_nonzero_has_no_zero_findings_tag() -> None:
 def test_format_issue_comment_contains_scan_timestamp() -> None:
     comment = format_issue_comment((_f(),), "2026-04-12T09:00:00Z")
     assert "2026-04-12T09:00:00Z" in comment
+
+
+def _make_comment(body: str) -> dict:
+    return {"body": body}
+
+
+# parse_zero_findings_timestamps
+def test_parse_zero_findings_extracts_timestamps() -> None:
+    comments = [
+        _make_comment(
+            "## Scan\n<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+        ),
+        _make_comment("## Scan\n<!-- scan:finding-count:3 -->"),
+        _make_comment(
+            "## Scan\n<!-- scan:zero-findings:2026-04-05T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+        ),
+    ]
+    timestamps = parse_zero_findings_timestamps(comments)
+    assert len(timestamps) == 2
+    assert timestamps[0].year == 2026
+    assert timestamps[0].month == 4
+    assert timestamps[0].day == 12
+
+
+def test_parse_zero_findings_empty_comments() -> None:
+    assert parse_zero_findings_timestamps([]) == []
+
+
+def test_parse_zero_findings_no_metadata() -> None:
+    comments = [_make_comment("human comment without metadata")]
+    assert parse_zero_findings_timestamps(comments) == []
+
+
+def test_parse_zero_findings_malformed_timestamp_skipped() -> None:
+    comments = [_make_comment("<!-- scan:zero-findings:not-a-date -->")]
+    # Malformed timestamps are silently skipped (warning in production)
+    assert parse_zero_findings_timestamps(comments) == []
+
+
+# should_close_issue
+def test_should_close_issue_two_consecutive_zero_24h_apart() -> None:
+    comments = [
+        _make_comment(
+            "<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+        ),
+        _make_comment(
+            "<!-- scan:zero-findings:2026-04-05T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+        ),
+    ]
+    assert should_close_issue(comments) is True
+
+
+def test_should_close_issue_only_one_zero_scan() -> None:
+    comments = [
+        _make_comment(
+            "<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+        ),
+    ]
+    assert should_close_issue(comments) is False
+
+
+def test_should_close_issue_two_zero_within_24h() -> None:
+    comments = [
+        _make_comment(
+            "<!-- scan:zero-findings:2026-04-12T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+        ),
+        _make_comment(
+            "<!-- scan:zero-findings:2026-04-12T08:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+        ),
+    ]
+    assert should_close_issue(comments) is False
+
+
+def test_should_close_issue_latest_has_findings() -> None:
+    comments = [
+        _make_comment("<!-- scan:finding-count:3 -->"),
+        _make_comment(
+            "<!-- scan:zero-findings:2026-04-05T09:00:00+00:00 -->\n<!-- scan:finding-count:0 -->"
+        ),
+    ]
+    assert should_close_issue(comments) is False
+
+
+def test_should_close_issue_empty_comments() -> None:
+    assert should_close_issue([]) is False

--- a/tests/unit/drift/test_issue_report.py
+++ b/tests/unit/drift/test_issue_report.py
@@ -1,0 +1,71 @@
+"""Tests for drift Issue body/comment formatting + metadata parsing."""
+
+from __future__ import annotations
+
+from gh_manage.drift_sync import (
+    Finding,
+    format_issue_body,
+    format_issue_comment,
+)
+
+
+def _f(severity: str = "high", check: str = "labels", field_path: str = "x") -> Finding:
+    return Finding(
+        severity=severity,  # type: ignore[arg-type]
+        check=check,
+        repo="yakkuro/gh-manage",
+        field_path=field_path,
+        current_value=None,
+        desired_value="y",
+        message="test message",
+    )
+
+
+# format_issue_body
+def test_format_issue_body_contains_hidden_metadata() -> None:
+    body = format_issue_body((_f(),), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "<!-- gh-manage:drift:yakkuro/gh-manage -->" in body
+
+
+def test_format_issue_body_contains_scan_timestamp() -> None:
+    body = format_issue_body((_f(),), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "2026-04-12T09:00:00Z" in body
+
+
+def test_format_issue_body_contains_markdown_report() -> None:
+    body = format_issue_body((_f(),), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "# Drift report" in body
+    assert "test message" in body
+
+
+def test_format_issue_body_contains_auto_update_note() -> None:
+    body = format_issue_body((_f(),), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "auto-updated" in body.lower()
+
+
+def test_format_issue_body_zero_findings() -> None:
+    body = format_issue_body((), "yakkuro/gh-manage", "2026-04-12T09:00:00Z")
+    assert "0 findings" in body
+
+
+# format_issue_comment
+def test_format_issue_comment_contains_finding_count_metadata() -> None:
+    comment = format_issue_comment((_f(), _f()), "2026-04-12T09:00:00Z")
+    assert "<!-- scan:finding-count:2 -->" in comment
+
+
+def test_format_issue_comment_zero_findings_has_zero_metadata() -> None:
+    comment = format_issue_comment((), "2026-04-12T09:00:00Z")
+    assert "<!-- scan:zero-findings:2026-04-12T09:00:00Z -->" in comment
+    assert "<!-- scan:finding-count:0 -->" in comment
+
+
+def test_format_issue_comment_nonzero_has_no_zero_findings_tag() -> None:
+    comment = format_issue_comment((_f(),), "2026-04-12T09:00:00Z")
+    assert "scan:zero-findings" not in comment
+    assert "<!-- scan:finding-count:1 -->" in comment
+
+
+def test_format_issue_comment_contains_scan_timestamp() -> None:
+    comment = format_issue_comment((_f(),), "2026-04-12T09:00:00Z")
+    assert "2026-04-12T09:00:00Z" in comment

--- a/tests/unit/github_api/test_issues.py
+++ b/tests/unit/github_api/test_issues.py
@@ -1,0 +1,139 @@
+"""Tests for gh_manage.github_api.issues — GitHub Issues API wrapper."""
+
+from __future__ import annotations
+
+import json
+from subprocess import CompletedProcess
+
+from pytest_mock import MockerFixture
+
+from gh_manage.github_api.issues import (
+    add_issue_comment,
+    close_issue,
+    create_issue,
+    ensure_drift_label,
+    get_issue_comments,
+    search_drift_issue,
+    update_issue_body,
+)
+
+
+def _mock_gh_success(mocker: MockerFixture, stdout: str) -> object:
+    return mocker.patch(
+        "subprocess.run",
+        return_value=CompletedProcess(args=[], returncode=0, stdout=stdout, stderr=""),
+    )
+
+
+def _mock_gh_failure(mocker: MockerFixture, stderr: str, returncode: int = 1) -> object:
+    return mocker.patch(
+        "subprocess.run",
+        return_value=CompletedProcess(
+            args=[], returncode=returncode, stdout="", stderr=stderr
+        ),
+    )
+
+
+# search_drift_issue
+def test_search_drift_issue_found(mocker: MockerFixture) -> None:
+    response = [{"number": 42, "title": "[gh-manage drift] yakkuro/gh-manage"}]
+    _mock_gh_success(mocker, json.dumps(response))
+    result = search_drift_issue("yakkuro/gh-manage")
+    assert result is not None
+    assert result["number"] == 42
+
+
+def test_search_drift_issue_not_found(mocker: MockerFixture) -> None:
+    _mock_gh_success(mocker, json.dumps([]))
+    result = search_drift_issue("yakkuro/gh-manage")
+    assert result is None
+
+
+def test_search_drift_issue_uses_label_filter(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, "[]")
+    search_drift_issue("yakkuro/gh-manage")
+    args = mock_run.call_args.args[0]
+    args_str = " ".join(args)
+    assert "repos/yakkuro/gh-manage/issues" in args_str
+    assert "gh-manage:drift" in args_str
+
+
+# create_issue
+def test_create_issue_returns_issue_dict(mocker: MockerFixture) -> None:
+    response = {
+        "number": 42,
+        "html_url": "https://github.com/yakkuro/gh-manage/issues/42",
+    }
+    _mock_gh_success(mocker, json.dumps(response))
+    result = create_issue("yakkuro/gh-manage", "title", "body", ["gh-manage:drift"])
+    assert result["number"] == 42
+
+
+def test_create_issue_sends_body_via_stdin(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, '{"number": 1}')
+    create_issue("yakkuro/gh-manage", "Test", "Body", ["gh-manage:drift"])
+    args = mock_run.call_args.args[0]
+    assert "-X" in args and "POST" in args
+    assert "--input" in args and "-" in args
+    stdin_input = mock_run.call_args.kwargs["input"]
+    parsed = json.loads(stdin_input)
+    assert parsed["title"] == "Test"
+    assert parsed["body"] == "Body"
+    assert parsed["labels"] == ["gh-manage:drift"]
+
+
+# update_issue_body
+def test_update_issue_body_uses_patch(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, "{}")
+    update_issue_body("yakkuro/gh-manage", 42, "new body")
+    args = mock_run.call_args.args[0]
+    assert "repos/yakkuro/gh-manage/issues/42" in args
+    assert "-X" in args and "PATCH" in args
+    stdin_input = mock_run.call_args.kwargs["input"]
+    assert json.loads(stdin_input)["body"] == "new body"
+
+
+# add_issue_comment
+def test_add_issue_comment_posts_to_comments_endpoint(
+    mocker: MockerFixture,
+) -> None:
+    mock_run = _mock_gh_success(mocker, "{}")
+    add_issue_comment("yakkuro/gh-manage", 42, "scan comment")
+    args = mock_run.call_args.args[0]
+    assert "repos/yakkuro/gh-manage/issues/42/comments" in args
+    assert "-X" in args and "POST" in args
+
+
+# close_issue
+def test_close_issue_patches_state_closed(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, "{}")
+    close_issue("yakkuro/gh-manage", 42)
+    stdin_input = mock_run.call_args.kwargs["input"]
+    assert json.loads(stdin_input)["state"] == "closed"
+
+
+# ensure_drift_label
+def test_ensure_drift_label_creates_label(mocker: MockerFixture) -> None:
+    mock_run = _mock_gh_success(mocker, "{}")
+    ensure_drift_label("yakkuro/gh-manage")
+    args = mock_run.call_args.args[0]
+    assert "repos/yakkuro/gh-manage/labels" in args
+    assert "-X" in args and "POST" in args
+
+
+def test_ensure_drift_label_ignores_422_already_exists(
+    mocker: MockerFixture,
+) -> None:
+    """422 = label already exists. Should not raise."""
+    _mock_gh_failure(mocker, "HTTP 422: Validation Failed\nalready_exists\n")
+    # Should NOT raise
+    ensure_drift_label("yakkuro/gh-manage")
+
+
+# get_issue_comments
+def test_get_issue_comments_returns_list(mocker: MockerFixture) -> None:
+    comments = [{"id": 1, "body": "hello"}, {"id": 2, "body": "world"}]
+    _mock_gh_success(mocker, json.dumps(comments))
+    result = get_issue_comments("yakkuro/gh-manage", 42, per_page=5)
+    assert len(result) == 2
+    assert result[0]["body"] == "hello"

--- a/tests/unit/models/test_repos.py
+++ b/tests/unit/models/test_repos.py
@@ -1,0 +1,67 @@
+"""Tests for gh_manage.models.repos — RepoEntry + ReposConfig."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from gh_manage.models.repos import RepoEntry, ReposConfig
+from gh_manage.config import load_config
+from importlib.resources import files
+from pathlib import Path
+
+
+def test_repo_entry_valid() -> None:
+    e = RepoEntry(name="yakkuro/gh-manage", profile="python-service")
+    assert e.name == "yakkuro/gh-manage"
+    assert e.profile == "python-service"
+    assert e.enabled is True  # default
+
+
+def test_repo_entry_enabled_false() -> None:
+    e = RepoEntry(name="yakkuro/archived", profile="python-service", enabled=False)
+    assert e.enabled is False
+
+
+def test_repo_entry_rejects_no_slash() -> None:
+    with pytest.raises(ValidationError, match="owner/repo"):
+        RepoEntry(name="just-a-name", profile="python-service")
+
+
+def test_repo_entry_rejects_multiple_slashes() -> None:
+    with pytest.raises(ValidationError, match="owner/repo"):
+        RepoEntry(name="a/b/c", profile="python-service")
+
+
+def test_repo_entry_rejects_empty_parts() -> None:
+    with pytest.raises(ValidationError, match="non-empty"):
+        RepoEntry(name="/repo", profile="python-service")
+
+
+def test_repo_entry_rejects_extra_field() -> None:
+    with pytest.raises(ValidationError):
+        RepoEntry(name="a/b", profile="p", unknown="x")  # type: ignore[call-arg]
+
+
+def test_repos_config_valid() -> None:
+    config = ReposConfig(
+        version=1,
+        repos=[RepoEntry(name="yakkuro/gh-manage", profile="python-service")],
+    )
+    assert len(config.repos) == 1
+
+
+def test_repos_config_rejects_version_2() -> None:
+    with pytest.raises(ValidationError):
+        ReposConfig(
+            version=2,  # type: ignore[arg-type]
+            repos=[],
+        )
+
+
+def test_bundled_repos_yml_loads() -> None:
+    """Production repos.yml loads without validation errors."""
+    repos_path = Path(str(files("gh_manage.data") / "repos.yml"))
+    config = load_config(repos_path, ReposConfig)
+    assert len(config.repos) >= 1
+    assert config.repos[0].name == "yakkuro/gh-manage"


### PR DESCRIPTION
## Summary

Phase 8.5 adds the automation layer to the Phase 8 drift scanner:

- **`--report-mode issue`**: Auto-creates/updates/closes GitHub Issues per repo. Body = latest markdown summary (auto-updated). Each scan adds a comment with hidden metadata.
- **`--all` flag**: Loads bundled `repos.yml`, scans all enabled repos. Partial continue on per-repo failure. Skips `check_profile_files` (no local clone).
- **24h auto-close**: When 2 consecutive scans ≥24h apart show zero findings, Issue is closed. Hidden metadata in comments drives the state machine.
- **`drift-scanner.yml`**: Weekly cron (Monday 00:00 UTC) + manual `workflow_dispatch`.

## New components

- `github_api/issues.py` — 7 Issue CRUD functions (search, create, update body, add comment, close, ensure label, get comments)
- `models/repos.py` — `RepoEntry(name: "owner/repo", profile, enabled)` + `ReposConfig` pydantic schema
- `data/repos.yml` — bundled repo list (initial: gh-manage only)
- `drift-scanner.yml` — weekly cron workflow
- `drift_sync.py` additions: `format_issue_body`, `format_issue_comment`, `parse_zero_findings_timestamps`, `should_close_issue`, `resolve_drift_issue`

## Test coverage

352 → 400 (+48 new tests)

## Dogfood results

- `--report-mode issue`: Created Issue #20 on yakkuro/gh-manage (2 findings)
- `--all --report-mode stdout`: Scanned 1 repo, structured summary printed

## Test plan

- [x] 400 tests pass locally
- [x] Dogfood: single-repo issue mode → Issue created
- [x] Dogfood: --all stdout mode → summary printed
- [ ] CI PR Gate passes

Generated with [Claude Code](https://claude.ai/code)