### PR TITLE
fix(reusable): harden install/test-command against eval injection (#36)

### DIFF
--- a/.github/workflows/eval-hardening-smoke.yml
+++ b/.github/workflows/eval-hardening-smoke.yml
@@ -128,16 +128,37 @@ jobs:
           fi
           echo "Injection neutralised: pytest errored on literal ';' arg and 'PWNED_BY_INJECTION' never executed."
 
-  # F3 — Python quoted setup-command compatibility. Proves eval still
-  # honours single quotes inside setup-command (the image-ocr pattern).
+  # F3 — Python quoted setup-command compatibility. Replicates the
+  # reusable workflow's setup step inline so we can assert that the
+  # marker actually reached stdout. Calling the reusable workflow
+  # gives us no way to see its logs from this job, so a compile-only
+  # smoke (the previous shape) would silently pass even if eval's
+  # quote handling regressed.
   python-f3-quoted-setup:
-    name: eval-hardening / python-F3 (quoted setup, expect marker in log)
-    uses: ./.github/workflows/reusable-pr-gate-python.yml
-    with:
-      python-version: "3.12"
-      working-directory: tests/fixtures/projects/python-sample
-      setup-command: "printf '%s\\n' 'quote-preservation-ok'"
-      gh-manage-ref: ${{ github.sha }}
+    name: eval-hardening / python-F3 (quoted setup, marker must appear)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Replicate reusable setup step (eval + quoted args)
+        id: setup
+        shell: bash
+        env:
+          SETUP_CMD: "printf '%s\\n' 'quote-preservation-ok'"
+        run: |
+          set -euo pipefail
+          : > /tmp/setup.log
+          eval "${SETUP_CMD}" 2>&1 | tee -a /tmp/setup.log
+      - name: Assert quote-preservation marker appeared
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! grep -qFx 'quote-preservation-ok' /tmp/setup.log; then
+            echo "::error::expected bare 'quote-preservation-ok' line; eval quote handling regressed"
+            cat /tmp/setup.log
+            exit 1
+          fi
+          echo "Quoted setup-command preserved single quotes through eval."
 
   # ========== TypeScript ==========
 
@@ -227,13 +248,30 @@ jobs:
           fi
           echo "Injection neutralised (typescript)."
 
-  # F3 — TypeScript quoted setup-command. Guards against future TS
-  # consumers adopting a quoted setup-command.
+  # F3 — TypeScript quoted setup-command. Same replication pattern as
+  # python-f3-quoted-setup; see that job for rationale.
   typescript-f3-quoted-setup:
-    name: eval-hardening / ts-F3 (quoted setup, expect marker in log)
-    uses: ./.github/workflows/reusable-pr-gate-typescript.yml
-    with:
-      node-version: "20"
-      working-directory: tests/fixtures/projects/typescript-sample
-      setup-command: "printf '%s\\n' 'ts-quote-preservation-ok'"
-      gh-manage-ref: ${{ github.sha }}
+    name: eval-hardening / ts-F3 (quoted setup, marker must appear)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Replicate reusable setup step (eval + quoted args)
+        id: setup
+        shell: bash
+        env:
+          SETUP_CMD: "printf '%s\\n' 'ts-quote-preservation-ok'"
+        run: |
+          set -euo pipefail
+          : > /tmp/setup.log
+          eval "${SETUP_CMD}" 2>&1 | tee -a /tmp/setup.log
+      - name: Assert quote-preservation marker appeared
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! grep -qFx 'ts-quote-preservation-ok' /tmp/setup.log; then
+            echo "::error::expected bare 'ts-quote-preservation-ok' line; eval quote handling regressed"
+            cat /tmp/setup.log
+            exit 1
+          fi
+          echo "Quoted setup-command preserved single quotes through eval (typescript)."

--- a/.github/workflows/eval-hardening-smoke.yml
+++ b/.github/workflows/eval-hardening-smoke.yml
@@ -93,7 +93,22 @@ jobs:
           # ${{ github.job }} is the job_id string, not the numeric
           # job ID that --job expects. The marker string is unique
           # enough that whole-run grep is sound.
-          gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>&1 || true
+          if ! gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>/tmp/inject.err; then
+            echo "::error::gh run view failed — cannot verify injection property"
+            cat /tmp/inject.err
+            exit 1
+          fi
+          if [[ ! -s /tmp/inject.log ]]; then
+            echo "::error::gh run view returned empty log — cannot verify injection property"
+            exit 1
+          fi
+          # Confirm logs actually include the inject step's output. If
+          # the TEST_CMD echo is absent, logs are truncated and grep -q
+          # on the marker would be a vacuous check.
+          if ! grep -q 'Running test-command:' /tmp/inject.log; then
+            echo "::error::inject-step logs missing — assertion would be vacuous"
+            exit 1
+          fi
           if grep -q 'PWNED_BY_INJECTION' /tmp/inject.log; then
             echo "::error::injection marker leaked — eval hardening regressed"
             exit 1
@@ -178,8 +193,21 @@ jobs:
         run: |
           set -euo pipefail
           # See comment in python-f2-injection assert step for why we
-          # do not filter --job.
-          gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>&1 || true
+          # do not filter --job and why we check log non-emptiness
+          # and presence of the inject step's echo line.
+          if ! gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>/tmp/inject.err; then
+            echo "::error::gh run view failed — cannot verify injection property"
+            cat /tmp/inject.err
+            exit 1
+          fi
+          if [[ ! -s /tmp/inject.log ]]; then
+            echo "::error::gh run view returned empty log — cannot verify injection property"
+            exit 1
+          fi
+          if ! grep -q 'Running test-command:' /tmp/inject.log; then
+            echo "::error::inject-step logs missing — assertion would be vacuous"
+            exit 1
+          fi
           if grep -q 'PWNED_BY_INJECTION' /tmp/inject.log; then
             echo "::error::injection marker leaked — eval hardening regressed (typescript)"
             exit 1

--- a/.github/workflows/eval-hardening-smoke.yml
+++ b/.github/workflows/eval-hardening-smoke.yml
@@ -153,6 +153,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ ! -s /tmp/setup.log ]]; then
+            echo "::error::/tmp/setup.log empty or missing — setup step did not capture output"
+            exit 1
+          fi
           if ! grep -qFx 'quote-preservation-ok' /tmp/setup.log; then
             echo "::error::expected bare 'quote-preservation-ok' line; eval quote handling regressed"
             cat /tmp/setup.log
@@ -269,6 +273,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ ! -s /tmp/setup.log ]]; then
+            echo "::error::/tmp/setup.log empty or missing — setup step did not capture output"
+            exit 1
+          fi
           if ! grep -qFx 'ts-quote-preservation-ok' /tmp/setup.log; then
             echo "::error::expected bare 'ts-quote-preservation-ok' line; eval quote handling regressed"
             cat /tmp/setup.log

--- a/.github/workflows/eval-hardening-smoke.yml
+++ b/.github/workflows/eval-hardening-smoke.yml
@@ -1,0 +1,202 @@
+name: Eval Hardening Smoke
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/reusable-pr-gate-python.yml'
+      - '.github/workflows/reusable-pr-gate-typescript.yml'
+      - '.github/workflows/eval-hardening-smoke.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/reusable-pr-gate-python.yml'
+      - '.github/workflows/reusable-pr-gate-typescript.yml'
+      - '.github/workflows/eval-hardening-smoke.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ========== Python ==========
+
+  # F1 — Python positive: flags and paths exercise word-splitting of the
+  # most common non-default install/test-command shape across the 22
+  # bundled consumers.
+  python-f1-flags-paths:
+    name: eval-hardening / python-F1 (flags+paths, expect pass)
+    uses: ./.github/workflows/reusable-pr-gate-python.yml
+    with:
+      python-version: "3.12"
+      working-directory: tests/fixtures/projects/python-sample
+      install-command: "uv sync --all-extras"
+      test-command: "uv run pytest tests/ -v --tb=short"
+      gh-manage-ref: ${{ github.sha }}
+
+  # F2 — Python injection attempt. Spec sketches this with a sibling
+  # jobs.<id>.uses: + continue-on-error job; smoke-test.yml documents
+  # that job-level continue-on-error is not honoured for reusable
+  # workflow calls, so we replicate the critical ${TEST_CMD} step in a
+  # regular job with step-level continue-on-error, then assert.
+  python-f2-injection:
+    name: eval-hardening / python-F2 (injection neutralised)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python and uv
+        uses: ./actions/setup-python-uv
+        with:
+          python-version: "3.12"
+
+      - name: Install fixture deps
+        shell: bash
+        working-directory: tests/fixtures/projects/python-sample
+        run: |
+          set -euo pipefail
+          uv sync
+
+      # Replicates the body of the reusable workflow's test step. The
+      # key property under test: ${TEST_CMD} expands via word splitting
+      # only; the ';' token becomes a literal positional argv to pytest.
+      # This is exactly the same shell line as line 133 of
+      # reusable-pr-gate-python.yml, so the fixture stays in sync with
+      # the production change by construction.
+      - name: Replicate reusable test step (expect failure, marker MUST NOT leak)
+        id: inject
+        continue-on-error: true
+        shell: bash
+        working-directory: tests/fixtures/projects/python-sample
+        env:
+          TEST_CMD: "uv run pytest tests/ ; echo PWNED_BY_INJECTION"
+        run: |
+          set -euo pipefail
+          echo "::group::test"
+          echo "Running test-command: ${TEST_CMD}"
+          ${TEST_CMD}
+          echo "::endgroup::"
+
+      - name: Assert injection marker did not leak
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTCOME: ${{ steps.inject.outcome }}
+        run: |
+          set -euo pipefail
+          # gh run view <RUN_ID> --log returns combined logs for ALL
+          # jobs in the run (including this in-progress job's completed
+          # prior steps). We do NOT filter by --job because
+          # ${{ github.job }} is the job_id string, not the numeric
+          # job ID that --job expects. The marker string is unique
+          # enough that whole-run grep is sound.
+          gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>&1 || true
+          if grep -q 'PWNED_BY_INJECTION' /tmp/inject.log; then
+            echo "::error::injection marker leaked — eval hardening regressed"
+            exit 1
+          fi
+          # Secondary sanity check: the replication step should have
+          # failed (pytest errors on the ';' extra argv). If it
+          # succeeded, the fixture is wrong or pytest silently ignores
+          # unknown positionals.
+          if [[ "${OUTCOME}" != "failure" ]]; then
+            echo "::error::expected replication step to fail with unknown argv; outcome=${OUTCOME}"
+            exit 1
+          fi
+          echo "Injection neutralised: pytest errored on literal ';' arg and 'PWNED_BY_INJECTION' never executed."
+
+  # F3 — Python quoted setup-command compatibility. Proves eval still
+  # honours single quotes inside setup-command (the image-ocr pattern).
+  python-f3-quoted-setup:
+    name: eval-hardening / python-F3 (quoted setup, expect marker in log)
+    uses: ./.github/workflows/reusable-pr-gate-python.yml
+    with:
+      python-version: "3.12"
+      working-directory: tests/fixtures/projects/python-sample
+      setup-command: "printf '%s\\n' 'quote-preservation-ok'"
+      gh-manage-ref: ${{ github.sha }}
+
+  # ========== TypeScript ==========
+
+  # F1 — TypeScript positive: word splitting of pnpm install flags and
+  # a non-default test invocation.
+  typescript-f1-flags:
+    name: eval-hardening / ts-F1 (flags, expect pass)
+    uses: ./.github/workflows/reusable-pr-gate-typescript.yml
+    with:
+      node-version: "20"
+      working-directory: tests/fixtures/projects/typescript-sample
+      install-command: "pnpm install --frozen-lockfile"
+      test-command: "pnpm test -- --run"
+      gh-manage-ref: ${{ github.sha }}
+
+  # F2 — TypeScript injection attempt. Same replication pattern as F2
+  # Python; uses pnpm instead of uv.
+  typescript-f2-injection:
+    name: eval-hardening / ts-F2 (injection neutralised)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node and pnpm
+        uses: ./actions/setup-node-pnpm
+        with:
+          node-version: "20"
+
+      - name: Install fixture deps
+        shell: bash
+        working-directory: tests/fixtures/projects/typescript-sample
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile
+
+      - name: Replicate reusable test step (expect failure, marker MUST NOT leak)
+        id: inject
+        continue-on-error: true
+        shell: bash
+        working-directory: tests/fixtures/projects/typescript-sample
+        env:
+          TEST_CMD: "pnpm test ; echo PWNED_BY_INJECTION"
+        run: |
+          set -euo pipefail
+          echo "::group::test"
+          echo "Running test-command: ${TEST_CMD}"
+          ${TEST_CMD}
+          echo "::endgroup::"
+
+      - name: Assert injection marker did not leak
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTCOME: ${{ steps.inject.outcome }}
+        run: |
+          set -euo pipefail
+          # See comment in python-f2-injection assert step for why we
+          # do not filter --job.
+          gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>&1 || true
+          if grep -q 'PWNED_BY_INJECTION' /tmp/inject.log; then
+            echo "::error::injection marker leaked — eval hardening regressed (typescript)"
+            exit 1
+          fi
+          if [[ "${OUTCOME}" != "failure" ]]; then
+            echo "::error::expected replication step to fail; outcome=${OUTCOME}"
+            exit 1
+          fi
+          echo "Injection neutralised (typescript)."
+
+  # F3 — TypeScript quoted setup-command. Guards against future TS
+  # consumers adopting a quoted setup-command.
+  typescript-f3-quoted-setup:
+    name: eval-hardening / ts-F3 (quoted setup, expect marker in log)
+    uses: ./.github/workflows/reusable-pr-gate-typescript.yml
+    with:
+      node-version: "20"
+      working-directory: tests/fixtures/projects/typescript-sample
+      setup-command: "printf '%s\\n' 'ts-quote-preservation-ok'"
+      gh-manage-ref: ${{ github.sha }}

--- a/.github/workflows/eval-hardening-smoke.yml
+++ b/.github/workflows/eval-hardening-smoke.yml
@@ -66,6 +66,10 @@ jobs:
       # This is exactly the same shell line as line 133 of
       # reusable-pr-gate-python.yml, so the fixture stays in sync with
       # the production change by construction.
+      #
+      # We capture stdout+stderr inline via tee to /tmp/inject.log.
+      # gh run view --log cannot read logs of an in-progress run, so
+      # the assertion step must read a local file, not the API.
       - name: Replicate reusable test step (expect failure, marker MUST NOT leak)
         id: inject
         continue-on-error: true
@@ -74,42 +78,43 @@ jobs:
         env:
           TEST_CMD: "uv run pytest tests/ ; echo PWNED_BY_INJECTION"
         run: |
-          set -euo pipefail
-          echo "::group::test"
-          echo "Running test-command: ${TEST_CMD}"
-          ${TEST_CMD}
-          echo "::endgroup::"
+          set -uo pipefail
+          : > /tmp/inject.log
+          {
+            echo "Running test-command: ${TEST_CMD}"
+            ${TEST_CMD}
+            echo "::inject-rc::$?"
+          } 2>&1 | tee -a /tmp/inject.log
+          # Propagate inner rc explicitly; `set -e` is intentionally
+          # off above so we can record the failure rather than aborting.
+          rc=$(grep -oE '::inject-rc::[0-9]+' /tmp/inject.log | tail -1 | sed 's/.*:://')
+          echo "inject-rc=${rc:-unknown}"
+          exit "${rc:-1}"
 
       - name: Assert injection marker did not leak
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OUTCOME: ${{ steps.inject.outcome }}
         run: |
           set -euo pipefail
-          # gh run view <RUN_ID> --log returns combined logs for ALL
-          # jobs in the run (including this in-progress job's completed
-          # prior steps). We do NOT filter by --job because
-          # ${{ github.job }} is the job_id string, not the numeric
-          # job ID that --job expects. The marker string is unique
-          # enough that whole-run grep is sound.
-          if ! gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>/tmp/inject.err; then
-            echo "::error::gh run view failed — cannot verify injection property"
-            cat /tmp/inject.err
-            exit 1
-          fi
           if [[ ! -s /tmp/inject.log ]]; then
-            echo "::error::gh run view returned empty log — cannot verify injection property"
+            echo "::error::/tmp/inject.log empty or missing — inject step did not run"
             exit 1
           fi
           # Confirm logs actually include the inject step's output. If
-          # the TEST_CMD echo is absent, logs are truncated and grep -q
-          # on the marker would be a vacuous check.
+          # the TEST_CMD echo is absent, the capture is broken and
+          # grep -q on the marker would be a vacuous check.
           if ! grep -q 'Running test-command:' /tmp/inject.log; then
-            echo "::error::inject-step logs missing — assertion would be vacuous"
+            echo "::error::inject-step log missing header — assertion would be vacuous"
             exit 1
           fi
-          if grep -q 'PWNED_BY_INJECTION' /tmp/inject.log; then
+          # Match a whole-line marker only. pytest/vitest may echo the
+          # unrecognized positional arg back in "file not found:
+          # PWNED_BY_INJECTION" error lines — that proves injection did
+          # NOT fire (the shell saw it as argv, not a statement). Only a
+          # bare `echo PWNED_BY_INJECTION` produces a standalone-line
+          # marker, which is the true leak signal.
+          if grep -qFx 'PWNED_BY_INJECTION' /tmp/inject.log; then
             echo "::error::injection marker leaked — eval hardening regressed"
             exit 1
           fi
@@ -171,6 +176,8 @@ jobs:
           set -euo pipefail
           pnpm install --frozen-lockfile
 
+      # See python-f2-injection for architecture notes on the inline
+      # tee capture and why we cannot use gh run view --log here.
       - name: Replicate reusable test step (expect failure, marker MUST NOT leak)
         id: inject
         continue-on-error: true
@@ -179,36 +186,38 @@ jobs:
         env:
           TEST_CMD: "pnpm test ; echo PWNED_BY_INJECTION"
         run: |
-          set -euo pipefail
-          echo "::group::test"
-          echo "Running test-command: ${TEST_CMD}"
-          ${TEST_CMD}
-          echo "::endgroup::"
+          set -uo pipefail
+          : > /tmp/inject.log
+          {
+            echo "Running test-command: ${TEST_CMD}"
+            ${TEST_CMD}
+            echo "::inject-rc::$?"
+          } 2>&1 | tee -a /tmp/inject.log
+          rc=$(grep -oE '::inject-rc::[0-9]+' /tmp/inject.log | tail -1 | sed 's/.*:://')
+          echo "inject-rc=${rc:-unknown}"
+          exit "${rc:-1}"
 
       - name: Assert injection marker did not leak
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OUTCOME: ${{ steps.inject.outcome }}
         run: |
           set -euo pipefail
-          # See comment in python-f2-injection assert step for why we
-          # do not filter --job and why we check log non-emptiness
-          # and presence of the inject step's echo line.
-          if ! gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>/tmp/inject.err; then
-            echo "::error::gh run view failed — cannot verify injection property"
-            cat /tmp/inject.err
-            exit 1
-          fi
           if [[ ! -s /tmp/inject.log ]]; then
-            echo "::error::gh run view returned empty log — cannot verify injection property"
+            echo "::error::/tmp/inject.log empty or missing — inject step did not run"
             exit 1
           fi
           if ! grep -q 'Running test-command:' /tmp/inject.log; then
-            echo "::error::inject-step logs missing — assertion would be vacuous"
+            echo "::error::inject-step log missing header — assertion would be vacuous"
             exit 1
           fi
-          if grep -q 'PWNED_BY_INJECTION' /tmp/inject.log; then
+          # Match a whole-line marker only. pytest/vitest may echo the
+          # unrecognized positional arg back in "file not found:
+          # PWNED_BY_INJECTION" error lines — that proves injection did
+          # NOT fire (the shell saw it as argv, not a statement). Only a
+          # bare `echo PWNED_BY_INJECTION` produces a standalone-line
+          # marker, which is the true leak signal.
+          if grep -qFx 'PWNED_BY_INJECTION' /tmp/inject.log; then
             echo "::error::injection marker leaked — eval hardening regressed (typescript)"
             exit 1
           fi

--- a/.github/workflows/reusable-pr-gate-python.yml
+++ b/.github/workflows/reusable-pr-gate-python.yml
@@ -13,12 +13,12 @@ on:
         type: string
         default: "."
       install-command:
-        description: "Dependency install command executed inside working-directory."
+        description: "Dependency install command executed inside working-directory. Runs via shell word splitting (${CMD}), NOT eval. Shell metacharacters (pipes, quotes, redirects, $(), ;) are not interpreted; pass space-separated arguments only. For commands needing shell features, use setup-command or a committed shell script."
         required: false
         type: string
         default: "uv sync"
       test-command:
-        description: "Test command executed inside working-directory."
+        description: "Test command executed inside working-directory. Runs via shell word splitting (${CMD}), NOT eval. Shell metacharacters (pipes, quotes, redirects, $(), ;) are not interpreted; pass space-separated arguments only. For commands needing shell features, use setup-command or a committed shell script."
         required: false
         type: string
         default: "uv run pytest"
@@ -33,7 +33,7 @@ on:
         type: boolean
         default: true
       setup-command:
-        description: "Optional shell command executed after install, before tests."
+        description: "Optional shell command executed after install, before tests. Runs via `eval` and interprets shell metacharacters (quotes, pipes, $()). SECURITY: only pass static literal values from trusted source. MUST NOT forward github.event.* fields, workflow_dispatch inputs, or any consumer-controlled string — doing so allows remote code execution in the PR gate. See docs/security.md."
         required: false
         type: string
         default: ""
@@ -90,7 +90,7 @@ jobs:
           set -euo pipefail
           echo "::group::install"
           echo "Running install-command: ${INSTALL_CMD}"
-          eval "${INSTALL_CMD}"
+          ${INSTALL_CMD}
           echo "::endgroup::"
 
       - name: Run ruff (if lint enabled)
@@ -130,5 +130,5 @@ jobs:
           set -euo pipefail
           echo "::group::test"
           echo "Running test-command: ${TEST_CMD}"
-          eval "${TEST_CMD}"
+          ${TEST_CMD}
           echo "::endgroup::"

--- a/.github/workflows/reusable-pr-gate-typescript.yml
+++ b/.github/workflows/reusable-pr-gate-typescript.yml
@@ -13,12 +13,12 @@ on:
         type: string
         default: "."
       install-command:
-        description: "Dependency install command executed inside working-directory."
+        description: "Dependency install command executed inside working-directory. Runs via shell word splitting (${CMD}), NOT eval. Shell metacharacters (pipes, quotes, redirects, $(), ;) are not interpreted; pass space-separated arguments only. For commands needing shell features, use setup-command or a committed shell script."
         required: false
         type: string
         default: "pnpm install --frozen-lockfile"
       test-command:
-        description: "Test command executed inside working-directory."
+        description: "Test command executed inside working-directory. Runs via shell word splitting (${CMD}), NOT eval. Shell metacharacters (pipes, quotes, redirects, $(), ;) are not interpreted; pass space-separated arguments only. For commands needing shell features, use setup-command or a committed shell script."
         required: false
         type: string
         default: "pnpm test"
@@ -33,7 +33,7 @@ on:
         type: boolean
         default: true
       setup-command:
-        description: "Optional shell command executed after install, before tests."
+        description: "Optional shell command executed after install, before tests. Runs via `eval` and interprets shell metacharacters (quotes, pipes, $()). SECURITY: only pass static literal values from trusted source. MUST NOT forward github.event.* fields, workflow_dispatch inputs, or any consumer-controlled string — doing so allows remote code execution in the PR gate. See docs/security.md."
         required: false
         type: string
         default: ""
@@ -90,7 +90,7 @@ jobs:
           set -euo pipefail
           echo "::group::install"
           echo "Running install-command: ${INSTALL_CMD}"
-          eval "${INSTALL_CMD}"
+          ${INSTALL_CMD}
           echo "::endgroup::"
 
       - name: Run eslint (if lint enabled)
@@ -130,5 +130,5 @@ jobs:
           set -euo pipefail
           echo "::group::test"
           echo "Running test-command: ${TEST_CMD}"
-          eval "${TEST_CMD}"
+          ${TEST_CMD}
           echo "::endgroup::"

--- a/CHANGELOG-reusable.md
+++ b/CHANGELOG-reusable.md
@@ -8,6 +8,21 @@ The CLI changelog lives in `CHANGELOG-cli.md`.
 
 _Nothing yet._
 
+## [1.1.0] - 2026-04-XX
+
+### Security
+
+- **[Behaviour change]** `install-command` and `test-command` no longer interpret shell metacharacters. Previously both fields were executed via `eval "${CMD}"`, which allowed command injection when consumers passed values sourced from untrusted inputs (`github.event.*` fields, workflow_dispatch inputs). They now execute via `${CMD}` (shell word splitting only). Shell metacharacters in these inputs are passed to the install/test binary as literal arguments rather than interpreted.
+  - All consumers listed in `src/gh_manage/data/repos.yml` as of 2026-04-17 (22 repos) were inspected manually and verified unaffected: none used shell metacharacters in `install-command` or `test-command`.
+  - Consumers that need shell features (quotes, pipes, redirects) in these fields must migrate them to `setup-command` or to a committed shell script invoked by path.
+  - `setup-command` continues to execute via `eval` as a documented escape hatch and is explicitly scoped as "trusted source only" — see `docs/security.md` for the full trust model.
+  - Closes #36.
+
+### Added
+
+- `setup-command` input description now explicitly documents its trust requirements and links to `docs/security.md`.
+- New `docs/security.md` covering the workflow input threat model, safe/unsafe patterns, and version history.
+
 ## [1.0.0] - 2026-04-14
 
 Stable API milestone. No functional changes since v0.2.1.

--- a/docs/plans/2026-04-17-issue-36-eval-hardening-plan.md
+++ b/docs/plans/2026-04-17-issue-36-eval-hardening-plan.md
@@ -1,0 +1,1102 @@
+# Issue #36 — `eval` Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (default) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `eval "${CMD}"` with `${CMD}` (word splitting only) in `install-command` and `test-command` of both reusable PR-gate workflows, keeping `eval` in `setup-command` as a documented escape hatch, and ship as reusable-track `v1.1.0`.
+
+**Architecture:** Two-line edits per workflow file (Python + TypeScript) plus input-description security notes. Regression coverage via three fixture jobs per language in a new smoke workflow. Release flow = annotated tag + GitHub Release + 22 consumer-side version-bump PRs in four batches.
+
+**Tech Stack:** GitHub Actions (bash `set -euo pipefail`), pytest (positive fixture), pnpm (TS fixture), `gh` CLI for release and consumer rollout. Documentation in Markdown.
+
+**Spec:** `docs/specs/2026-04-17-issue-36-eval-hardening-design.md`
+
+**Branch (already created):** `fix/issue-36-eval-hardening`
+
+---
+
+## Plan-phase constraint resolution
+
+Two spec-to-reality mismatches resolved here so task authors don't re-discover them:
+
+1. **F2 fixture mechanism.** Spec sketches F2 as a sibling `jobs.<id>.uses:` + `continue-on-error: true` pair. `.github/workflows/smoke-test.yml:37-41` documents that **GitHub Actions does not honour `continue-on-error` at job level for `jobs.<id>.uses:`**. Plan F2 therefore uses a regular job that directly replicates the critical `${TEST_CMD}` run step with step-level `continue-on-error`, then asserts `PWNED_BY_INJECTION` is absent. This tests the same security property (word splitting vs shell interpretation) without invoking the full reusable workflow. F1 and F3 still use the reusable workflow via `jobs.<id>.uses:` because they are expected to pass — no `continue-on-error` needed.
+
+2. **CHANGELOG file name.** Spec says `CHANGELOG.md`; repo actually splits into `CHANGELOG-reusable.md` (this is what we edit) and `CHANGELOG-cli.md` (untouched here).
+
+---
+
+## File structure
+
+Edited:
+- `.github/workflows/reusable-pr-gate-python.yml` — line 93 and 133 swap, input descriptions updated.
+- `.github/workflows/reusable-pr-gate-typescript.yml` — same two lines, same description updates.
+- `docs/usage/python.md` — `install-command` / `test-command` / `setup-command` sections.
+- `docs/usage/typescript.md` — same three sections.
+- `docs/versioning.md` — one-line note on minor-version behaviour changes.
+- `CHANGELOG-reusable.md` — v1.1.0 section inserted under `## [Unreleased]`.
+
+Created:
+- `.github/workflows/eval-hardening-smoke.yml` — dedicated smoke workflow (F1/F2/F3 × {Python, TypeScript}).
+- `docs/security.md` — trust-model page, ~100 lines.
+
+Not modified:
+- `src/gh_manage/data/repos.yml` — rollout happens on the consumer side, not here.
+
+---
+
+## Task 1: Edit `reusable-pr-gate-python.yml`
+
+**Files:**
+- Modify: `.github/workflows/reusable-pr-gate-python.yml:15-24` (input descriptions) and `:35-39` (setup-command description) and `:93` (install eval swap) and `:133` (test eval swap)
+
+- [ ] **Step 1: Update `install-command` input description (lines 15-19)**
+
+Replace:
+
+```yaml
+      install-command:
+        description: "Dependency install command executed inside working-directory."
+        required: false
+        type: string
+        default: "uv sync"
+```
+
+with:
+
+```yaml
+      install-command:
+        description: "Dependency install command executed inside working-directory. Runs via shell word splitting (${CMD}), NOT eval. Shell metacharacters (pipes, quotes, redirects, $(), ;) are not interpreted; pass space-separated arguments only. For commands needing shell features, use setup-command or a committed shell script."
+        required: false
+        type: string
+        default: "uv sync"
+```
+
+- [ ] **Step 2: Update `test-command` input description (lines 20-24)**
+
+Replace:
+
+```yaml
+      test-command:
+        description: "Test command executed inside working-directory."
+        required: false
+        type: string
+        default: "uv run pytest"
+```
+
+with:
+
+```yaml
+      test-command:
+        description: "Test command executed inside working-directory. Runs via shell word splitting (${CMD}), NOT eval. Shell metacharacters (pipes, quotes, redirects, $(), ;) are not interpreted; pass space-separated arguments only. For commands needing shell features, use setup-command or a committed shell script."
+        required: false
+        type: string
+        default: "uv run pytest"
+```
+
+- [ ] **Step 3: Update `setup-command` input description (lines 35-39)**
+
+Replace:
+
+```yaml
+      setup-command:
+        description: "Optional shell command executed after install, before tests."
+        required: false
+        type: string
+        default: ""
+```
+
+with:
+
+```yaml
+      setup-command:
+        description: "Optional shell command executed after install, before tests. Runs via `eval` and interprets shell metacharacters (quotes, pipes, $()). SECURITY: only pass static literal values from trusted source. MUST NOT forward github.event.* fields, workflow_dispatch inputs, or any consumer-controlled string — doing so allows remote code execution in the PR gate. See docs/security.md."
+        required: false
+        type: string
+        default: ""
+```
+
+- [ ] **Step 4: Swap line 93 — install step**
+
+Replace:
+
+```yaml
+          echo "Running install-command: ${INSTALL_CMD}"
+          eval "${INSTALL_CMD}"
+```
+
+with:
+
+```yaml
+          echo "Running install-command: ${INSTALL_CMD}"
+          ${INSTALL_CMD}
+```
+
+- [ ] **Step 5: Swap line 133 — test step**
+
+Replace:
+
+```yaml
+          echo "Running test-command: ${TEST_CMD}"
+          eval "${TEST_CMD}"
+```
+
+with:
+
+```yaml
+          echo "Running test-command: ${TEST_CMD}"
+          ${TEST_CMD}
+```
+
+- [ ] **Step 6: Verify setup-command step unchanged**
+
+Open the file, confirm the `Run setup command (if provided)` step still contains `if ! eval "${SETUP_CMD}"; then` (around line 118). Do not edit.
+
+- [ ] **Step 7: Local YAML syntax check**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/reusable-pr-gate-python.yml'))"`
+Expected: command exits 0 with no output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/reusable-pr-gate-python.yml
+git commit -m "fix(reusable): drop eval from install/test command in python PR gate
+
+Closes part of #36. install-command and test-command now execute via
+\${CMD} word splitting instead of eval \"\${CMD}\", so shell
+metacharacters in the input value are passed as literal argv instead of
+being interpreted. setup-command retains eval as the documented escape
+hatch (image-ocr depends on single-quote preservation)."
+```
+
+---
+
+## Task 2: Edit `reusable-pr-gate-typescript.yml`
+
+Mirror Task 1 against the TypeScript workflow. Line numbers are identical (15-24 for install/test descriptions, 35-39 for setup-command, 93 for install swap, 133 for test swap).
+
+**Files:**
+- Modify: `.github/workflows/reusable-pr-gate-typescript.yml` (same lines as Task 1)
+
+- [ ] **Step 1: Update `install-command` description (lines 15-19)**
+
+Replace:
+
+```yaml
+      install-command:
+        description: "Dependency install command executed inside working-directory."
+        required: false
+        type: string
+        default: "pnpm install --frozen-lockfile"
+```
+
+with:
+
+```yaml
+      install-command:
+        description: "Dependency install command executed inside working-directory. Runs via shell word splitting (${CMD}), NOT eval. Shell metacharacters (pipes, quotes, redirects, $(), ;) are not interpreted; pass space-separated arguments only. For commands needing shell features, use setup-command or a committed shell script."
+        required: false
+        type: string
+        default: "pnpm install --frozen-lockfile"
+```
+
+- [ ] **Step 2: Update `test-command` description (lines 20-24)**
+
+Replace:
+
+```yaml
+      test-command:
+        description: "Test command executed inside working-directory."
+        required: false
+        type: string
+        default: "pnpm test"
+```
+
+with:
+
+```yaml
+      test-command:
+        description: "Test command executed inside working-directory. Runs via shell word splitting (${CMD}), NOT eval. Shell metacharacters (pipes, quotes, redirects, $(), ;) are not interpreted; pass space-separated arguments only. For commands needing shell features, use setup-command or a committed shell script."
+        required: false
+        type: string
+        default: "pnpm test"
+```
+
+- [ ] **Step 3: Update `setup-command` description (lines 35-39)**
+
+Replace:
+
+```yaml
+      setup-command:
+        description: "Optional shell command executed after install, before tests."
+        required: false
+        type: string
+        default: ""
+```
+
+with:
+
+```yaml
+      setup-command:
+        description: "Optional shell command executed after install, before tests. Runs via `eval` and interprets shell metacharacters (quotes, pipes, $()). SECURITY: only pass static literal values from trusted source. MUST NOT forward github.event.* fields, workflow_dispatch inputs, or any consumer-controlled string — doing so allows remote code execution in the PR gate. See docs/security.md."
+        required: false
+        type: string
+        default: ""
+```
+
+- [ ] **Step 4: Swap line 93 — install step**
+
+Replace:
+
+```yaml
+          echo "Running install-command: ${INSTALL_CMD}"
+          eval "${INSTALL_CMD}"
+```
+
+with:
+
+```yaml
+          echo "Running install-command: ${INSTALL_CMD}"
+          ${INSTALL_CMD}
+```
+
+- [ ] **Step 5: Swap line 133 — test step**
+
+Replace:
+
+```yaml
+          echo "Running test-command: ${TEST_CMD}"
+          eval "${TEST_CMD}"
+```
+
+with:
+
+```yaml
+          echo "Running test-command: ${TEST_CMD}"
+          ${TEST_CMD}
+```
+
+- [ ] **Step 6: Verify setup-command step unchanged**
+
+Confirm the TypeScript file's `Run setup command (if provided)` step still contains `if ! eval "${SETUP_CMD}"; then`.
+
+- [ ] **Step 7: Local YAML syntax check**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/reusable-pr-gate-typescript.yml'))"`
+Expected: command exits 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/reusable-pr-gate-typescript.yml
+git commit -m "fix(reusable): drop eval from install/test command in typescript PR gate
+
+Closes part of #36. Mirrors the python-side change: install-command and
+test-command execute via \${CMD} word splitting; setup-command retains
+eval as the documented escape hatch. No TypeScript consumer currently
+uses setup-command, but the eval retention keeps parity with the python
+workflow and reserves the escape hatch for future consumers."
+```
+
+---
+
+## Task 3: Create smoke workflow `.github/workflows/eval-hardening-smoke.yml`
+
+This workflow is the regression gate for the eval-hardening change. It runs on PRs that touch either reusable workflow or the smoke workflow itself.
+
+**Files:**
+- Create: `.github/workflows/eval-hardening-smoke.yml`
+
+- [ ] **Step 1: Write the failing test (the smoke workflow itself)**
+
+Create the file with all six fixture jobs (Python F1/F2/F3 + TypeScript F1/F2/F3). Full content:
+
+```yaml
+name: Eval Hardening Smoke
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/reusable-pr-gate-python.yml'
+      - '.github/workflows/reusable-pr-gate-typescript.yml'
+      - '.github/workflows/eval-hardening-smoke.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/reusable-pr-gate-python.yml'
+      - '.github/workflows/reusable-pr-gate-typescript.yml'
+      - '.github/workflows/eval-hardening-smoke.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ========== Python ==========
+
+  # F1 — Python positive: flags and paths exercise word-splitting of the
+  # most common non-default install/test-command shape across the 22
+  # bundled consumers.
+  python-f1-flags-paths:
+    name: eval-hardening / python-F1 (flags+paths, expect pass)
+    uses: ./.github/workflows/reusable-pr-gate-python.yml
+    with:
+      python-version: "3.12"
+      working-directory: tests/fixtures/projects/python-sample
+      install-command: "uv sync --all-extras"
+      test-command: "uv run pytest tests/ -v --tb=short"
+      gh-manage-ref: ${{ github.sha }}
+
+  # F2 — Python injection attempt. Spec sketches this with a sibling
+  # jobs.<id>.uses: + continue-on-error job; smoke-test.yml documents
+  # that job-level continue-on-error is not honoured for reusable
+  # workflow calls, so we replicate the critical ${TEST_CMD} step in a
+  # regular job with step-level continue-on-error, then assert.
+  python-f2-injection:
+    name: eval-hardening / python-F2 (injection neutralised)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python and uv
+        uses: ./actions/setup-python-uv
+        with:
+          python-version: "3.12"
+
+      - name: Install fixture deps
+        shell: bash
+        working-directory: tests/fixtures/projects/python-sample
+        run: |
+          set -euo pipefail
+          uv sync
+
+      # Replicates the body of the reusable workflow's test step. The
+      # key property under test: ${TEST_CMD} expands via word splitting
+      # only; the ';' token becomes a literal positional argv to pytest.
+      # This is exactly the same shell line as line 133 of
+      # reusable-pr-gate-python.yml, so the fixture stays in sync with
+      # the production change by construction.
+      - name: Replicate reusable test step (expect failure, marker MUST NOT leak)
+        id: inject
+        continue-on-error: true
+        shell: bash
+        working-directory: tests/fixtures/projects/python-sample
+        env:
+          TEST_CMD: "uv run pytest tests/ ; echo PWNED_BY_INJECTION"
+        run: |
+          set -euo pipefail
+          echo "::group::test"
+          echo "Running test-command: ${TEST_CMD}"
+          ${TEST_CMD}
+          echo "::endgroup::"
+
+      - name: Assert injection marker did not leak
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTCOME: ${{ steps.inject.outcome }}
+        run: |
+          set -euo pipefail
+          # gh run view <RUN_ID> --log returns combined logs for ALL
+          # jobs in the run (including this in-progress job's completed
+          # prior steps). We do NOT filter by --job because
+          # ${{ github.job }} is the job_id string, not the numeric
+          # job ID that --job expects. The marker string is unique
+          # enough that whole-run grep is sound.
+          gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>&1 || true
+          if grep -q 'PWNED_BY_INJECTION' /tmp/inject.log; then
+            echo "::error::injection marker leaked — eval hardening regressed"
+            exit 1
+          fi
+          # Secondary sanity check: the replication step should have
+          # failed (pytest errors on the ';' extra argv). If it
+          # succeeded, the fixture is wrong or pytest silently ignores
+          # unknown positionals.
+          if [[ "${OUTCOME}" != "failure" ]]; then
+            echo "::error::expected replication step to fail with unknown argv; outcome=${OUTCOME}"
+            exit 1
+          fi
+          echo "Injection neutralised: pytest errored on literal ';' arg and 'PWNED_BY_INJECTION' never executed."
+
+  # F3 — Python quoted setup-command compatibility. Proves eval still
+  # honours single quotes inside setup-command (the image-ocr pattern).
+  python-f3-quoted-setup:
+    name: eval-hardening / python-F3 (quoted setup, expect marker in log)
+    uses: ./.github/workflows/reusable-pr-gate-python.yml
+    with:
+      python-version: "3.12"
+      working-directory: tests/fixtures/projects/python-sample
+      setup-command: "printf '%s\\n' 'quote-preservation-ok'"
+      gh-manage-ref: ${{ github.sha }}
+
+  # ========== TypeScript ==========
+
+  # F1 — TypeScript positive: word splitting of pnpm install flags and
+  # a non-default test invocation.
+  typescript-f1-flags:
+    name: eval-hardening / ts-F1 (flags, expect pass)
+    uses: ./.github/workflows/reusable-pr-gate-typescript.yml
+    with:
+      node-version: "20"
+      working-directory: tests/fixtures/projects/typescript-sample
+      install-command: "pnpm install --frozen-lockfile"
+      test-command: "pnpm test -- --run"
+      gh-manage-ref: ${{ github.sha }}
+
+  # F2 — TypeScript injection attempt. Same replication pattern as F2
+  # Python; uses pnpm instead of uv.
+  typescript-f2-injection:
+    name: eval-hardening / ts-F2 (injection neutralised)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node and pnpm
+        uses: ./actions/setup-node-pnpm
+        with:
+          node-version: "20"
+
+      - name: Install fixture deps
+        shell: bash
+        working-directory: tests/fixtures/projects/typescript-sample
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile
+
+      - name: Replicate reusable test step (expect failure, marker MUST NOT leak)
+        id: inject
+        continue-on-error: true
+        shell: bash
+        working-directory: tests/fixtures/projects/typescript-sample
+        env:
+          TEST_CMD: "pnpm test ; echo PWNED_BY_INJECTION"
+        run: |
+          set -euo pipefail
+          echo "::group::test"
+          echo "Running test-command: ${TEST_CMD}"
+          ${TEST_CMD}
+          echo "::endgroup::"
+
+      - name: Assert injection marker did not leak
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTCOME: ${{ steps.inject.outcome }}
+        run: |
+          set -euo pipefail
+          # See comment in python-f2-injection assert step for why we
+          # do not filter --job.
+          gh run view "${{ github.run_id }}" --log > /tmp/inject.log 2>&1 || true
+          if grep -q 'PWNED_BY_INJECTION' /tmp/inject.log; then
+            echo "::error::injection marker leaked — eval hardening regressed (typescript)"
+            exit 1
+          fi
+          if [[ "${OUTCOME}" != "failure" ]]; then
+            echo "::error::expected replication step to fail; outcome=${OUTCOME}"
+            exit 1
+          fi
+          echo "Injection neutralised (typescript)."
+
+  # F3 — TypeScript quoted setup-command. Guards against future TS
+  # consumers adopting a quoted setup-command.
+  typescript-f3-quoted-setup:
+    name: eval-hardening / ts-F3 (quoted setup, expect marker in log)
+    uses: ./.github/workflows/reusable-pr-gate-typescript.yml
+    with:
+      node-version: "20"
+      working-directory: tests/fixtures/projects/typescript-sample
+      setup-command: "printf '%s\\n' 'ts-quote-preservation-ok'"
+      gh-manage-ref: ${{ github.sha }}
+```
+
+- [ ] **Step 2: Confirm fixture directories referenced actually exist**
+
+Run: `ls tests/fixtures/projects/python-sample tests/fixtures/projects/typescript-sample`
+Expected: both directories listed; each contains the project scaffolding used by the existing smoke-test.yml.
+
+If either is missing, stop — the fixture assumes these already exist (they are used by `.github/workflows/smoke-test.yml`). Report the gap back rather than inventing a new fixture.
+
+- [ ] **Step 3: YAML syntax check**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/eval-hardening-smoke.yml'))"`
+Expected: exits 0.
+
+- [ ] **Step 4: Shellcheck on the embedded bash blocks (best-effort)**
+
+Run: `grep -c 'set -euo pipefail' .github/workflows/eval-hardening-smoke.yml`
+Expected: ≥ 4 (one per non-trivial bash step: F2 install, F2 replicate, F2 assert, TS F2 install, TS F2 replicate, TS F2 assert).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/eval-hardening-smoke.yml
+git commit -m "test(smoke): add eval-hardening regression fixtures (F1/F2/F3 × py,ts)
+
+Adds a dedicated smoke workflow exercising three regression scenarios
+per language:
+- F1: flags-and-paths positive (most common non-default consumer shape).
+- F2: injection attempt; asserts PWNED_BY_INJECTION does not appear in
+  the job log, proving \${CMD} word splitting neutralises ';' + echo.
+- F3: quoted setup-command; proves eval still honours single quotes for
+  the image-ocr-style pip install -e '.[dev,bot]' pattern.
+
+F2 replicates the critical test step inline instead of invoking the
+reusable workflow with continue-on-error at job level, because GitHub
+Actions does not honour continue-on-error for jobs.<id>.uses: (see
+smoke-test.yml:37-41). Behavioural parity with the production workflow
+is maintained because the replication uses the same env-var
+indirection and the same set -euo pipefail; \${CMD} shell line.
+
+Part of #36."
+```
+
+---
+
+## Task 4: Create `docs/security.md`
+
+**Files:**
+- Create: `docs/security.md`
+
+- [ ] **Step 1: Write the security doc**
+
+Content:
+
+```markdown
+# Security Model — Reusable PR Gate Inputs
+
+This page documents the execution mechanism and trust requirements for
+the three consumer-supplied shell-command inputs on
+`reusable-pr-gate-python.yml` and `reusable-pr-gate-typescript.yml`.
+See `CHANGELOG-reusable.md` for release history.
+
+## Trust model
+
+| Input | Execution mechanism | Shell metacharacters | Required source |
+|-------|---------------------|----------------------|-----------------|
+| `install-command` | `${CMD}` (word splitting) | **Not interpreted** | Any source acceptable — the workflow neutralises shell injection by itself. Values with metacharacters will error out at the install binary, not execute. |
+| `test-command` | `${CMD}` (word splitting) | **Not interpreted** | Same as `install-command`. |
+| `setup-command` | `eval "${CMD}"` | **Interpreted** (quotes, `\|`, `$()`, `;`, etc.) | **Trusted source only.** Consumer is responsible for ensuring the value is a static literal and never comes from untrusted input. |
+
+## What MUST NOT be forwarded to `setup-command`
+
+The following sources are user-controlled in a typical GitHub
+repository and must never flow into `setup-command`:
+
+- `github.event.pull_request.title`
+- `github.event.pull_request.body`
+- `github.event.issue.title`
+- `github.event.issue.body`
+- `github.event.comment.body`
+- `github.event.review.body`
+- `inputs.*` from `workflow_dispatch` events triggered by non-maintainers
+- Values fetched from external URLs, third-party APIs, or other
+  repositories
+
+Forwarding any of these to `setup-command` allows remote code execution
+inside the PR-gate runner. The runner has `contents: read` on your
+repo plus access to any secrets exposed to the workflow call, so the
+blast radius is at minimum the workflow run's secret set.
+
+## Safe patterns
+
+The following patterns are safe because they use static literals
+defined in the workflow file itself:
+
+```yaml
+# Safe: static literal
+setup-command: "pip install -e '.[dev,bot]'"
+```
+
+```yaml
+# Safe: static literal driven by a matrix value (the matrix list is
+# defined in the workflow, not user-controlled).
+strategy:
+  matrix:
+    extras: ["dev", "dev,bot", "dev,ml"]
+setup-command: "pip install -e '.[${{ matrix.extras }}]'"
+```
+
+```yaml
+# Safe: secret or input defined at the caller level by a maintainer.
+# The value is still trusted because a maintainer authored the workflow
+# file and chose what feeds in.
+setup-command: "${{ secrets.MAINTAINER_DEFINED_SETUP }}"
+```
+
+## Unsafe patterns
+
+```yaml
+# UNSAFE: pull request body is attacker-controlled.
+setup-command: "echo '${{ github.event.pull_request.body }}'"
+```
+
+```yaml
+# UNSAFE: comment body is attacker-controlled.
+setup-command: "run-${{ github.event.comment.body }}"
+```
+
+```yaml
+# UNSAFE: workflow_dispatch input may be submitted by anyone with
+# actions:write on the repo.
+setup-command: "${{ inputs.user-provided-command }}"
+```
+
+## Version history
+
+| Release | Behaviour |
+|---------|-----------|
+| v1.0.x | `install-command`, `test-command`, and `setup-command` all executed via `eval "${CMD}"`. Shell metacharacters in any of the three were interpreted, so forwarding untrusted input to any of them allowed RCE. |
+| v1.1.0 (2026-04-XX) | `install-command` and `test-command` switched to `${CMD}` word splitting. `setup-command` still uses `eval` as a documented escape hatch for quote-preservation patterns (e.g., `pip install -e '.[dev,bot]'`). |
+
+## Reporting a security issue
+
+Do **not** open a public issue for a suspected vulnerability in this
+workflow. Instead, use GitHub's private vulnerability reporting on the
+`yakkuro/gh-manage` repository (`Security` tab → `Report a
+vulnerability`).
+```
+
+- [ ] **Step 2: Confirm file is well-formed markdown**
+
+Run: `python3 -c "import pathlib; t = pathlib.Path('docs/security.md').read_text(); assert 'Trust model' in t and 'Unsafe patterns' in t and 'Version history' in t; print(len(t.splitlines()), 'lines')"`
+Expected: prints a line count roughly in the 80-120 range and exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/security.md
+git commit -m "docs(security): add trust model for reusable PR-gate inputs
+
+Covers the v1.1.0 input trust split: install-command and test-command
+execute via word splitting, setup-command retains eval and requires a
+trusted source. Enumerates the github.event.* fields that must never
+flow into setup-command and gives safe / unsafe pattern examples.
+
+Part of #36."
+```
+
+---
+
+## Task 5: Update `docs/usage/python.md`, `docs/usage/typescript.md`, `docs/versioning.md`
+
+**Files:**
+- Modify: `docs/usage/python.md` — `install-command`, `test-command`, `setup-command` sections.
+- Modify: `docs/usage/typescript.md` — same three sections.
+- Modify: `docs/versioning.md` — one line under the v1.0.0 stability promise.
+
+- [ ] **Step 1: Locate the `install-command` section in `docs/usage/python.md`**
+
+Read the file, find the heading/section that documents `install-command`. Add a paragraph immediately after the existing description:
+
+> **Shell handling (v1.1.0+):** `install-command` executes via `${CMD}` (shell word splitting), not `eval`. Shell metacharacters — pipes, quotes, redirects, `$()`, `;` — are passed to the install binary as literal arguments, not interpreted. If you need shell features, use `setup-command` or commit a shell script to the consumer repository and invoke it by path. See [docs/security.md](../security.md) for the trust model.
+
+- [ ] **Step 2: Locate the `test-command` section in `docs/usage/python.md`**
+
+Add the same paragraph pattern (adapted for test-command):
+
+> **Shell handling (v1.1.0+):** `test-command` executes via `${CMD}` (shell word splitting), not `eval`. Same constraints as `install-command` above.
+
+- [ ] **Step 3: Locate the `setup-command` section in `docs/usage/python.md`**
+
+Add a security callout after the existing description:
+
+> **SECURITY (v1.1.0+):** `setup-command` executes via `eval` and interprets shell metacharacters. Only pass **static literal** values from a trusted source. Never forward `github.event.*`, `workflow_dispatch` inputs, or any consumer-controlled string to this field. See [docs/security.md](../security.md) for the full trust model and list of unsafe patterns.
+
+- [ ] **Step 4: Repeat Steps 1-3 for `docs/usage/typescript.md`**
+
+Same three sections, same text. If the TypeScript doc's prose differs slightly (e.g., pnpm-specific phrasing), adapt the intro clause but keep the v1.1.0 note wording identical so they diff cleanly.
+
+- [ ] **Step 5: Update `docs/versioning.md`**
+
+Find the v1.0.0 stability-promise section. Add one line:
+
+> Documented behaviour changes that tighten security (e.g., removing `eval` from already-risky inputs) may ship in a MINOR version if the change is announced in `CHANGELOG-reusable.md`'s `Security` section and does not alter the declared input surface. v1.1.0 is the first precedent: `install-command` and `test-command` behaviour changed from `eval` to word splitting, but the input types, names, defaults, and required flags are unchanged.
+
+- [ ] **Step 6: Sanity scan**
+
+Run: `grep -l "v1.1.0" docs/usage/python.md docs/usage/typescript.md docs/versioning.md docs/security.md`
+Expected: all four files listed.
+
+Run: `grep -c "docs/security.md\|security.md" docs/usage/python.md docs/usage/typescript.md`
+Expected: each file ≥ 2 (one link from install-command/test-command section, one from setup-command section).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/usage/python.md docs/usage/typescript.md docs/versioning.md
+git commit -m "docs(usage): annotate v1.1.0 shell-handling change in install/test/setup
+
+Adds a 'Shell handling (v1.1.0+)' paragraph to install-command and
+test-command sections of both usage guides, a security callout to
+setup-command, and a note in versioning.md explaining the v1.1.0
+precedent for MINOR-version security hardening.
+
+All four documentation files now cross-link to docs/security.md.
+
+Part of #36."
+```
+
+---
+
+## Task 6: Add v1.1.0 entry to `CHANGELOG-reusable.md`
+
+**Files:**
+- Modify: `CHANGELOG-reusable.md` — insert section under `## [Unreleased]` (line 7).
+
+- [ ] **Step 1: Replace the `## [Unreleased]` block**
+
+Current content at `CHANGELOG-reusable.md:7-9`:
+
+```markdown
+## [Unreleased]
+
+_Nothing yet._
+```
+
+Replace with:
+
+```markdown
+## [Unreleased]
+
+_Nothing yet._
+
+## [1.1.0] - 2026-04-XX
+
+### Security
+
+- **[Behaviour change]** `install-command` and `test-command` no longer interpret shell metacharacters. Previously both fields were executed via `eval "${CMD}"`, which allowed command injection when consumers passed values sourced from untrusted inputs (`github.event.*` fields, workflow_dispatch inputs). They now execute via `${CMD}` (shell word splitting only). Shell metacharacters in these inputs are passed to the install/test binary as literal arguments rather than interpreted.
+  - All consumers listed in `src/gh_manage/data/repos.yml` as of 2026-04-17 (22 repos) were inspected manually and verified unaffected: none used shell metacharacters in `install-command` or `test-command`.
+  - Consumers that need shell features (quotes, pipes, redirects) in these fields must migrate them to `setup-command` or to a committed shell script invoked by path.
+  - `setup-command` continues to execute via `eval` as a documented escape hatch and is explicitly scoped as "trusted source only" — see `docs/security.md` for the full trust model.
+  - Closes #36.
+
+### Added
+
+- `setup-command` input description now explicitly documents its trust requirements and links to `docs/security.md`.
+- New `docs/security.md` covering the workflow input threat model, safe/unsafe patterns, and version history.
+```
+
+- [ ] **Step 2: Verify markdown structure**
+
+Run: `grep -c '^## \[1.1.0\]' CHANGELOG-reusable.md`
+Expected: 1.
+
+- [ ] **Step 3: Confirm the v1.0.0 section is untouched**
+
+Run: `grep -c '^## \[1.0.0\] - 2026-04-14' CHANGELOG-reusable.md`
+Expected: 1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG-reusable.md
+git commit -m "docs(changelog): add v1.1.0 security entry for eval hardening
+
+Documents the install-command / test-command eval→\${CMD} shift and
+the setup-command trust-model clarification. Explicitly anchors the
+'22 consumers verified unaffected' claim to repos.yml as of
+2026-04-17 (the survey date) so the claim stays falsifiable.
+
+Release tag / GitHub Release creation covered by the release
+checklist, executed post-merge. Part of #36."
+```
+
+---
+
+## Task 7: Open PR and run four-reviewer protocol
+
+This is a procedural task; the four-reviewer review is mandated by
+`~/.claude/rules/workflow-review.md`.
+
+**Files:**
+- No edits in this task — just PR creation and review handling.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/issue-36-eval-hardening
+```
+
+- [ ] **Step 2: Open PR against `main`**
+
+Use the PR title `fix(reusable): harden install/test-command against eval injection (#36)`.
+
+Body (use a HEREDOC with `gh pr create`):
+
+```markdown
+## Summary
+- Swaps `eval "${CMD}"` → `${CMD}` in `install-command` and `test-command` of both reusable PR-gate workflows, retains `eval` in `setup-command` as the documented escape hatch (image-ocr compatibility).
+- Adds F1/F2/F3 regression fixtures (per-language) in a new `eval-hardening-smoke.yml`.
+- Ships as reusable-track `v1.1.0`; adds `docs/security.md`; updates usage guides, versioning.md, and CHANGELOG-reusable.md.
+
+## Test plan
+- [ ] Smoke workflow F1 Python passes (flags+paths).
+- [ ] Smoke workflow F2 Python fails at the replicate step and passes the assertion step (PWNED_BY_INJECTION not present).
+- [ ] Smoke workflow F3 Python shows `quote-preservation-ok` in log.
+- [ ] TypeScript F1/F2/F3 equivalents.
+- [ ] Existing `smoke-test.yml` still green (no regression in the main self-dogfood path).
+
+## Spec and plan
+- Spec: `docs/specs/2026-04-17-issue-36-eval-hardening-design.md`
+- Plan: `docs/plans/2026-04-17-issue-36-eval-hardening-plan.md`
+
+Closes #36.
+
+Generated with [Claude Code](https://claude.ai/code)
+```
+
+Command:
+
+```bash
+gh pr create --title "fix(reusable): harden install/test-command against eval injection (#36)" --body "$(cat <<'EOF'
+...body above...
+EOF
+)"
+```
+
+- [ ] **Step 3: Launch the four reviewers in parallel**
+
+Follow `~/.claude/rules/workflow-review.md` exactly. All four reviews run in a single message of parallel Agent calls:
+
+1. Codex — `bash scripts/codex-review-resilient.sh "<prompt>"` (prompt references the PR URL, the spec, the plan, and the diff).
+2. `superpowers:code-reviewer` — pass the spec path and the plan path so the reviewer can validate plan compliance.
+3. `pr-review-toolkit:silent-failure-hunter` — pass the diff; focus on the F2 assertion step (marker log scan is the load-bearing assertion).
+4. `code-reviewer` (custom) — pass the diff; `git diff main..HEAD --stat | tail -1` shows line count; pick model per workflow-review.md's table.
+
+- [ ] **Step 4: Address CRITICAL and HIGH findings**
+
+For every CRITICAL: fix and push. Do not merge until zero CRITICAL remain.
+For HIGH: fix unless there is a documented rationale to skip.
+For MEDIUM/LOW: judge individually; skipped items must be annotated in the PR with rationale.
+
+- [ ] **Step 5: Wait for CI green**
+
+Run: `gh pr checks <PR_NUMBER> --watch`
+Expected: all required checks pass, including `Eval Hardening Smoke` (the new workflow).
+
+- [ ] **Step 6: Squash merge**
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch
+```
+
+No commit step — the merge happens through `gh pr merge`.
+
+---
+
+## Task 8: Release `v1.1.0` (reusable track)
+
+This task must run on `main` after Task 7's merge. It follows
+`docs/release-checklist.md` in this repo.
+
+**Files:**
+- No edits — tagging and GitHub Release only.
+
+- [ ] **Step 1: Sync local main**
+
+```bash
+git checkout main && git pull --ff-only origin main
+```
+
+- [ ] **Step 2: Confirm the CHANGELOG-reusable.md is the merged version**
+
+Run: `grep -A1 '^## \[1.1.0\]' CHANGELOG-reusable.md | head -2`
+Expected: prints `## [1.1.0] - 2026-04-XX` (or the real date once bumped) followed by the next line.
+
+- [ ] **Step 3: Replace `2026-04-XX` in CHANGELOG with the actual release date**
+
+Use `date -u +%F` to get today's UTC date. Update the header:
+
+```bash
+today=$(date -u +%F)
+# In CHANGELOG-reusable.md, change "## [1.1.0] - 2026-04-XX" to "## [1.1.0] - ${today}"
+```
+
+Edit via the Edit tool, then commit:
+
+```bash
+git add CHANGELOG-reusable.md
+git commit -m "chore(release): stamp v1.1.0 release date"
+git push origin main
+```
+
+- [ ] **Step 4: Create annotated tag**
+
+```bash
+git tag -a v1.1.0 -m "Reusable workflows v1.1.0 — eval hardening (closes #36)
+
+install-command and test-command switch from eval \"\${CMD}\" to
+\${CMD} word splitting. setup-command retains eval as a documented
+escape hatch. See CHANGELOG-reusable.md for the full entry and
+docs/security.md for the trust model."
+git push origin v1.1.0
+```
+
+- [ ] **Step 5: Create GitHub Release**
+
+```bash
+gh release create v1.1.0 \
+  --title "Reusable workflows v1.1.0 — eval hardening" \
+  --notes-file <(awk '/^## \[1.1.0\]/,/^## \[1.0.0\]/' CHANGELOG-reusable.md | sed '$d')
+```
+
+(`sed '$d'` strips the trailing separator line, which would otherwise be the start of the v1.0.0 header.)
+
+- [ ] **Step 6: Verify the release is discoverable**
+
+Run: `gh release view v1.1.0`
+Expected: renders title, body with CHANGELOG excerpt, and the `v1.1.0` tag name.
+
+- [ ] **Step 7: Observe one drift-scanner cron cycle**
+
+The drift scanner is pinned to `@main` (not `@v1.1.0`), so it will pick up the post-merge workflow content immediately. The plan's correctness criterion is "no new critical drift findings in the next cron cycle after merge."
+
+Run: `gh workflow list --repo yakkuro/gh-manage | grep -i drift`
+Expected: drift workflow exists; note its next scheduled run in your task log.
+
+After the next cron fires, check: `gh run list --workflow=drift-scanner.yml --repo yakkuro/gh-manage --limit 1`
+Expected: latest run is green.
+
+(If not green, open a follow-up Issue referencing #36 and halt the consumer rollout until resolved.)
+
+---
+
+## Task 9: Consumer rollout (22 PRs, 4 batches)
+
+This task opens version-bump PRs against every repo listed in
+`src/gh_manage/data/repos.yml` as of the release. The repos are
+external (yakkuro/\*), so each PR is a separate branch in a separate
+repository; the subagent-driven-development skill dispatches one
+worker per consumer per batch.
+
+**Files:**
+- No edits in this repo — cross-repo PRs only.
+
+- [ ] **Step 1: Snapshot the consumer list at release time**
+
+Run: `python3 -c "import yaml; repos = yaml.safe_load(open('src/gh_manage/data/repos.yml'))['repos']; [print(r['full_name']) for r in repos]"`
+Save the output to a scratch file (e.g., `/tmp/rollout-consumers.txt`). The plan's rollout acts on this snapshot; repos added after the snapshot are out of scope for this PR rollout (they pick up v1.1.0 on their next opt-in).
+
+Expected output: 22 repository full_names.
+
+- [ ] **Step 2: Split into 4 batches of 5-6 repos**
+
+Strategy: alphabetical by full_name, batches of 6/6/5/5. Rationale:
+alphabetical is deterministic and makes it easy to pick up a specific
+batch without overlap. Save the batch assignments:
+
+```text
+batch-1: repos 1-6
+batch-2: repos 7-12
+batch-3: repos 13-17
+batch-4: repos 18-22
+```
+
+- [ ] **Step 3: Dispatch batch-1 workers in parallel**
+
+Each worker does, in the target consumer repo:
+
+1. Clone the consumer to a temp worktree.
+2. Create branch `chore/bump-gh-manage-v1.1.0`.
+3. Edit `.github/workflows/ci.yml`:
+   - Change `uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v1.0.0` → `@v1.1.0` (and same for typescript variant if present).
+   - Change `gh-manage-ref: v1.0.0` → `gh-manage-ref: v1.1.0`.
+4. Commit: `chore: bump gh-manage from v1.0.0 to v1.1.0 (security hardening)`
+5. Push branch; open PR with body:
+
+   ```markdown
+   Bumps `gh-manage` from `v1.0.0` to `v1.1.0`.
+
+   v1.1.0 hardens `install-command` and `test-command` against shell
+   injection by switching from `eval "${CMD}"` to `${CMD}` word
+   splitting. See yakkuro/gh-manage#36 and
+   [CHANGELOG-reusable.md](https://github.com/yakkuro/gh-manage/blob/main/CHANGELOG-reusable.md).
+
+   This repo's current install/test commands were manually inspected
+   on 2026-04-17 and are compatible with the new behaviour.
+   ```
+
+6. Return the PR URL to the leader.
+
+- [ ] **Step 4: Merge batch-1 PRs as each goes green**
+
+For each batch-1 PR:
+
+```bash
+gh pr checks <consumer_PR_number> --repo yakkuro/<repo> --watch
+```
+
+**Flake handling (per spec §"Flake handling"):** if the PR gate fails
+on the first run, re-run the failed job once. If it fails a second
+time, treat as a real regression: park the PR (comment explaining why
+it's on hold), investigate the consumer's command pattern for a missed
+metachar dependency, and either migrate to `setup-command` or raise
+it back to the spec. Never merge on flaky-green — require two
+consecutive green runs for any consumer that failed at least once.
+
+On two consecutive greens:
+
+```bash
+gh pr merge <consumer_PR_number> --repo yakkuro/<repo> --squash --delete-branch
+```
+
+- [ ] **Step 5: Repeat Steps 3-4 for batch-2, batch-3, batch-4**
+
+Batches are serial (wait for previous batch to fully merge before
+starting the next). Rationale: if batch-1 surfaces an unexpected
+consumer pattern, we want to halt rollout before queuing more bump
+PRs.
+
+- [ ] **Step 6: Final verification**
+
+After all 22 PRs merge:
+
+```bash
+# Run drift scanner once more to confirm pin drift is zero.
+gh workflow run drift-scanner.yml --repo yakkuro/gh-manage
+gh run list --workflow=drift-scanner.yml --repo yakkuro/gh-manage --limit 1
+```
+
+Expected: drift scanner run is green; no repo shows `gh-manage-ref`
+pinned to `v1.0.0`.
+
+Run: `gh issue view 36 --repo yakkuro/gh-manage`
+Expected: closed (autoclose via the PR merge in Task 7).
+
+- [ ] **Step 7: Document rollout completion**
+
+Add a brief note to `docs/phase-10-canary-log.md` or the appropriate
+rollout log with the merge dates of all 22 consumer PRs. Commit:
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b chore/issue-36-rollout-complete
+# edit docs/phase-10-canary-log.md
+git add docs/phase-10-canary-log.md
+git commit -m "docs(phase-10): record v1.1.0 consumer rollout completion
+
+All 22 consumer PRs merged; gh-manage-ref pins uniformly at v1.1.0.
+Drift scanner green post-rollout. Closes #36 rollout milestone."
+git push -u origin chore/issue-36-rollout-complete
+gh pr create --fill
+```
+
+Merge via four-reviewer flow (tiny doc-only PR; workflow-review.md
+lets reviewers skip the full protocol but still requires at least one
+pass).
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/plans/2026-04-17-issue-36-eval-hardening-plan.md`.
+
+**Execution mode:** subagent-driven (default per user memory — skip the inline-vs-subagent choice in writing-plans handoff).
+
+Next step: invoke `superpowers:subagent-driven-development` and start with Task 1.

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,9 +9,9 @@ See `CHANGELOG-reusable.md` for release history.
 
 | Input | Execution mechanism | Shell metacharacters | Required source |
 |-------|---------------------|----------------------|-----------------|
-| `install-command` | `${CMD}` (word splitting) | **Not interpreted** | Any source acceptable — the workflow neutralises shell injection by itself. Values with metacharacters will error out at the install binary, not execute. |
-| `test-command` | `${CMD}` (word splitting) | **Not interpreted** | Same as `install-command`. |
-| `setup-command` | `eval "${CMD}"` | **Interpreted** (quotes, \|, `$()`, `;`, etc.) | **Trusted source only.** Consumer is responsible for ensuring the value is a static literal and never comes from untrusted input. |
+| `install-command` | `${CMD}` (word splitting) | Quote/`;`/`\|`/`$()`/backtick/redirection: **not interpreted**. Pathname globbing (`*`, `?`, `[...]`): **still expands** against the working directory. | Trusted workflow-author input. Arbitrary untrusted input (PR title, comment body, etc.) is **not** safe — an attacker-controlled filename combined with a glob pattern can still select which binary runs. |
+| `test-command` | `${CMD}` (word splitting) | Same as `install-command`. | Same as `install-command`. |
+| `setup-command` | `eval "${CMD}"` | **All interpreted** (quotes, `\|`, `$()`, `;`, globs, etc.) | **Trusted source only.** Consumer is responsible for ensuring the value is a static literal and never comes from untrusted input. |
 
 ## What MUST NOT be forwarded to `setup-command`
 
@@ -82,7 +82,7 @@ setup-command: "${{ inputs.user-provided-command }}"
 | Release | Behaviour |
 |---------|-----------|
 | v1.0.x | `install-command`, `test-command`, and `setup-command` all executed via `eval "${CMD}"`. Shell metacharacters in any of the three were interpreted, so forwarding untrusted input to any of them allowed RCE. |
-| v1.1.0 (2026-04-XX) | `install-command` and `test-command` switched to `${CMD}` word splitting. `setup-command` still uses `eval` as a documented escape hatch for quote-preservation patterns (e.g., `pip install -e '.[dev,bot]'`). |
+| v1.1.0 (2026-04-XX) | `install-command` and `test-command` switched to `${CMD}` word splitting. `setup-command` still uses `eval` as a documented escape hatch for quote-preservation patterns (e.g., `pip install -e '.[dev,bot]'`). Pathname globbing still expands in all three inputs; hardening via `set -f` is tracked as a follow-up. |
 
 ## Reporting a security issue
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,92 @@
+# Security Model — Reusable PR Gate Inputs
+
+This page documents the execution mechanism and trust requirements for
+the three consumer-supplied shell-command inputs on
+`reusable-pr-gate-python.yml` and `reusable-pr-gate-typescript.yml`.
+See `CHANGELOG-reusable.md` for release history.
+
+## Trust model
+
+| Input | Execution mechanism | Shell metacharacters | Required source |
+|-------|---------------------|----------------------|-----------------|
+| `install-command` | `${CMD}` (word splitting) | **Not interpreted** | Any source acceptable — the workflow neutralises shell injection by itself. Values with metacharacters will error out at the install binary, not execute. |
+| `test-command` | `${CMD}` (word splitting) | **Not interpreted** | Same as `install-command`. |
+| `setup-command` | `eval "${CMD}"` | **Interpreted** (quotes, \|, `$()`, `;`, etc.) | **Trusted source only.** Consumer is responsible for ensuring the value is a static literal and never comes from untrusted input. |
+
+## What MUST NOT be forwarded to `setup-command`
+
+The following sources are user-controlled in a typical GitHub
+repository and must never flow into `setup-command`:
+
+- `github.event.pull_request.title`
+- `github.event.pull_request.body`
+- `github.event.issue.title`
+- `github.event.issue.body`
+- `github.event.comment.body`
+- `github.event.review.body`
+- `inputs.*` from `workflow_dispatch` events triggered by non-maintainers
+- Values fetched from external URLs, third-party APIs, or other
+  repositories
+
+Forwarding any of these to `setup-command` allows remote code execution
+inside the PR-gate runner. The runner has `contents: read` on your
+repo plus access to any secrets exposed to the workflow call, so the
+blast radius is at minimum the workflow run's secret set.
+
+## Safe patterns
+
+The following patterns are safe because they use static literals
+defined in the workflow file itself:
+
+```yaml
+# Safe: static literal
+setup-command: "pip install -e '.[dev,bot]'"
+```
+
+```yaml
+# Safe: static literal driven by a matrix value (the matrix list is
+# defined in the workflow, not user-controlled).
+strategy:
+  matrix:
+    extras: ["dev", "dev,bot", "dev,ml"]
+setup-command: "pip install -e '.[${{ matrix.extras }}]'"
+```
+
+```yaml
+# Safe: secret or input defined at the caller level by a maintainer.
+# The value is still trusted because a maintainer authored the workflow
+# file and chose what feeds in.
+setup-command: "${{ secrets.MAINTAINER_DEFINED_SETUP }}"
+```
+
+## Unsafe patterns
+
+```yaml
+# UNSAFE: pull request body is attacker-controlled.
+setup-command: "echo '${{ github.event.pull_request.body }}'"
+```
+
+```yaml
+# UNSAFE: comment body is attacker-controlled.
+setup-command: "run-${{ github.event.comment.body }}"
+```
+
+```yaml
+# UNSAFE: workflow_dispatch input may be submitted by anyone with
+# actions:write on the repo.
+setup-command: "${{ inputs.user-provided-command }}"
+```
+
+## Version history
+
+| Release | Behaviour |
+|---------|-----------|
+| v1.0.x | `install-command`, `test-command`, and `setup-command` all executed via `eval "${CMD}"`. Shell metacharacters in any of the three were interpreted, so forwarding untrusted input to any of them allowed RCE. |
+| v1.1.0 (2026-04-XX) | `install-command` and `test-command` switched to `${CMD}` word splitting. `setup-command` still uses `eval` as a documented escape hatch for quote-preservation patterns (e.g., `pip install -e '.[dev,bot]'`). |
+
+## Reporting a security issue
+
+Do **not** open a public issue for a suspected vulnerability in this
+workflow. Instead, use GitHub's private vulnerability reporting on the
+`yakkuro/gh-manage` repository (`Security` tab → `Report a
+vulnerability`).

--- a/docs/specs/2026-04-17-issue-36-eval-hardening-design.md
+++ b/docs/specs/2026-04-17-issue-36-eval-hardening-design.md
@@ -197,44 +197,59 @@ pytest command and the subsequent `echo` prints the marker; under the new
 `${CMD}` behaviour, pytest receives `;`, `echo`, `PWNED_BY_INJECTION` as extra
 positional arguments and errors out without emitting the marker.
 
-Concrete implementation sketch (to be finalised during the plan phase):
+Concrete implementation sketch (to be finalised during the plan phase).
+Reusable workflows are invoked at the **job** level (not step level), so the
+fixture needs two sibling jobs in the same run:
 
 ```yaml
-- name: Invoke reusable PR gate (expects pytest failure)
-  id: invoke
-  continue-on-error: true
-  uses: ./.github/workflows/reusable-pr-gate-python.yml
-  with:
-    test-command: "uv run pytest tests/ ; echo PWNED_BY_INJECTION"
-    # ... other required inputs
+jobs:
+  f2-invoke:
+    # The invoked job is expected to fail; mark the whole job as
+    # continue-on-error so the asserting job still runs.
+    continue-on-error: true
+    uses: ./.github/workflows/reusable-pr-gate-python.yml
+    with:
+      python-version: "3.12"
+      gh-manage-ref: ${{ github.sha }}
+      test-command: "uv run pytest tests/ ; echo PWNED_BY_INJECTION"
+      # ... other required inputs
 
-- name: Assert injection neutralised
-  shell: bash
-  run: |
-    set -euo pipefail
-    # Fetch the invoked job's logs via gh CLI (the fixture job runs in
-    # the same run, so gh run view --log returns the combined output).
-    gh run view "${{ github.run_id }}" --log \
-      | tee /tmp/pr-gate-output.log
-    if grep -q 'PWNED_BY_INJECTION' /tmp/pr-gate-output.log; then
-      echo "::error::injection marker leaked — eval hardening regressed"
-      exit 1
-    fi
-  env:
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  f2-assert:
+    needs: f2-invoke
+    if: always()  # run even after f2-invoke fails
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read  # required for gh run view --log
+    steps:
+      - name: Assert injection neutralised
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # gh run view <RUN_ID> --log returns combined logs for ALL jobs in
+          # the run, including the sibling f2-invoke job. Grep the whole
+          # log for the injection marker.
+          gh run view "${{ github.run_id }}" --log > /tmp/run.log
+          if grep -q 'PWNED_BY_INJECTION' /tmp/run.log; then
+            echo "::error::injection marker leaked — eval hardening regressed"
+            exit 1
+          fi
 ```
 
-Secondary assertion: the invoke step ends in failure (pytest errors on the
-extra args). `continue-on-error: true` lets the workflow proceed past that
-step; the primary assertion above is what gates success.
+Secondary assertion: `f2-invoke` ends in failure (pytest errors on the extra
+args). The `continue-on-error: true` at job level lets `f2-assert` still
+run; the primary log-scan assertion is what gates success.
 
 The deliberate choice to **not** use output redirection (`> /tmp/pwned` etc.)
 keeps the marker observable in log output, so a single log-scan assertion is
 sufficient to distinguish old vs new behaviour.
 
-The plan phase will decide whether `gh run view --log` is the right
-capture mechanism or whether a `script -c` wrapper inside the fixture is
-preferable; both produce a greppable log.
+The plan phase will confirm that `gh run view --log` on GitHub-hosted
+runners returns the sibling-job logs (this is the documented behaviour, but
+should be verified in a throwaway branch before the real fixture relies on
+it).
 
 **F3 — quoted setup-command (image-ocr compatibility)**
 
@@ -246,6 +261,13 @@ Asserts: the literal string `quote-preservation-ok` appears in the job log,
 proving that single quotes in setup-command are still honoured by `eval`.
 (A real `pip install -e '.[dev,bot]'` call would be slow; `printf` is a fast
 equivalent that proves quote preservation.)
+
+`printf` is a **syntactic proxy** for image-ocr's real command. It proves
+that bash's `eval` still parses single-quote grouping correctly — which is
+the only `eval`-level property `pip install -e '.[dev,bot]'` depends on. It
+does not re-validate `pip`'s own argument handling; that responsibility
+stays with image-ocr's own CI, which continues to exercise the full real
+command on every PR.
 
 ### TypeScript fixtures
 
@@ -369,6 +391,16 @@ with:
 - Merge each PR after the consumer's CI (which now invokes the new v1.1.0
   workflow) goes green. Green CI is the per-consumer regression proof.
 
+**Flake handling**: if a consumer's PR gate fails with a non-deterministic
+error unrelated to the v1.1.0 bump (e.g., network hiccup during `uv sync`,
+pre-existing flaky test), re-run the failed job once. If it still fails on
+the second run, treat as a real regression: park the PR, investigate the
+consumer's command pattern for a missed metachar dependency, and either
+migrate that consumer's command to `setup-command` or raise it as a scope
+change back to this spec. Do **not** merge a consumer bump on flaky-green
+(pattern: single failure then single pass with no apparent cause) — require
+two consecutive green runs for any consumer that failed at least once.
+
 ### Interaction with Phase 10
 
 - Phase 10 AC① (20+ active repos on the reusable workflow) is already
@@ -421,9 +453,13 @@ with:
   perturbing the main PR gate.
 - [ ] F2 assertion proves the string `PWNED_BY_INJECTION` does not appear in
   the job log after the test step.
-- [ ] `docs/security.md` exists; `docs/usage/python.md`,
-  `docs/usage/typescript.md`, `docs/versioning.md`, and `CHANGELOG.md`
-  are updated.
+- [ ] `docs/security.md` exists (~100 lines, trust-model table + examples
+  + version history) and is linked from both `docs/usage/python.md` and
+  `docs/usage/typescript.md` in the `setup-command` section.
+- [ ] `docs/usage/python.md`, `docs/usage/typescript.md`,
+  `docs/versioning.md`, and `CHANGELOG.md` are updated as described in the
+  Documentation changes section; the four-reviewer PR review confirms each
+  file's diff.
 - [ ] `v1.1.0` tag pushed, GitHub Release created.
 - [ ] 22 consumer PRs opened, merged, with green CI for each.
 - [ ] Issue #36 closed via the implementation PR.

--- a/docs/specs/2026-04-17-issue-36-eval-hardening-design.md
+++ b/docs/specs/2026-04-17-issue-36-eval-hardening-design.md
@@ -86,6 +86,11 @@ value across all 22 consumers is image-ocr's quoted `setup-command`.
 - Consumer forwards untrusted input to `setup-command`. The input description
   will explicitly forbid this; enforcing it in the workflow is not feasible
   without a metachar allow-list, which we explicitly rejected (Q1 option (c)).
+  **`setup-command` remains a security boundary that depends on consumer
+  discipline.** If consumer mis-use of `setup-command` becomes a repeated
+  pattern (e.g., surfaced by future drift-scanner checks or PR reviews), the
+  next step is to add runtime deprecation warnings in a later minor release
+  rather than a silent runtime check.
 - Consumer repository write access attacks. An actor who can modify `ci.yml`
   already has full write and does not need injection.
 - `gh-manage-ref` tampering (covered separately by existing ref-pin policies).
@@ -114,13 +119,47 @@ Identical changes: lines 93 and 133 switch to `${CMD}`, line 118 retains
 
 ### 3. Runtime behaviour after the change
 
+`install-command` and `test-command` (change scope):
+
 | Input value | Old (`eval`) | New (`${CMD}`) |
 |-------------|--------------|---------------|
-| `uv run pytest` | argv: `uv run pytest` | argv: `uv run pytest` ✓ |
-| `uv sync --all-extras` | argv: `uv sync --all-extras` | argv: `uv sync --all-extras` ✓ |
+| `uv run pytest` | argv: `uv`, `run`, `pytest` | argv: `uv`, `run`, `pytest` ✓ |
+| `uv sync --all-extras` | argv: `uv`, `sync`, `--all-extras` | argv: `uv`, `sync`, `--all-extras` ✓ |
 | `uv run pytest tests/ -v --tb=short` | argv: 5 tokens | argv: 5 tokens ✓ |
-| `uv run pytest; echo PWNED` | runs `pytest`, then `echo` | argv: `uv run pytest; echo PWNED` → pytest collection error, job fails, no PWNED emitted |
-| `pip install -e '.[dev,bot]'` (setup-command) | argv: `pip install -e .[dev,bot]` | (unchanged — setup-command keeps `eval`) |
+| `uv run pytest ; echo PWNED` | runs `pytest`, then `echo` | argv: `uv`, `run`, `pytest`, `;`, `echo`, `PWNED` → pytest errors on extra args, job fails, `PWNED` never emitted |
+
+`setup-command` (unchanged — `eval` retained as documented escape hatch):
+
+| Input value | Behaviour |
+|-------------|-----------|
+| `pip install -e '.[dev,bot]'` | argv: `pip`, `install`, `-e`, `.[dev,bot]` (quotes stripped by `eval`). Used today by yakkuro/image-ocr. |
+| Static literal with pipes, redirects, or `$()` | Executed by shell via `eval`. Consumer accepts the security responsibility per the input's description. |
+
+### 4. Input → env-var → shell expansion (workflow wiring, unchanged)
+
+The edit only changes the `run:` body of three steps; the step-level `env:`
+block that binds the reusable-workflow `inputs.*` values to shell environment
+variables is already in place and is preserved:
+
+```yaml
+- name: Install dependencies
+  shell: bash
+  working-directory: ${{ inputs.working-directory }}
+  env:
+    INSTALL_CMD: ${{ inputs.install-command }}  # unchanged binding
+  run: |
+    set -euo pipefail
+    echo "::group::install"
+    echo "Running install-command: ${INSTALL_CMD}"
+    ${INSTALL_CMD}          # was: eval "${INSTALL_CMD}"
+    echo "::endgroup::"
+```
+
+The same `env:` binding exists for `SETUP_CMD` and `TEST_CMD` in their
+respective steps; none of the bindings move. This matters because the
+security property (no GitHub Actions expression re-evaluation of
+user-controlled input) relies on the env-var indirection, and that
+indirection is preserved.
 
 ## Testing strategy
 
@@ -158,14 +197,44 @@ pytest command and the subsequent `echo` prints the marker; under the new
 `${CMD}` behaviour, pytest receives `;`, `echo`, `PWNED_BY_INJECTION` as extra
 positional arguments and errors out without emitting the marker.
 
-Secondary assertion: the test step exits non-zero (pytest fails on the extra
-args). Allow the step to fail via `continue-on-error: true`, then enforce the
-primary assertion in a follow-up step that `grep -L PWNED_BY_INJECTION` over
-the captured step output (or equivalent mechanism available in the runner).
+Concrete implementation sketch (to be finalised during the plan phase):
+
+```yaml
+- name: Invoke reusable PR gate (expects pytest failure)
+  id: invoke
+  continue-on-error: true
+  uses: ./.github/workflows/reusable-pr-gate-python.yml
+  with:
+    test-command: "uv run pytest tests/ ; echo PWNED_BY_INJECTION"
+    # ... other required inputs
+
+- name: Assert injection neutralised
+  shell: bash
+  run: |
+    set -euo pipefail
+    # Fetch the invoked job's logs via gh CLI (the fixture job runs in
+    # the same run, so gh run view --log returns the combined output).
+    gh run view "${{ github.run_id }}" --log \
+      | tee /tmp/pr-gate-output.log
+    if grep -q 'PWNED_BY_INJECTION' /tmp/pr-gate-output.log; then
+      echo "::error::injection marker leaked — eval hardening regressed"
+      exit 1
+    fi
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Secondary assertion: the invoke step ends in failure (pytest errors on the
+extra args). `continue-on-error: true` lets the workflow proceed past that
+step; the primary assertion above is what gates success.
 
 The deliberate choice to **not** use output redirection (`> /tmp/pwned` etc.)
 keeps the marker observable in log output, so a single log-scan assertion is
 sufficient to distinguish old vs new behaviour.
+
+The plan phase will decide whether `gh run view --log` is the right
+capture mechanism or whether a `script -c` wrapper inside the fixture is
+preferable; both produce a greppable log.
 
 **F3 — quoted setup-command (image-ocr compatibility)**
 
@@ -191,8 +260,17 @@ test-command: "pnpm test -- --run"
 test-command: "pnpm test ; echo PWNED_BY_INJECTION"
 ```
 
-F3 is omitted for TypeScript — no TS consumer uses `setup-command` with
-quotes, and the Python F3 already proves the `eval` path stays functional.
+A minimal TS F3 is also included, to guard against future TS consumers
+adopting a quoted setup-command and hitting divergent shell behaviour:
+
+```yaml
+# F3 (TypeScript)
+setup-command: "printf '%s\\n' 'ts-quote-preservation-ok'"
+```
+
+Asserts: the literal string `ts-quote-preservation-ok` appears in the job
+log. Reuses the same mechanism as the Python F3; only the command payload
+differs so the fixture can stand alone in a TS matrix entry.
 
 ## Documentation changes
 
@@ -227,7 +305,9 @@ quotes, and the Python F3 already proves the `eval` path stays functional.
   `eval "${CMD}"`, which allowed command injection when consumers passed
   values sourced from untrusted inputs (PR events, issue bodies). They now
   execute via `${CMD}` (word splitting only).
-  - All 22 bundled yakkuro/* consumers verified unaffected.
+  - All consumers listed in `src/gh_manage/data/repos.yml` as of 2026-04-17
+    (22 repos) verified unaffected by manual inspection of each consumer's
+    `ci.yml` install-command / test-command values.
   - Consumers using shell features (quotes, pipes, redirects) in
     install-command or test-command must migrate them to setup-command or a
     committed shell script.
@@ -254,7 +334,11 @@ precedent.
    fixtures, docs, CHANGELOG.
 2. PR against `main`, four-reviewer protocol per
    `~/.claude/rules/workflow-review.md` (Codex + superpowers:code-reviewer +
-   silent-failure-hunter + code-reviewer).
+   silent-failure-hunter + code-reviewer). The reviewers' scope is the
+   workflow edits, fixtures, docs, and CHANGELOG only. The consumer rollout
+   plan (Section "Consumer rollout") is validated separately by re-reading
+   the spec against the then-current `repos.yml` before opening the 22 bump
+   PRs — this is a pre-flight check, not a code review.
 3. CI green + reviewers approve → squash merge.
 4. On `main`: annotated tag `v1.1.0`, push.
 5. GitHub Release with CHANGELOG `v1.1.0` section as release notes.
@@ -290,10 +374,15 @@ with:
 - Phase 10 AC① (20+ active repos on the reusable workflow) is already
   satisfied at 22/20 and is not affected.
 - Phase 10 AC② (two consecutive weeks of zero critical drift findings) is
-  not affected — drift scanner evaluates `ci.yml` shape against the bundled
-  profile, independently of how the workflow executes internally. The 22
-  consumer bump PRs update the profile pin *in lock-step* with the bundled
-  data, so no new drift is introduced.
+  not affected. Drift scanner checks **whether** each consumer's `ci.yml`
+  specifies the expected reusable-workflow version pin and required inputs,
+  not **how** that workflow executes internally. Two facts combine to keep
+  AC② green across this change:
+  1. The internal switch from `eval "${CMD}"` to `${CMD}` is invisible to
+     the drift scanner (it does not inspect the reusable workflow's bash).
+  2. The 22 consumer bump PRs update each `ci.yml`'s pin from `@v1.0.0` to
+     `@v1.1.0` in lock-step with the bundled profile's expected pin, so the
+     scanner sees pin-equality on the next cron after all bump PRs merge.
 
 ### Risks and rollback
 
@@ -301,7 +390,7 @@ with:
 |------|-----------|
 | An undiscovered consumer pattern fails CI under word splitting. | Survey showed zero such patterns across the 22 consumers. If one surfaces during rollout, the consumer's PR fails CI; migrate that consumer's command to `setup-command` or a script, do not revert v1.1.0. |
 | Tagging mistake (lightweight vs annotated, wrong commit). | Follow `docs/release-checklist.md`; use `git tag -a`. |
-| Rollback needed post-release. | Create a new commit on `main` that restores `eval` in the two affected call sites, tag `v1.1.1`. Do not delete the `v1.1.0` tag. Close unmerged consumer PRs. |
+| Rollback needed post-release. | Create a new commit on `main` that restores `eval` in the two affected call sites, tag `v1.1.1`. Do not delete the `v1.1.0` tag. For unmerged consumer PRs with green CI, leave a comment linking the rollback commit and explaining the reason before closing, so that context is preserved on the PR timeline. |
 
 ## Non-goals
 
@@ -324,8 +413,12 @@ with:
   use `${CMD}` for `install-command` and `test-command`, retain `eval` for
   `setup-command`.
 - [ ] Input descriptions reflect the new trust model.
-- [ ] F1, F2, F3 fixtures exist and are exercised by at least one smoke
-  workflow on PRs that touch `.github/workflows/`.
+- [ ] F1, F2, F3 (Python) and F1, F2, F3 (TypeScript) fixtures exist and are
+  exercised by a dedicated smoke workflow (new file
+  `.github/workflows/eval-hardening-smoke.yml`, preferred) on PRs that touch
+  `.github/workflows/`. Extending the existing self-dogfood `ci.yml` is an
+  acceptable alternative if the fixture matrix can be scoped to avoid
+  perturbing the main PR gate.
 - [ ] F2 assertion proves the string `PWNED_BY_INJECTION` does not appear in
   the job log after the test step.
 - [ ] `docs/security.md` exists; `docs/usage/python.md`,

--- a/docs/specs/2026-04-17-issue-36-eval-hardening-design.md
+++ b/docs/specs/2026-04-17-issue-36-eval-hardening-design.md
@@ -1,0 +1,336 @@
+# Issue #36: Reusable Workflow `eval` Hardening — Design
+
+**Status**: Approved for implementation
+**Target release**: reusable track `v1.1.0`
+**Author**: yakkuro (brainstorming session 2026-04-17)
+**Closes**: [Issue #36](https://github.com/yakkuro/gh-manage/issues/36)
+
+## Problem
+
+`reusable-pr-gate-python.yml` and `reusable-pr-gate-typescript.yml` execute three
+consumer-supplied string inputs via `eval "${CMD}"`:
+
+- `install-command` (line 93 in both files)
+- `setup-command` (line 118)
+- `test-command` (line 133)
+
+The values are passed through `env:` (so GitHub Actions expression injection,
+`${{ }}` re-evaluation, is already prevented), but `eval` re-interprets shell
+metacharacters contained in the value. If a consumer's `ci.yml` forwards an
+untrusted value (for example
+`test-command: ${{ github.event.comment.body }}`), a malicious actor can
+append shell metacharacters (`;`, `$()`, pipes, redirects) and achieve remote
+code execution inside the PR Gate job.
+
+The PR Gate is a public reusable workflow called by any repository via
+`uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@<ref>`,
+so defence in depth at the workflow layer is warranted even though the primary
+consumer-side mistake (forwarding untrusted input) must also be avoided.
+
+## Prior attempt (reverted)
+
+Commit `04870e8` (2026-04-16) removed `eval` from all three call sites by
+replacing `eval "${CMD}"` with `${CMD}` (shell word splitting). Codex review
+flagged a regression in `yakkuro/image-ocr`, whose consumer `ci.yml` contains:
+
+```yaml
+setup-command: "pip install -e '.[dev,bot]'"
+```
+
+Without `eval`, the single quotes reach `pip` as literal characters, so `pip`
+tries to install a package literally named `'.[dev,bot]'` and fails. The change
+was reverted in `7f0e16d` with a note that Issue #36 needs a different
+approach.
+
+## Design decisions (Q&A summary)
+
+| # | Question | Decision |
+|---|----------|----------|
+| Q1 | Scope | **(a) Defence in depth** — remove `eval` from `install-command` and `test-command`, keep `eval` in `setup-command` as a documented escape hatch |
+| Q2 | Versioning | **(ii) Minor bump** to `v1.1.0` — documented behaviour change, not a full major per `docs/versioning.md` |
+| Q3 | `setup-command` handling | **(1) Documentation only** — description gets a security note, no runtime validation or deprecation |
+| Q4 | Testing | **(B) Regression fixtures** — three fixtures: flags+path pattern, injection attempt (negative), image-ocr-style quoted setup (compatibility) |
+| Q5 | Consumer rollout | **(1) Push (maintainer driven)** — release `v1.1.0`, then open 22 bump PRs against every `repos.yml` entry |
+
+## Consumer-input survey (verified 2026-04-17)
+
+All 22 bundled consumers (`src/gh_manage/data/repos.yml`) inspected. Only the
+following fields and patterns are in active use:
+
+| Pattern | Count | Field(s) |
+|---------|-------|----------|
+| `uv sync` (default) | majority | install-command |
+| `uv sync --all-extras` / `uv sync --extra dev` / `uv sync --group dev` / `uv sync --extra bench --extra dev` | 6 repos | install-command |
+| `uv run pytest` (default) | majority | test-command |
+| `uv run pytest tests/ -v --tb=short` (and variants with `--ignore=`) | 4 repos | test-command |
+| `uv run mypy packages/` | 1 repo (deep-research) | setup-command |
+| `pip install -e '.[dev,bot]'` | **1 repo (image-ocr)** | setup-command |
+
+No consumer uses shell metacharacters (`;`, `|`, `$()`, `` ` ``, `>`, `<`,
+quotes) in `install-command` or `test-command`. The only metachar-dependent
+value across all 22 consumers is image-ocr's quoted `setup-command`.
+
+## Threat model
+
+### In scope
+
+- Consumer `ci.yml` forwards an externally-controlled value
+  (`github.event.comment.body`, `github.event.issue.title`, inputs from
+  workflow_dispatch, etc.) to `install-command` or `test-command`. Before
+  `v1.1.0` this allowed RCE via `eval`. After `v1.1.0` the injected metachars
+  are passed as literal argv to the install/test binary, which typically
+  errors out.
+
+### Out of scope (consumer-side responsibility)
+
+- Consumer forwards untrusted input to `setup-command`. The input description
+  will explicitly forbid this; enforcing it in the workflow is not feasible
+  without a metachar allow-list, which we explicitly rejected (Q1 option (c)).
+- Consumer repository write access attacks. An actor who can modify `ci.yml`
+  already has full write and does not need injection.
+- `gh-manage-ref` tampering (covered separately by existing ref-pin policies).
+
+## Implementation changes
+
+### 1. `.github/workflows/reusable-pr-gate-python.yml`
+
+| Step | Line | Change |
+|------|------|--------|
+| Install dependencies | 93 | `eval "${INSTALL_CMD}"` → `${INSTALL_CMD}` |
+| Run setup command | 118 | **unchanged** (`eval` retained) |
+| Run tests | 133 | `eval "${TEST_CMD}"` → `${TEST_CMD}` |
+
+Input descriptions (at the top of the file) are updated:
+
+- `install-command` and `test-command`: add note that the value runs via
+  `${CMD}` word splitting and does not support shell metacharacters.
+- `setup-command`: add explicit security warning that the value is executed
+  via `eval` and must come from a static literal, never an untrusted source.
+
+### 2. `.github/workflows/reusable-pr-gate-typescript.yml`
+
+Identical changes: lines 93 and 133 switch to `${CMD}`, line 118 retains
+`eval`, input descriptions are updated.
+
+### 3. Runtime behaviour after the change
+
+| Input value | Old (`eval`) | New (`${CMD}`) |
+|-------------|--------------|---------------|
+| `uv run pytest` | argv: `uv run pytest` | argv: `uv run pytest` ✓ |
+| `uv sync --all-extras` | argv: `uv sync --all-extras` | argv: `uv sync --all-extras` ✓ |
+| `uv run pytest tests/ -v --tb=short` | argv: 5 tokens | argv: 5 tokens ✓ |
+| `uv run pytest; echo PWNED` | runs `pytest`, then `echo` | argv: `uv run pytest; echo PWNED` → pytest collection error, job fails, no PWNED emitted |
+| `pip install -e '.[dev,bot]'` (setup-command) | argv: `pip install -e .[dev,bot]` | (unchanged — setup-command keeps `eval`) |
+
+## Testing strategy
+
+### Existing coverage
+
+The self-dogfood CI in `.github/workflows/ci.yml` invokes
+`reusable-pr-gate-python.yml` against gh-manage itself (simple `uv sync` +
+`uv run pytest`). This continues to exercise the default path.
+
+### New regression fixtures
+
+Placed under `tests/fixtures/eval-hardening/` (or equivalent, to be confirmed
+during planning) and invoked by a new smoke-test workflow or by extending an
+existing one. Three fixtures:
+
+**F1 — flags and paths (positive, real-world pattern)**
+
+```yaml
+install-command: "uv sync --all-extras"
+test-command: "uv run pytest tests/ -v --tb=short"
+```
+
+Asserts: job succeeds. Validates word-splitting correctness for the most
+common non-default pattern across the 22 consumers.
+
+**F2 — injection attempt (negative)**
+
+```yaml
+test-command: "uv run pytest tests/ ; echo PWNED_BY_INJECTION"
+```
+
+Primary assertion (load-bearing): the string `PWNED_BY_INJECTION` does **not**
+appear in the job log. Under the old `eval` behaviour, `;` terminates the
+pytest command and the subsequent `echo` prints the marker; under the new
+`${CMD}` behaviour, pytest receives `;`, `echo`, `PWNED_BY_INJECTION` as extra
+positional arguments and errors out without emitting the marker.
+
+Secondary assertion: the test step exits non-zero (pytest fails on the extra
+args). Allow the step to fail via `continue-on-error: true`, then enforce the
+primary assertion in a follow-up step that `grep -L PWNED_BY_INJECTION` over
+the captured step output (or equivalent mechanism available in the runner).
+
+The deliberate choice to **not** use output redirection (`> /tmp/pwned` etc.)
+keeps the marker observable in log output, so a single log-scan assertion is
+sufficient to distinguish old vs new behaviour.
+
+**F3 — quoted setup-command (image-ocr compatibility)**
+
+```yaml
+setup-command: "printf '%s\\n' 'quote-preservation-ok'"
+```
+
+Asserts: the literal string `quote-preservation-ok` appears in the job log,
+proving that single quotes in setup-command are still honoured by `eval`.
+(A real `pip install -e '.[dev,bot]'` call would be slow; `printf` is a fast
+equivalent that proves quote preservation.)
+
+### TypeScript fixtures
+
+Mirror F1 and F2 with `pnpm` equivalents:
+
+```yaml
+# F1
+install-command: "pnpm install --frozen-lockfile"
+test-command: "pnpm test -- --run"
+
+# F2
+test-command: "pnpm test ; echo PWNED_BY_INJECTION"
+```
+
+F3 is omitted for TypeScript — no TS consumer uses `setup-command` with
+quotes, and the Python F3 already proves the `eval` path stays functional.
+
+## Documentation changes
+
+### New: `docs/security.md`
+
+~100 lines, one page. Content outline:
+
+- Trust model table for the three inputs (execution mechanism, metachar
+  support, trusted-source requirement).
+- Explicit examples of what MUST NOT be forwarded to `setup-command`.
+- Version history (v1.0.x had `eval` on all three; v1.1.0 has `eval` only on
+  `setup-command`).
+
+### Updated: `docs/usage/python.md`, `docs/usage/typescript.md`
+
+- In the `install-command` and `test-command` sections: "Only space-separated
+  args are supported. For commands requiring quotes or other shell features,
+  move them to `setup-command` or commit a shell script to the consumer
+  repository."
+- In the `setup-command` section: link to `docs/security.md` and restate the
+  "trusted input only" rule.
+
+### Updated: `CHANGELOG.md` (reusable track, top of file)
+
+```markdown
+## [1.1.0] - 2026-04-XX
+
+### Security
+
+- **[Behaviour change]** `install-command` and `test-command` no longer
+  interpret shell metacharacters. Previously both fields were executed via
+  `eval "${CMD}"`, which allowed command injection when consumers passed
+  values sourced from untrusted inputs (PR events, issue bodies). They now
+  execute via `${CMD}` (word splitting only).
+  - All 22 bundled yakkuro/* consumers verified unaffected.
+  - Consumers using shell features (quotes, pipes, redirects) in
+    install-command or test-command must migrate them to setup-command or a
+    committed shell script.
+  - Closes #36.
+
+### Added
+
+- `setup-command` input description now explicitly documents its trust
+  requirements.
+- New `docs/security.md` covering the workflow input threat model.
+```
+
+### Updated: `docs/versioning.md`
+
+Add one line under the v1.0.0 stability promise noting that documented
+behaviour changes may ship in minor versions and citing v1.1.0 as the
+precedent.
+
+## Release and consumer rollout
+
+### Release flow (per `docs/release-checklist.md`)
+
+1. Feature branch: `fix/issue-36-eval-hardening` containing workflow edits,
+   fixtures, docs, CHANGELOG.
+2. PR against `main`, four-reviewer protocol per
+   `~/.claude/rules/workflow-review.md` (Codex + superpowers:code-reviewer +
+   silent-failure-hunter + code-reviewer).
+3. CI green + reviewers approve → squash merge.
+4. On `main`: annotated tag `v1.1.0`, push.
+5. GitHub Release with CHANGELOG `v1.1.0` section as release notes.
+6. Drift scanner already pinned to `@main`, so it picks up the new workflow
+   behaviour on the next weekly cron automatically — observe one cron cycle
+   to confirm no regressions.
+
+### Consumer rollout (22 PRs)
+
+**Scope**: every repo listed in `src/gh_manage/data/repos.yml` at the time of
+the release (currently 22, all `python-service` profile).
+
+**Edit per consumer** in `.github/workflows/ci.yml`:
+
+```yaml
+uses: yakkuro/gh-manage/.github/workflows/reusable-pr-gate-python.yml@v1.1.0  # was @v1.0.0
+with:
+  ...
+  gh-manage-ref: v1.1.0  # was v1.0.0
+```
+
+**Execution** (subagent-driven, covered by the implementation plan):
+
+- Split 22 repos into 4 batches of 5–6 repos each.
+- Per batch, spawn parallel workers that each open one PR with:
+  - Title: `chore: bump gh-manage from v1.0.0 to v1.1.0 (security hardening)`
+  - Body: short note referencing `yakkuro/gh-manage#36`.
+- Merge each PR after the consumer's CI (which now invokes the new v1.1.0
+  workflow) goes green. Green CI is the per-consumer regression proof.
+
+### Interaction with Phase 10
+
+- Phase 10 AC① (20+ active repos on the reusable workflow) is already
+  satisfied at 22/20 and is not affected.
+- Phase 10 AC② (two consecutive weeks of zero critical drift findings) is
+  not affected — drift scanner evaluates `ci.yml` shape against the bundled
+  profile, independently of how the workflow executes internally. The 22
+  consumer bump PRs update the profile pin *in lock-step* with the bundled
+  data, so no new drift is introduced.
+
+### Risks and rollback
+
+| Risk | Mitigation |
+|------|-----------|
+| An undiscovered consumer pattern fails CI under word splitting. | Survey showed zero such patterns across the 22 consumers. If one surfaces during rollout, the consumer's PR fails CI; migrate that consumer's command to `setup-command` or a script, do not revert v1.1.0. |
+| Tagging mistake (lightweight vs annotated, wrong commit). | Follow `docs/release-checklist.md`; use `git tag -a`. |
+| Rollback needed post-release. | Create a new commit on `main` that restores `eval` in the two affected call sites, tag `v1.1.1`. Do not delete the `v1.1.0` tag. Close unmerged consumer PRs. |
+
+## Non-goals
+
+- Completely removing `eval` from `setup-command`. Considered and rejected
+  (Q1): it would force image-ocr into a breaking migration today without
+  providing proportional security gain, because `setup-command` values in all
+  known consumers are static literals.
+- Metacharacter allow-list / deny-list validation. Considered and rejected
+  (Q1): implementation complexity (quote-handling edge cases) outweighs the
+  benefit given that the word-splitting switch already neutralises the most
+  common injection vectors.
+- Deprecating `setup-command`. Considered and rejected (Q3): outside the
+  scope of a security hardening patch; will be revisited during v2.0
+  planning.
+- Fixing unrelated issues (#40, #39, #29, #20). Tracked separately.
+
+## Acceptance criteria
+
+- [ ] `reusable-pr-gate-python.yml` and `reusable-pr-gate-typescript.yml`
+  use `${CMD}` for `install-command` and `test-command`, retain `eval` for
+  `setup-command`.
+- [ ] Input descriptions reflect the new trust model.
+- [ ] F1, F2, F3 fixtures exist and are exercised by at least one smoke
+  workflow on PRs that touch `.github/workflows/`.
+- [ ] F2 assertion proves the string `PWNED_BY_INJECTION` does not appear in
+  the job log after the test step.
+- [ ] `docs/security.md` exists; `docs/usage/python.md`,
+  `docs/usage/typescript.md`, `docs/versioning.md`, and `CHANGELOG.md`
+  are updated.
+- [ ] `v1.1.0` tag pushed, GitHub Release created.
+- [ ] 22 consumer PRs opened, merged, with green CI for each.
+- [ ] Issue #36 closed via the implementation PR.

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -53,6 +53,14 @@ That's it. The workflow will:
 | `setup-command` | string | `""` | Optional shell command executed after install, before tests. |
 | `uv-version` | string | `"0.5.0"` | `uv` release pin. Override only if you need a newer release. |
 
+### install-command
+
+**Shell handling (v1.1.0+):** `install-command` executes via `${CMD}` (shell word splitting), not `eval`. Shell metacharacters — pipes, quotes, redirects, `$()`, `;` — are passed to the install binary as literal arguments, not interpreted. If you need shell features, use `setup-command` or commit a shell script to the consumer repository and invoke it by path. See [docs/security.md](../security.md) for the trust model.
+
+### test-command
+
+**Shell handling (v1.1.0+):** `test-command` executes via `${CMD}` (shell word splitting), not `eval`. Same constraints as `install-command` above.
+
 ## Tool versions
 
 gh-manage pins tool versions inside its composite actions for reproducibility:
@@ -96,6 +104,8 @@ jobs:
 ```
 
 The command runs after `install-command` and before `test-command`. Failure aborts the job with a clear error.
+
+**SECURITY (v1.1.0+):** `setup-command` executes via `eval` and interprets shell metacharacters. Only pass **static literal** values from a trusted source. Never forward `github.event.*`, `workflow_dispatch` inputs, or any consumer-controlled string to this field. See [docs/security.md](../security.md) for the full trust model and list of unsafe patterns.
 
 ## Versioning
 

--- a/docs/usage/typescript.md
+++ b/docs/usage/typescript.md
@@ -57,6 +57,14 @@ That's it. The workflow will:
 | `setup-command` | string | `""` | Optional shell command executed after install, before tests. |
 | `pnpm-version` | string | `"10.33.0"` | `pnpm` release pin. Override only if you need a specific release. |
 
+### install-command
+
+**Shell handling (v1.1.0+):** `install-command` executes via `${CMD}` (shell word splitting), not `eval`. Shell metacharacters — pipes, quotes, redirects, `$()`, `;` — are passed to the install binary as literal arguments, not interpreted. If you need shell features, use `setup-command` or commit a shell script to the consumer repository and invoke it by path. See [docs/security.md](../security.md) for the trust model.
+
+### test-command
+
+**Shell handling (v1.1.0+):** `test-command` executes via `${CMD}` (shell word splitting), not `eval`. Same constraints as `install-command` above.
+
 ## Tool versions (v0.2.0)
 
 gh-manage uses a **hybrid pinning strategy** — some tools are pinned inside the composite actions, others are consumer-owned:
@@ -147,6 +155,8 @@ jobs:
 ```
 
 The command runs after `install-command` and before `test-command`. Failure aborts the job with a clear error.
+
+**SECURITY (v1.1.0+):** `setup-command` executes via `eval` and interprets shell metacharacters. Only pass **static literal** values from a trusted source. Never forward `github.event.*`, `workflow_dispatch` inputs, or any consumer-controlled string to this field. See [docs/security.md](../security.md) for the full trust model and list of unsafe patterns.
 
 ## Versioning
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -48,6 +48,8 @@ What gh-manage guarantees NOT to break without a MAJOR bump:
 - **Composite action names and inputs** — the 7 composite actions (`log-gh-manage-version`, `setup-python-uv`, `run-ruff`, `run-mypy`, `setup-node-pnpm`, `run-eslint`, `run-tsc`) and their input surfaces are frozen.
 - **Pinned tool versions in reusable workflows** — `uv 0.5.0`, `ruff 0.8.0`, `mypy 1.12.0`, `pnpm 10.33.0`, `typescript 6.0.2`. Upgrading a pinned tool in a way that breaks consumer CI is a MAJOR break.
 
+Documented behaviour changes that tighten security (e.g., removing `eval` from already-risky inputs) may ship in a MINOR version if the change is announced in `CHANGELOG-reusable.md`'s `Security` section and does not alter the declared input surface. v1.1.0 is the first precedent: `install-command` and `test-command` behaviour changed from `eval` to word splitting, but the input types, names, defaults, and required flags are unchanged.
+
 What is explicitly NOT part of the stability promise (internal):
 
 - Module-level Python APIs inside `src/gh_manage/` (e.g., `compute_files_diff` signature). Refactoring is free.


### PR DESCRIPTION
## Summary
- Swaps `eval "${CMD}"` → `${CMD}` in `install-command` and `test-command` of both reusable PR-gate workflows, retains `eval` in `setup-command` as the documented escape hatch (image-ocr compatibility).
- Adds F1/F2/F3 regression fixtures (per-language) in a new `eval-hardening-smoke.yml`.
- Ships as reusable-track `v1.1.0`; adds `docs/security.md`; updates usage guides, versioning.md, and CHANGELOG-reusable.md.

## Test plan
- [ ] Smoke workflow F1 Python passes (flags+paths).
- [ ] Smoke workflow F2 Python fails at the replicate step and passes the assertion step (PWNED_BY_INJECTION not present).
- [ ] Smoke workflow F3 Python shows `quote-preservation-ok` in log.
- [ ] TypeScript F1/F2/F3 equivalents.
- [ ] Existing `smoke-test.yml` still green (no regression in the main self-dogfood path).

## Spec and plan
- Spec: `docs/specs/2026-04-17-issue-36-eval-hardening-design.md`
- Plan: `docs/plans/2026-04-17-issue-36-eval-hardening-plan.md`

Closes #36.

Generated with [Claude Code](https://claude.ai/code)