### PR TITLE
feat: parallel --all drift scan with --concurrency (cli/v1.4.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gh-manage"
-version = "1.3.0"
+version = "1.4.0"
 description = "GitHub-based CI/CD, Issue management, and operational system for yakkuro/* repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gh_manage/__init__.py
+++ b/src/gh_manage/__init__.py
@@ -1,3 +1,3 @@
 """gh-manage: GitHub-based CI/CD, Issue management, and operational system."""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -159,7 +159,7 @@ def _scan_all_repos(
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    from gh_manage.models.repos import ReposConfig
+    from gh_manage.models.repos import RepoEntry, ReposConfig
 
     repos_path = resolve_repos_path()
     config = load_config(repos_path, ReposConfig)
@@ -175,7 +175,16 @@ def _scan_all_repos(
     for e in disabled_entries:
         per_repo_results[e.name] = f"  {e.name}: SKIPPED (disabled)"
 
-    def _worker(entry):
+    def _worker(entry: RepoEntry) -> tuple[str, str, str | Exception]:
+        """Scan one repo. Returns (name, status, payload_or_exc).
+
+        The broad `except Exception` fallback is intentional for parallel
+        isolation (spec §2): one repo's failure — even from an unexpected
+        exception type like OSError on tempdir creation — must NOT abort
+        the whole --all run. Domain exceptions are caught first for
+        specific error messages; anything else is caught and materialized
+        as FAILED so `future.result()` never raises.
+        """
         try:
             result_str = _scan_single_repo(
                 entry.name,
@@ -194,6 +203,8 @@ def _scan_all_repos(
             ProtectionError,
             DriftError,
         ) as e:
+            return (entry.name, "FAILED", e)
+        except Exception as e:  # noqa: BLE001 — parallel isolation, spec §2
             return (entry.name, "FAILED", e)
 
     if enabled_entries and concurrency > 1:

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -148,26 +148,34 @@ def _scan_all_repos(
     severity: str,
     report_mode: str,
     output: Path | None,
+    concurrency: int = 4,
 ) -> None:
-    """Scan all enabled repos from repos.yml.
+    """Scan all enabled repos from repos.yml in parallel.
 
-    Prints a structured summary to stderr with scan counts and results.
+    Threading discipline (spec §2): workers are pure functions that
+    return (name, status_label, payload_or_exc). Only the main thread
+    emits to stdout/stderr — no print locks needed, line-atomic output
+    is guaranteed.
     """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     from gh_manage.models.repos import ReposConfig
 
     repos_path = resolve_repos_path()
     config = load_config(repos_path, ReposConfig)
 
-    results = []
-    skipped = 0
-    failed = 0
+    # Partition repos: enabled vs disabled
+    enabled_entries = [e for e in config.repos if e.enabled]
+    disabled_entries = [e for e in config.repos if not e.enabled]
 
-    for entry in config.repos:
-        if not entry.enabled:
-            results.append(f"  {entry.name}: SKIPPED (disabled)")
-            skipped += 1
-            continue
+    per_repo_results: dict[
+        str, str
+    ] = {}  # name -> "OK" | "SKIPPED (...)" | "FAILED (...)"
 
+    for e in disabled_entries:
+        per_repo_results[e.name] = f"  {e.name}: SKIPPED (disabled)"
+
+    def _worker(entry):
         try:
             result_str = _scan_single_repo(
                 entry.name,
@@ -177,10 +185,7 @@ def _scan_all_repos(
                 output,
                 skip_profile_check=True,
             )
-            # For stdout/json/markdown mode, print the result
-            if report_mode in ("stdout", "json", "markdown-file"):
-                click.echo(result_str)
-            results.append(f"  {entry.name}: OK")
+            return (entry.name, "OK", result_str)
         except (
             GhError,
             ConfigError,
@@ -189,17 +194,42 @@ def _scan_all_repos(
             ProtectionError,
             DriftError,
         ) as e:
-            results.append(f"  {entry.name}: FAILED ({e})")
-            failed += 1
+            return (entry.name, "FAILED", e)
 
-    # Print summary to stderr
-    scanned = len(config.repos) - skipped
+    if enabled_entries and concurrency > 1:
+        click.echo(
+            f"[drift --all] {len(enabled_entries)} repos, concurrency={concurrency}",
+            err=True,
+        )
+
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        future_to_entry = {pool.submit(_worker, e): e for e in enabled_entries}
+        completed = 0
+        for future in as_completed(future_to_entry):
+            name, status, payload = future.result()
+            completed += 1
+            if status == "OK":
+                if report_mode in ("stdout", "json", "markdown-file"):
+                    click.echo(payload)
+                per_repo_results[name] = f"  {name}: OK"
+            else:  # FAILED
+                per_repo_results[name] = f"  {name}: FAILED ({payload})"
+            if concurrency > 1:
+                click.echo(
+                    f"[drift --all] {completed}/{len(enabled_entries)} scanned",
+                    err=True,
+                )
+
+    scanned = len(enabled_entries)
+    skipped = len(disabled_entries)
+    failed = sum(1 for v in per_repo_results.values() if "FAILED" in v)
     click.echo(
         f"\n--- Scan Summary ---\nScanned: {scanned}, Skipped: {skipped}, Failed: {failed}",
         err=True,
     )
-    for result in results:
-        click.echo(result, err=True)
+    # Print per-repo results in repos.yml order (deterministic)
+    for entry in config.repos:
+        click.echo(per_repo_results[entry.name], err=True)
 
 
 @click.command(
@@ -272,7 +302,7 @@ def drift(
                 "--all and path/--profile are mutually exclusive. "
                 "Use either '--all' (scans all repos) or 'path --profile' (single repo)."
             )
-        _scan_all_repos(severity, report_mode, output)
+        _scan_all_repos(severity, report_mode, output, concurrency=concurrency)
         return
 
     # Single-repo mode

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -228,6 +228,15 @@ def _scan_all_repos(
     help="Scan all enabled repos from repos.yml instead of a single path.",
 )
 @click.option(
+    "--concurrency",
+    type=click.IntRange(1, 16),
+    default=4,
+    show_default=True,
+    help="Parallel worker count for --all mode. Values outside [1,16] are rejected. "
+    "Only meaningful with --all; ignored otherwise. "
+    "--concurrency 8+ may interact with GitHub secondary rate-limit.",
+)
+@click.option(
     "--severity",
     type=click.Choice(["critical", "high", "medium", "low"]),
     default="low",
@@ -250,6 +259,7 @@ def drift(
     path: Path | None,
     profile_name: str | None,
     scan_all: bool,
+    concurrency: int,
     severity: str,
     report_mode: str,
     output: Path | None,

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -8,7 +8,7 @@ import gh_manage
 def test_package_version_is_defined() -> None:
     assert hasattr(gh_manage, "__version__")
     assert isinstance(gh_manage.__version__, str)
-    assert gh_manage.__version__ == "1.3.0"
+    assert gh_manage.__version__ == "1.4.0"
 
 
 def test_cli_module_is_importable() -> None:

--- a/tests/unit/commands/test_drift.py
+++ b/tests/unit/commands/test_drift.py
@@ -1,0 +1,40 @@
+"""Tests for gh_manage.commands.drift — CLI-level behavior.
+
+Engine tests live in tests/unit/drift/. This file covers CLI flag
+validation and the parallel _scan_all_repos orchestration (Task 12+).
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from gh_manage.commands.drift import drift
+
+
+def test_concurrency_zero_rejected() -> None:
+    """--concurrency 0 must be rejected by click.IntRange(1, 16)."""
+    runner = CliRunner()
+    result = runner.invoke(drift, ["--all", "--concurrency", "0"])
+    assert result.exit_code == 2
+    # click rejects out-of-range with non-zero exit
+    assert "no such option" not in result.output.lower()  # flag must exist
+
+
+def test_concurrency_seventeen_rejected() -> None:
+    """--concurrency 17 must be rejected by click.IntRange(1, 16)."""
+    runner = CliRunner()
+    result = runner.invoke(drift, ["--all", "--concurrency", "17"])
+    assert result.exit_code == 2
+    assert "no such option" not in result.output.lower()
+
+
+def test_concurrency_one_accepted() -> None:
+    """--concurrency 1 must be a valid value (sequential-equivalent mode).
+
+    The actual invocation will fail because we haven't mocked repos.yml,
+    but the click validation must pass first.
+    """
+    runner = CliRunner()
+    result = runner.invoke(drift, ["--all", "--concurrency", "1"])
+    # click validation passed (flag accepted) — any subsequent error is not about the flag itself
+    assert "no such option" not in result.output.lower()

--- a/tests/unit/commands/test_drift.py
+++ b/tests/unit/commands/test_drift.py
@@ -6,6 +6,9 @@ validation and the parallel _scan_all_repos orchestration (Task 12+).
 
 from __future__ import annotations
 
+import time
+from pathlib import Path
+
 from click.testing import CliRunner
 
 from gh_manage.commands.drift import drift
@@ -38,3 +41,176 @@ def test_concurrency_one_accepted() -> None:
     result = runner.invoke(drift, ["--all", "--concurrency", "1"])
     # click validation passed (flag accepted) — any subsequent error is not about the flag itself
     assert "no such option" not in result.output.lower()
+
+
+# Task 12: parallel _scan_all_repos
+
+
+def test_scan_all_repos_parallel_returns_all_three_results(mocker) -> None:
+    """3 mock repos, concurrency=3, all succeed → all 3 in stdout."""
+    from gh_manage.models.repos import ReposConfig, RepoEntry
+
+    fake_config = ReposConfig(
+        version=1,
+        repos=[
+            RepoEntry(name="yakkuro/a", profile="python-service", enabled=True),
+            RepoEntry(name="yakkuro/b", profile="python-service", enabled=True),
+            RepoEntry(name="yakkuro/c", profile="python-service", enabled=True),
+        ],
+    )
+
+    mocker.patch("gh_manage.commands.drift.load_config", return_value=fake_config)
+    mocker.patch(
+        "gh_manage.commands.drift.resolve_repos_path",
+        return_value=Path("/fake/repos.yml"),
+    )
+
+    def fake_scan(owner_repo, *args, **kwargs):
+        return f"scan-of-{owner_repo}"
+
+    mocker.patch("gh_manage.commands.drift._scan_single_repo", side_effect=fake_scan)
+
+    runner = CliRunner()
+    result = runner.invoke(drift, ["--all", "--concurrency", "3"])
+
+    assert result.exit_code == 0, result.output
+    assert "scan-of-yakkuro/a" in result.output
+    assert "scan-of-yakkuro/b" in result.output
+    assert "scan-of-yakkuro/c" in result.output
+
+
+def test_scan_all_repos_one_failure_does_not_abort_others(mocker) -> None:
+    from gh_manage.github_client import GhAPIError
+    from gh_manage.models.repos import ReposConfig, RepoEntry
+
+    fake_config = ReposConfig(
+        version=1,
+        repos=[
+            RepoEntry(name="yakkuro/ok", profile="python-service", enabled=True),
+            RepoEntry(name="yakkuro/bad", profile="python-service", enabled=True),
+        ],
+    )
+    mocker.patch("gh_manage.commands.drift.load_config", return_value=fake_config)
+    mocker.patch(
+        "gh_manage.commands.drift.resolve_repos_path",
+        return_value=Path("/fake/repos.yml"),
+    )
+
+    def fake_scan(owner_repo, *args, **kwargs):
+        if owner_repo == "yakkuro/bad":
+            raise GhAPIError("synthetic failure", status_code=500)
+        return "ok-output"
+
+    mocker.patch("gh_manage.commands.drift._scan_single_repo", side_effect=fake_scan)
+
+    runner = CliRunner()
+    result = runner.invoke(drift, ["--all", "--concurrency", "2"])
+
+    assert result.exit_code == 0
+    assert "ok-output" in result.output
+    # Summary (stderr in the real app; CliRunner with mix_stderr=True merges them)
+    assert "FAILED" in result.output
+    assert "yakkuro/bad" in result.output
+
+
+def test_scan_all_repos_summary_in_repos_yml_order(mocker) -> None:
+    """Per-repo results may stream in completion order, but the final
+    summary must list repos in repos.yml order for deterministic diffs.
+    """
+    from gh_manage.models.repos import ReposConfig, RepoEntry
+
+    fake_config = ReposConfig(
+        version=1,
+        repos=[
+            RepoEntry(name="yakkuro/first", profile="python-service", enabled=True),
+            RepoEntry(name="yakkuro/second", profile="python-service", enabled=True),
+            RepoEntry(name="yakkuro/third", profile="python-service", enabled=True),
+        ],
+    )
+    mocker.patch("gh_manage.commands.drift.load_config", return_value=fake_config)
+    mocker.patch(
+        "gh_manage.commands.drift.resolve_repos_path",
+        return_value=Path("/fake/repos.yml"),
+    )
+    mocker.patch("gh_manage.commands.drift._scan_single_repo", return_value="done")
+
+    runner = CliRunner()
+    result = runner.invoke(drift, ["--all", "--concurrency", "3"])
+    assert result.exit_code == 0
+
+    # Summary lines appear after '--- Scan Summary ---'
+    summary = result.output.split("--- Scan Summary ---", 1)[1]
+    first_idx = summary.index("yakkuro/first")
+    second_idx = summary.index("yakkuro/second")
+    third_idx = summary.index("yakkuro/third")
+    assert first_idx < second_idx < third_idx
+
+
+def test_scan_all_repos_parallel_wall_clock_faster_than_sequential(
+    mocker,
+) -> None:
+    """4 mock repos @ 1s each; concurrency=4 must finish < 1.8s (overhead
+    budget). concurrency=1 must be > 3.5s (sequential). Guards against
+    GIL-bound regressions where workers don't actually run in parallel.
+    """
+    from gh_manage.models.repos import ReposConfig, RepoEntry
+
+    fake_config = ReposConfig(
+        version=1,
+        repos=[
+            RepoEntry(name=f"yakkuro/r{i}", profile="python-service", enabled=True)
+            for i in range(4)
+        ],
+    )
+    mocker.patch("gh_manage.commands.drift.load_config", return_value=fake_config)
+    mocker.patch(
+        "gh_manage.commands.drift.resolve_repos_path",
+        return_value=Path("/fake/repos.yml"),
+    )
+
+    def slow_scan(owner_repo, *args, **kwargs):
+        time.sleep(1.0)
+        return "done"
+
+    mocker.patch("gh_manage.commands.drift._scan_single_repo", side_effect=slow_scan)
+
+    runner = CliRunner()
+    t0 = time.monotonic()
+    result = runner.invoke(drift, ["--all", "--concurrency", "4"])
+    parallel_elapsed = time.monotonic() - t0
+    assert result.exit_code == 0
+    assert parallel_elapsed < 1.8, f"parallel took {parallel_elapsed:.2f}s"
+
+    t0 = time.monotonic()
+    result = runner.invoke(drift, ["--all", "--concurrency", "1"])
+    sequential_elapsed = time.monotonic() - t0
+    assert result.exit_code == 0
+    assert sequential_elapsed > 3.5, f"sequential took {sequential_elapsed:.2f}s"
+
+
+def test_scan_all_repos_disabled_entries_skipped(mocker) -> None:
+    from gh_manage.models.repos import ReposConfig, RepoEntry
+
+    fake_config = ReposConfig(
+        version=1,
+        repos=[
+            RepoEntry(name="yakkuro/on", profile="python-service", enabled=True),
+            RepoEntry(name="yakkuro/off", profile="python-service", enabled=False),
+        ],
+    )
+    mocker.patch("gh_manage.commands.drift.load_config", return_value=fake_config)
+    mocker.patch(
+        "gh_manage.commands.drift.resolve_repos_path",
+        return_value=Path("/fake/repos.yml"),
+    )
+
+    scan_mock = mocker.patch(
+        "gh_manage.commands.drift._scan_single_repo", return_value="done"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(drift, ["--all", "--concurrency", "2"])
+    assert result.exit_code == 0
+    assert "SKIPPED" in result.output
+    assert "yakkuro/off" in result.output
+    assert scan_mock.call_count == 1  # only the enabled one

--- a/tests/unit/commands/test_drift.py
+++ b/tests/unit/commands/test_drift.py
@@ -113,6 +113,44 @@ def test_scan_all_repos_one_failure_does_not_abort_others(mocker) -> None:
     assert "yakkuro/bad" in result.output
 
 
+def test_scan_all_repos_unexpected_exception_does_not_abort_scan(mocker) -> None:
+    """Non-domain exceptions (e.g. OSError from tempdir) must NOT escape
+    future.result() and crash --all. Spec §2 parallel isolation requires
+    any exception to be materialized as FAILED.
+    """
+    from gh_manage.models.repos import RepoEntry, ReposConfig
+
+    fake_config = ReposConfig(
+        version=1,
+        repos=[
+            RepoEntry(name="yakkuro/ok", profile="python-service", enabled=True),
+            RepoEntry(name="yakkuro/crash", profile="python-service", enabled=True),
+        ],
+    )
+    mocker.patch("gh_manage.commands.drift.load_config", return_value=fake_config)
+    mocker.patch(
+        "gh_manage.commands.drift.resolve_repos_path",
+        return_value=Path("/fake/repos.yml"),
+    )
+
+    def fake_scan(owner_repo, *args, **kwargs):
+        if owner_repo == "yakkuro/crash":
+            raise OSError("tempdir unavailable")
+        return "ok-output"
+
+    mocker.patch("gh_manage.commands.drift._scan_single_repo", side_effect=fake_scan)
+
+    runner = CliRunner()
+    result = runner.invoke(drift, ["--all", "--concurrency", "2"])
+
+    # Exit 0: the scan completes; the unexpected OSError is materialized as FAILED
+    assert result.exit_code == 0, result.output
+    assert "ok-output" in result.output
+    assert "FAILED" in result.output
+    assert "yakkuro/crash" in result.output
+    assert "yakkuro/ok" in result.output
+
+
 def test_scan_all_repos_summary_in_repos_yml_order(mocker) -> None:
     """Per-repo results may stream in completion order, but the final
     summary must list repos in repos.yml order for deterministic diffs.

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "gh-manage"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Implements PR 2 of the Theme A resilience pack ([spec](docs/specs/2026-04-17-theme-a-resilience-pack-design.md)). Depends on cli/v1.3.0's retry layer for rate-limit recovery under concurrent load.

Phase 10 rollout (#27) scales drift scans from 9 to 20+ repos; sequential `--all` was approaching the 4-minute mark. Parallel scan completes 22 repos in ~8s.

## What ships

- **`gh-manage drift --all --concurrency N`** — new flag, default 4, clamp `[1, 16]` (click `IntRange`). `--concurrency 8+` documented as "use at your own risk" due to GitHub secondary rate-limit interaction.
- **`_scan_all_repos` refactor** — now uses `concurrent.futures.ThreadPoolExecutor`. Workers are pure functions returning `(name, status, payload)` tuples; only the main thread emits output via `click.echo` in the `as_completed` loop. Print lock not needed, line-atomic guarantee.
- **Per-repo streaming** — stdout in completion order (fast feedback).
- **Deterministic summary** — stderr summary in `repos.yml` order (diff-friendly across runs).
- **Progress indicator** — `[drift --all] N/M scanned` lines to stderr when `concurrency > 1`.

## Self-dogfood results (22 repos)

| Mode | Wall-clock |
|---|---|
| `--concurrency 4` (default) | 8.2s |
| `--concurrency 1` (sequential) | 29.2s |

3.5× speedup at default concurrency with zero FAILED entries.

## Non-goals (tracked elsewhere)

- Circuit breaker per-repo, shared rate-limit state across workers → #47 (deferred until fleet > 40).
- Structured logging / metrics → #47 / #50.
- Additional doctor checks, workflow-YAML prompt-injection linter → #48.

## Test plan

- [x] Full pytest suite green (552 tests).
- [x] Timed concurrency smoke: 4 workers × 1s → <1.8s; concurrency=1 → >3.5s (GIL-bound regression guard).
- [x] One-repo-fails test: other repos complete, FAILED in summary, exit 0.
- [x] Repos.yml-order summary test (deterministic `first < second < third`).
- [x] Disabled entries SKIPPED without calling `_scan_single_repo`.
- [x] Click `IntRange` rejects 0 / 17 with clear message.
- [x] `uvx ruff@0.8.0 check + format --check` clean.
- [x] `uv run mypy src/` clean.
- [x] Self-dogfood: `uv run gh-manage drift --all` completes 22 repos in 8.2s, zero FAILED.
- [x] Self-dogfood: `uv run gh-manage drift --all --concurrency 1` produces sequential-equivalent output.
- [x] Self-dogfood: `uv run gh-manage drift --all --concurrency 17` errors with clear clamp message.
- [ ] 4-reviewer protocol clean.

## Release plan

Merge → tag `cli/v1.4.0` per `docs/release-checklist.md`.

## Compatibility

Additive only. Default concurrency=4 is safe; `--concurrency 1` is exactly sequential-equivalent. Depends on cli/v1.3.0 retry layer for rate-limit handling under concurrent load.

Relates: #27 (Phase 10), #47 Theme A item 7.

Generated with [Claude Code](https://claude.ai/code)