### PR TITLE
chore: add Phase 10 batch 3 repos to repos.yml

### DIFF
--- a/src/gh_manage/data/repos.yml
+++ b/src/gh_manage/data/repos.yml
@@ -38,3 +38,7 @@ repos:
     profile: python-service
   - name: yakkuro/tg-commander
     profile: python-service
+  - name: yakkuro/codelens
+    profile: python-service
+  - name: yakkuro/deep-research
+    profile: python-service


### PR DESCRIPTION
## Summary
- Add codelens, deep-research to repos.yml
- repo-init deferred (pre-existing test failure in CI)
- Total python-service repos: 21 — **AC① (≥20) achieved**

Part of Phase 10 batch 3 (Issue #27).

Generated with [Claude Code](https://claude.ai/code)