### PR TITLE
chore: add repo-init to repos.yml (Phase 10 recovery)

### DIFF
--- a/src/gh_manage/data/repos.yml
+++ b/src/gh_manage/data/repos.yml
@@ -42,3 +42,5 @@ repos:
     profile: python-service
   - name: yakkuro/deep-research
     profile: python-service
+  - name: yakkuro/repo-init
+    profile: python-service


### PR DESCRIPTION
Agent fixed pre-existing git config bug, CI now passes. Total: 22 repos. Part of Phase 10 (Issue #27).