### PR TITLE
chore: bump cli version to 1.0.0

### DIFF
--- a/CHANGELOG-cli.md
+++ b/CHANGELOG-cli.md
@@ -8,6 +8,23 @@ The reusable workflow changelog lives in `CHANGELOG-reusable.md` and tracks inde
 
 _Nothing yet._
 
+## [1.0.0] - 2026-04-14
+
+Stable API milestone. No new CLI features; this release graduates the `gh-manage` Python CLI to the v1.0 stability contract. See [`CHANGELOG-reusable.md`](CHANGELOG-reusable.md) v1.0.0 for the reusable-workflow stability promise announced at the same commit. The CLI's subcommand surface (`labels`, `init`, `apply`, `protection`, `drift`, `issues`) and bundled data schemas (`labels.yml`, `branch-protection.yml`, `profile.yml`, `repos.yml`) are frozen under semver — removing or renaming any subcommand, flag, or schema key is a v2.0 break. See [`docs/versioning.md`](docs/versioning.md) for the full stability promise.
+
+### Changed
+
+- **`pyproject.toml`** — `version` bumped from `"0.6.0"` to `"1.0.0"`
+- **`src/gh_manage/__init__.py`** — `__version__` bumped from `"0.6.0"` to `"1.0.0"`
+- **`tests/test_sanity.py`** — expected `__version__` bumped to `"1.0.0"`
+- **`uv.lock`** — regenerated after pyproject.toml bump
+
+### Reference
+
+- Top-level design specification: [`docs/specs/2026-04-10-gh-manage-design.md`](docs/specs/2026-04-10-gh-manage-design.md)
+- Stability promise: [`docs/versioning.md`](docs/versioning.md)
+- Distribution channels: [`docs/distribution-channels.md`](docs/distribution-channels.md)
+
 ## [0.6.0] - 2026-04-12
 
 Phase 8.5 milestone: fully-automated weekly drift scanning with GitHub Issue reporting. Builds on Phase 8's stdout/json/markdown drift reports by adding `--report-mode issue` (creates one open Issue per repo with zero-findings auto-close after a 24-hour double-check), `--all` batch mode driven by bundled `repos.yml`, and a scheduled cron workflow (`drift-scanner.yml`). Shipped in [PR #21](https://github.com/yakkuro/gh-manage/pull/21). Plan: [`docs/plans/2026-04-12-phase-8.5-drift-automation.md`](docs/plans/2026-04-12-phase-8.5-drift-automation.md). Spec: [`docs/specs/2026-04-12-phase-8.5-drift-automation-design.md`](docs/specs/2026-04-12-phase-8.5-drift-automation-design.md).
@@ -159,6 +176,11 @@ First release on the CLI track. This is the Phase 4 milestone: establishes the C
 - **Tested on Linux and macOS only**. Windows support is not explicitly targeted in v0.1.0.
 - **No `gh extension upgrade` contract guarantees** beyond whatever the gh CLI's default behavior provides.
 
-[Unreleased]: https://github.com/yakkuro/gh-manage/compare/cli/v0.2.0...HEAD
+[Unreleased]: https://github.com/yakkuro/gh-manage/compare/cli/v1.0.0...HEAD
+[1.0.0]: https://github.com/yakkuro/gh-manage/releases/tag/cli/v1.0.0
+[0.6.0]: https://github.com/yakkuro/gh-manage/releases/tag/cli/v0.6.0
+[0.5.0]: https://github.com/yakkuro/gh-manage/releases/tag/cli/v0.5.0
+[0.4.0]: https://github.com/yakkuro/gh-manage/releases/tag/cli/v0.4.0
+[0.3.0]: https://github.com/yakkuro/gh-manage/releases/tag/cli/v0.3.0
 [0.2.0]: https://github.com/yakkuro/gh-manage/releases/tag/cli/v0.2.0
 [0.1.0]: https://github.com/yakkuro/gh-manage/releases/tag/cli/v0.1.0

--- a/CHANGELOG-reusable.md
+++ b/CHANGELOG-reusable.md
@@ -6,6 +6,8 @@ The CLI changelog lives in `CHANGELOG-cli.md`.
 
 ## [Unreleased]
 
+_Nothing yet._
+
 ## [1.0.0] - 2026-04-14
 
 Stable API milestone. No functional changes since v0.2.1.
@@ -140,7 +142,8 @@ _N/A — first release._
 - **Cross-repo self-checkout has NOT been empirically validated** in v0.1.0 — the same-repo dogfood (gh-manage's own `ci.yml`) and smoke-test are the only tested invocation paths. Phase 3 (port-registry adoption) will be the first real cross-repo test. If issues arise, they will be fixed in v0.1.1 or v0.2.0.
 - **Pinned tool versions are not the latest available** as of 2026-04-10. `uv` is pinned at 0.5.0 (latest: 0.11.6), `ruff` at 0.8.0 (latest: 0.15.10), `mypy` at 1.12.0 (latest: 1.20.0). Tool version refresh is scheduled for v0.2.0.
 
-[Unreleased]: https://github.com/yakkuro/gh-manage/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/yakkuro/gh-manage/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/yakkuro/gh-manage/releases/tag/v1.0.0
 [0.2.1]: https://github.com/yakkuro/gh-manage/releases/tag/v0.2.1
 [0.2.0]: https://github.com/yakkuro/gh-manage/releases/tag/v0.2.0
 [0.1.0]: https://github.com/yakkuro/gh-manage/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gh-manage"
-version = "0.6.0"
+version = "1.0.0"
 description = "GitHub-based CI/CD, Issue management, and operational system for yakkuro/* repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gh_manage/__init__.py
+++ b/src/gh_manage/__init__.py
@@ -1,3 +1,3 @@
 """gh-manage: GitHub-based CI/CD, Issue management, and operational system."""
 
-__version__ = "0.6.0"
+__version__ = "1.0.0"

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -8,7 +8,7 @@ import gh_manage
 def test_package_version_is_defined() -> None:
     assert hasattr(gh_manage, "__version__")
     assert isinstance(gh_manage.__version__, str)
-    assert gh_manage.__version__ == "0.6.0"
+    assert gh_manage.__version__ == "1.0.0"
 
 
 def test_cli_module_is_importable() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "gh-manage"
-version = "0.6.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bump PR for cli/v1.0.0 + v1.0.0 release. Follows \`docs/release-checklist.md\` "Before tagging a release" procedure.

Changes:

- \`pyproject.toml\` — version \`0.6.0\` → \`1.0.0\`
- \`src/gh_manage/__init__.py\` — \`__version__\` \`"0.6.0"\` → \`"1.0.0"\`
- \`tests/test_sanity.py\` — expected \`__version__\` updated
- \`CHANGELOG-cli.md\` — new \`[1.0.0] - 2026-04-14\` section + compare-link anchors updated
- \`CHANGELOG-reusable.md\` — empty \`[Unreleased]\` restored + compare-link anchors updated
- \`uv.lock\` — auto-regenerated by \`uv sync\`

## Review protocol

This PR qualifies for cross-agent review skip per \`docs/specs/2026-04-14-phase-9-v1-hardening-design.md\` section 6.2 justification:

1. **Zero logic changes** — only version-value swaps, CHANGELOG section renames, and lock-file regeneration
2. **Mechanical by construction** — sed-equivalent edits
3. **Gated by \`test_package_version_is_defined\`** — CI catches version mismatch automatically
4. **Historical precedent** — Phases 6, 7, 8, 8.5 all used this pattern

Merge after CI green only.

## Test plan

- [x] \`uv sync\` — uv.lock regenerated with 1.0.0 self-reference
- [x] \`uv run pytest\` — 401 passed (test_sanity catches version mismatch)

Generated with [Claude Code](https://claude.ai/code)