### PR TITLE
chore: add Phase 10 canary repos + finalize canary log

### DIFF
--- a/docs/phase-10-canary-log.md
+++ b/docs/phase-10-canary-log.md
@@ -1,20 +1,51 @@
 # Phase 10 Canary Log
 
 ## Canary repos
-1. yakkuro/shorts-factory (Tier 1, Rank 1, Score 4.0)
-2. yakkuro/polyagent (Tier 1, Rank 2, Score 4.0)
+1. yakkuro/shorts-factory (Tier 1, Rank 1, Score 4.0) — PR yakkuro/shorts-factory#2, merged 2026-04-16T01:46:40Z (018b0fe)
+2. yakkuro/polyagent (Tier 1, Rank 2, Score 4.0) — PR yakkuro/polyagent#5, merged 2026-04-16T01:55:05Z (fdb394b)
 
 ## Recipe execution log
-(populated during canary phase)
+
+### Canary #1: shorts-factory
+- Cloned, branched, created `.github/workflows/ci.yml`
+- Inputs: `python-version: "3.12"`, `gh-manage-ref: v1.0.0`, `type-check: false`
+- ruff check/format: already clean (no changes)
+- CI result: **all green**
+- Merge: squash-merge to main
+
+### Canary #2: polyagent
+- Cloned, branched, created `.github/workflows/ci.yml`
+- Inputs: `python-version: "3.12"`, `gh-manage-ref: v1.0.0`, `type-check: false`, `install-command: "uv sync --all-extras"`, `test-command` with `--ignore` for 3 DB-dependent test files
+- ruff check/format: already clean (no changes)
+- CI result: **all green** (CI, PR Gate, Integration Gate, AI Review)
+- Merge: squash-merge to main
 
 ## Edge cases encountered
-(populated during canary phase)
+
+1. **mypy fails on untyped third-party libs** (canary #1)
+   - Repos using moviepy, yaml, google-* libs have no type stubs
+   - **Resolution**: `type-check: false` as default for all adoption PRs
+
+2. **PostgreSQL service dependency** (canary #2)
+   - polyagent tests require PostgreSQL (via asyncpg)
+   - Reusable workflow cannot declare `services:` block (workflow_call limitation)
+   - 3 of 12 test files need DB: test_integration.py, test_lifecycle.py, test_memory.py
+   - **Resolution**: `test-command` with `--ignore` for DB tests; existing pr-gate.yml covers full suite
+
+3. **Optional dev dependencies** (canary #2)
+   - polyagent uses `[project.optional-dependencies]` for dev tools
+   - Default `uv sync` doesn't install pytest/ruff
+   - **Resolution**: `install-command: "uv sync --all-extras"`
 
 ## Recipe refinements for batch phase
-(populated during canary phase)
+
+- Default all adoption PRs with `type-check: false`
+- Check for `[project.optional-dependencies]` → use `install-command: "uv sync --all-extras"` if present
+- Check for service dependencies (PostgreSQL, Redis, etc.) → customize `test-command` with `--ignore` for dependent tests
+- Tier 1 repos (batch 1) are expected to be simpler (no services), but verify during batch
 
 ## Deferred repos
 (populated during batch phase — repos that failed adoption and were skipped/demoted)
 
 ## Status check context name
-(populated during canary — the exact string for branch protection required_contexts)
+`PR Gate / PR Gate` (confirmed from shorts-factory canary CI run)

--- a/docs/phase-10-canary-log.md
+++ b/docs/phase-10-canary-log.md
@@ -27,10 +27,11 @@
    - **Resolution**: `type-check: false` as default for all adoption PRs
 
 2. **PostgreSQL service dependency** (canary #2)
-   - polyagent tests require PostgreSQL (via asyncpg)
+   - polyagent's conftest.py defines a `db_pool` fixture requiring PostgreSQL (via asyncpg)
+   - Only `test_memory.py` uses the real DB fixture; `test_integration.py` and `test_lifecycle.py` use `MockMemoryStore`
    - Reusable workflow cannot declare `services:` block (workflow_call limitation)
-   - 3 of 12 test files need DB: test_integration.py, test_lifecycle.py, test_memory.py
-   - **Resolution**: `test-command` with `--ignore` for DB tests; existing pr-gate.yml covers full suite
+   - **Resolution**: `test-command` with `--ignore=tests/test_memory.py`; existing pr-gate.yml covers full suite
+   - **Note**: Adoption PR conservatively ignored all 3 files; a follow-up can narrow to `test_memory.py` only
 
 3. **Optional dev dependencies** (canary #2)
    - polyagent uses `[project.optional-dependencies]` for dev tools
@@ -40,7 +41,7 @@
 ## Recipe refinements for batch phase
 
 - Default all adoption PRs with `type-check: false`
-- Check for `[project.optional-dependencies]` → use `install-command: "uv sync --all-extras"` if present
+- Check for `[project.optional-dependencies]` → use `install-command: "uv sync --extra dev"` if dev extras exist (prefer targeted extras over `--all-extras` to avoid pulling unnecessary dependencies)
 - Check for service dependencies (PostgreSQL, Redis, etc.) → customize `test-command` with `--ignore` for dependent tests
 - Tier 1 repos (batch 1) are expected to be simpler (no services), but verify during batch
 

--- a/src/gh_manage/data/repos.yml
+++ b/src/gh_manage/data/repos.yml
@@ -18,3 +18,7 @@ repos:
     profile: python-service
   - name: yakkuro/picshop
     profile: python-service
+  - name: yakkuro/shorts-factory
+    profile: python-service
+  - name: yakkuro/polyagent
+    profile: python-service


### PR DESCRIPTION
## Summary
- Add `shorts-factory` and `polyagent` to `repos.yml` for drift scanner coverage
- Finalize `phase-10-canary-log.md` with execution details, edge cases, and recipe refinements

Part of Phase 10 post-canary (Issue #27).

## Test plan
- [x] `uv run pytest tests/` — 417 pass
- [x] repos.yml loads 11 repos correctly

Generated with [Claude Code](https://claude.ai/code)