### PR TITLE
chore: add Phase 10 batch 2 repos to repos.yml

### DIFF
--- a/src/gh_manage/data/repos.yml
+++ b/src/gh_manage/data/repos.yml
@@ -30,3 +30,11 @@ repos:
     profile: python-service
   - name: yakkuro/shelf-brain
     profile: python-service
+  - name: yakkuro/port-registry
+    profile: python-service
+  - name: yakkuro/git-digest
+    profile: python-service
+  - name: yakkuro/image-ocr
+    profile: python-service
+  - name: yakkuro/tg-commander
+    profile: python-service


### PR DESCRIPTION
## Summary
- Add port-registry, git-digest, image-ocr, tg-commander to repos.yml
- Total python-service repos: 19

Part of Phase 10 batch 2 (Issue #27).

Generated with [Claude Code](https://claude.ai/code)