### PR TITLE
fix: python-service required_contexts for PR gate enforcement

### DIFF
--- a/src/gh_manage/data/profiles/python-service.yml
+++ b/src/gh_manage/data/profiles/python-service.yml
@@ -8,4 +8,4 @@ files:
     dest: CLAUDE.md
     skip_if_exists: true
 protection_policy: solo-default
-required_contexts: []
+required_contexts: ["PR Gate / PR Gate"]

--- a/tests/fixtures/drift-scenarios/protection/allow-force-pushes-enabled.yml
+++ b/tests/fixtures/drift-scenarios/protection/allow-force-pushes-enabled.yml
@@ -9,7 +9,7 @@ inputs:
       enabled: false
     required_status_checks:
       strict: true
-      contexts: []
+      contexts: ["PR Gate / PR Gate"]
     required_pull_request_reviews:
       required_approving_review_count: 0
       dismiss_stale_reviews: false

--- a/tests/fixtures/drift-scenarios/protection/enforce-admins-weakened.yml
+++ b/tests/fixtures/drift-scenarios/protection/enforce-admins-weakened.yml
@@ -9,7 +9,7 @@ inputs:
       enabled: true
     required_status_checks:
       strict: true
-      contexts: []
+      contexts: ["PR Gate / PR Gate"]
     required_pull_request_reviews:
       required_approving_review_count: 0
       dismiss_stale_reviews: false

--- a/tests/fixtures/drift-scenarios/protection/reviews-removed.yml
+++ b/tests/fixtures/drift-scenarios/protection/reviews-removed.yml
@@ -9,7 +9,7 @@ inputs:
       enabled: false
     required_status_checks:
       strict: true
-      contexts: []
+      contexts: ["PR Gate / PR Gate"]
     required_pull_request_reviews: null
     required_conversation_resolution:
       enabled: true

--- a/tests/unit/protection_sync/test_golden.py
+++ b/tests/unit/protection_sync/test_golden.py
@@ -30,7 +30,7 @@ def test_production_data_loads() -> None:
 
 def test_build_desired_on_production_solo_default_matches_expected() -> None:
     """build_desired_protection(solo-default, python-service) produces the
-    canonical PUT body shape with contexts [] (empty list override)."""
+    canonical PUT body shape with contexts overridden by profile.required_contexts."""
     bp_path = Path(str(files("gh_manage.data") / "branch-protection.yml"))
     bp_config = load_config(bp_path, BranchProtectionConfig)
     profile_path = Path(str(files("gh_manage.data.profiles") / "python-service.yml"))

--- a/tests/unit/protection_sync/test_golden.py
+++ b/tests/unit/protection_sync/test_golden.py
@@ -25,7 +25,7 @@ def test_production_data_loads() -> None:
     profile_path = Path(str(files("gh_manage.data.profiles") / "python-service.yml"))
     profile = load_config(profile_path, ProfileSpec)
     assert profile.protection_policy == "solo-default"
-    assert profile.required_contexts == []
+    assert profile.required_contexts == ["PR Gate / PR Gate"]
 
 
 def test_build_desired_on_production_solo_default_matches_expected() -> None:
@@ -41,7 +41,7 @@ def test_build_desired_on_production_solo_default_matches_expected() -> None:
     assert body == {
         "required_status_checks": {
             "strict": True,
-            "contexts": [],  # profile.required_contexts override
+            "contexts": ["PR Gate / PR Gate"],  # profile.required_contexts override
         },
         "enforce_admins": False,
         "required_pull_request_reviews": {


### PR DESCRIPTION
## Summary
- Set `python-service.yml` profile `required_contexts` to `["PR Gate / PR Gate"]` (empirically confirmed from Phase 10 canary)
- Update golden test expectations to match
- Update 3 drift scenario fixtures (`allow-force-pushes-enabled`, `enforce-admins-weakened`, `reviews-removed`) that had `contexts: []` in their `current_protection` — now set to `["PR Gate / PR Gate"]` to match the profile

Part of Phase 10 post-canary fix-up (Issue #27).

## Test plan
- [x] `uv run pytest tests/unit/protection_sync/test_golden.py -v` — 3 pass
- [x] `uv run pytest tests/unit/drift/test_drift_sync.py -v` — 39 pass
- [x] `uv run pytest tests/ --tb=short` — 417 pass
- [x] `uvx ruff@0.8.0 check src/ tests/` — clean

Generated with [Claude Code](https://claude.ai/code)