### PR TITLE
chore(release): stamp v1.1.0 release date (2026-04-17)

### DIFF
--- a/CHANGELOG-reusable.md
+++ b/CHANGELOG-reusable.md
@@ -8,7 +8,7 @@ The CLI changelog lives in `CHANGELOG-cli.md`.
 
 _Nothing yet._
 
-## [1.1.0] - 2026-04-XX
+## [1.1.0] - 2026-04-17
 
 ### Security
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -82,7 +82,7 @@ setup-command: "${{ inputs.user-provided-command }}"
 | Release | Behaviour |
 |---------|-----------|
 | v1.0.x | `install-command`, `test-command`, and `setup-command` all executed via `eval "${CMD}"`. Shell metacharacters in any of the three were interpreted, so forwarding untrusted input to any of them allowed RCE. |
-| v1.1.0 (2026-04-XX) | `install-command` and `test-command` switched to `${CMD}` word splitting. `setup-command` still uses `eval` as a documented escape hatch for quote-preservation patterns (e.g., `pip install -e '.[dev,bot]'`). Pathname globbing still expands in all three inputs; hardening via `set -f` is tracked as a follow-up. |
+| v1.1.0 (2026-04-17) | `install-command` and `test-command` switched to `${CMD}` word splitting. `setup-command` still uses `eval` as a documented escape hatch for quote-preservation patterns (e.g., `pip install -e '.[dev,bot]'`). Pathname globbing still expands in all three inputs; hardening via `set -f` is tracked as a follow-up. |
 
 ## Reporting a security issue
 


### PR DESCRIPTION
## Summary

Replaces the `2026-04-XX` placeholder with the actual release date `2026-04-17` in:
- `CHANGELOG-reusable.md` — v1.1.0 header
- `docs/security.md` — version history table

## Scope

Date-stamp only. No functional, code, or workflow changes. 2 lines, 2 files.

## Review skip rationale

Per `workflow-review.md` skip conditions: single-concept change, ≤10 lines, config-value-only (release date), no logic changes. Full 4-reviewer protocol skipped — CI green sufficient.

## Test plan

- [x] `git diff --stat` confirms 2 lines changed across 2 files
- [ ] CI green on this branch
- [ ] Merge, then tag `v1.1.0` on the merge commit

Unblocks Task 8 (v1.1.0 release) in Issue #36 rollout.