### PR TITLE
feat: drift_sync structured logging (cli/v1.8.0)

### DIFF
--- a/docs/plans/2026-04-19-drift-sync-logging-plan.md
+++ b/docs/plans/2026-04-19-drift-sync-logging-plan.md
@@ -1,0 +1,1724 @@
+# drift_sync Structured Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `logging` into `drift_sync/` + `commands/drift.py` with a hybrid plain/JSON format, a root Click `--log-level` option, and 8 concrete log points that resolve [#62](https://github.com/yakkuro/gh-manage/issues/62) HIGH #3 (malformed-timestamp WARNING) and HIGH #5 (unexpected-exception traceback). Ship as `cli/v1.8.0`.
+
+**Architecture:** Single `gh_manage.logging_config.configure_logging()` entrypoint configures the `gh_manage` logger tree (not root); called once from `cli.py`'s root group callback. Format switches on `GH_MANAGE_LOG_JSON` env var or explicit `json=` arg. Each module uses `log = logging.getLogger(__name__)` so loggers are named `gh_manage.drift_sync.checks` etc. Formatters and datefmts are frozen inside `logging_config.py` to keep caplog record shape stable. Tests use pytest's `caplog` fixture.
+
+**Tech Stack:** Python 3.12, `uv`, `pytest 8`, `pytest-mock`, `click`, `python-json-logger` (NEW dep), `ruff@0.8.0`, `mypy`.
+
+**Spec reference:** `docs/specs/2026-04-19-drift-sync-logging-design.md` (approved 2026-04-19 after spec-critique rounds 1 + 2).
+
+**Branch:** `feat/drift-sync-logging` (already created at 1b66f62; this plan continues on that branch).
+
+---
+
+## File Structure
+
+**Create:**
+- `src/gh_manage/logging_config.py` — `configure_logging()` + `LogLevel` type alias.
+- `tests/unit/test_logging_config.py` — 7 tests covering the config module.
+- `tests/unit/drift/test_logging_events.py` — 7 tests covering log emission points.
+
+**Modify:**
+- `pyproject.toml` — add `python-json-logger>=2.0,<3.0` to `[project].dependencies`; bump version to `1.8.0`.
+- `uv.lock` — regenerated via `uv sync`.
+- `src/gh_manage/__init__.py` — bump `__version__` to `1.8.0`.
+- `tests/test_sanity.py` — update version assertion to `1.8.0`.
+- `src/gh_manage/cli.py` — add `--log-level` option, call `configure_logging()`.
+- `src/gh_manage/drift_sync/registry.py` — 2 DEBUG log points.
+- `src/gh_manage/drift_sync/checks.py` — 2 DEBUG + 1 WARNING + 1 ERROR log points.
+- `src/gh_manage/drift_sync/issue_state.py` — 1 WARNING (+ 3 INFO) log points (#62 HIGH #3).
+- `src/gh_manage/commands/drift.py` — 2 INFO + 1 `log.exception` (#62 HIGH #5).
+
+---
+
+## Pre-flight
+
+### Task 0: Baseline + branch check
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm branch and clean tree**
+
+```bash
+cd /home/server160/repos/gh-manage
+git status
+git log --oneline -3
+```
+
+Expected: on `feat/drift-sync-logging`, clean, HEAD = `1b66f62` (spec round-2 response). If `main` is ahead via a merge, rebase: `git fetch origin && git rebase origin/main`.
+
+- [ ] **Step 2: Record baseline pytest count**
+
+```bash
+uv run pytest -q 2>&1 | tail -3
+```
+
+Expected: `572 passed` (cli/v1.7.0 baseline). All subsequent tasks end on this count + whatever they add.
+
+---
+
+## Task 1: Add python-json-logger dependency
+
+**Files:**
+- Modify: `pyproject.toml` (add dependency only; version bump happens later in Task 9).
+- Modify: `uv.lock` (regenerated).
+
+- [ ] **Step 1: Read current dependencies block**
+
+```bash
+```
+
+Use Read on `pyproject.toml` to locate the `[project].dependencies` list.
+
+- [ ] **Step 2: Add `python-json-logger` to dependencies**
+
+Use Edit to append `"python-json-logger>=2.0,<3.0",` to the dependencies list (preserve alphabetical ordering if the file maintains it).
+
+- [ ] **Step 3: Regenerate lockfile**
+
+```bash
+uv sync
+```
+
+Expected: "Prepared 1 package" for `python-json-logger` (≈2.0.7 or later). Install succeeds.
+
+- [ ] **Step 4: Verify import works**
+
+```bash
+uv run python -c "from pythonjsonlogger.jsonlogger import JsonFormatter; print(JsonFormatter.__module__)"
+```
+
+Expected: `pythonjsonlogger.jsonlogger`.
+
+- [ ] **Step 5: Confirm suite still green**
+
+```bash
+uv run pytest -q 2>&1 | tail -3
+```
+
+Expected: 572 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "$(cat <<'EOF'
+chore(deps): add python-json-logger for structured logging
+
+Prereq for cli/v1.8.0 drift_sync logging rollout. Range `>=2.0,<3.0`
+pins a stable major; the dep is a single-module stdlib-compatible
+Formatter subclass.
+
+Refs #47 (Theme A item 6), spec docs/specs/2026-04-19-drift-sync-logging-design.md.
+EOF
+)"
+```
+
+---
+
+## Task 2: Implement `logging_config.py` (TDD)
+
+**Files:**
+- Create: `tests/unit/test_logging_config.py`
+- Create: `src/gh_manage/logging_config.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_logging_config.py` with this exact content:
+
+```python
+"""Tests for gh_manage.logging_config.
+
+All tests clean up the `gh_manage` logger's handler state after each run
+so tests don't interfere with each other or with pytest's own logger.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_gh_manage_logger():
+    """Save/restore the gh_manage logger state around each test."""
+    gh_logger = logging.getLogger("gh_manage")
+    saved_handlers = list(gh_logger.handlers)
+    saved_level = gh_logger.level
+    yield
+    gh_logger.handlers[:] = saved_handlers
+    gh_logger.setLevel(saved_level)
+
+
+def test_configure_logging_default_level_is_warning() -> None:
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging()
+    assert logging.getLogger("gh_manage").level == logging.WARNING
+
+
+def test_configure_logging_sets_explicit_level() -> None:
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging(level="info")
+    assert logging.getLogger("gh_manage").level == logging.INFO
+
+
+def test_configure_logging_plain_formatter_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GH_MANAGE_LOG_JSON", raising=False)
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging()
+    handler = logging.getLogger("gh_manage").handlers[0]
+    # Plain-text formatter is the stdlib class, not JsonFormatter.
+    assert type(handler.formatter).__name__ == "Formatter"
+
+
+def test_configure_logging_json_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_MANAGE_LOG_JSON", "1")
+    from gh_manage.logging_config import configure_logging
+    from pythonjsonlogger.jsonlogger import JsonFormatter
+
+    configure_logging()
+    handler = logging.getLogger("gh_manage").handlers[0]
+    assert isinstance(handler.formatter, JsonFormatter)
+
+
+def test_configure_logging_json_explicit_arg_overrides_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Env says yes; explicit arg says no. Explicit wins.
+    monkeypatch.setenv("GH_MANAGE_LOG_JSON", "1")
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging(json=False)
+    handler = logging.getLogger("gh_manage").handlers[0]
+    assert type(handler.formatter).__name__ == "Formatter"
+
+
+def test_configure_logging_idempotent() -> None:
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging(level="info")
+    configure_logging(level="debug")
+    gh_logger = logging.getLogger("gh_manage")
+    assert len(gh_logger.handlers) == 1
+    assert gh_logger.level == logging.DEBUG
+
+
+def test_configure_logging_writes_to_stream_argument() -> None:
+    """Stream override is how unit tests isolate from real stderr."""
+    from gh_manage.logging_config import configure_logging
+
+    buf = io.StringIO()
+    configure_logging(level="info", stream=buf)
+    logging.getLogger("gh_manage.test").info("sentinel-msg-xyz")
+    assert "sentinel-msg-xyz" in buf.getvalue()
+
+
+def test_configure_logging_does_not_add_handler_to_root_logger() -> None:
+    from gh_manage.logging_config import configure_logging
+
+    root_handlers_before = list(logging.getLogger().handlers)
+    configure_logging()
+    root_handlers_after = list(logging.getLogger().handlers)
+    assert root_handlers_before == root_handlers_after, (
+        "configure_logging must not touch the root logger — only the "
+        "`gh_manage` tree."
+    )
+```
+
+- [ ] **Step 2: Run tests — confirm they FAIL**
+
+```bash
+uv run pytest tests/unit/test_logging_config.py -v 2>&1 | tail -15
+```
+
+Expected: 8 collection/import errors (`ModuleNotFoundError: gh_manage.logging_config`). This is the Red phase.
+
+- [ ] **Step 3: Write `logging_config.py`**
+
+Create `src/gh_manage/logging_config.py` with this content:
+
+```python
+"""Central logging configuration for gh_manage.
+
+Invoked once from cli.py's root group callback. Configures only the
+`gh_manage` logger tree — third-party packages' loggers (click,
+pydantic, httpx, etc.) are left alone. Output goes to stderr by
+default; tests pass a StringIO via the `stream` argument.
+
+Format is selected at configuration time and cannot be changed at
+runtime. This keeps the caplog record shape stable for tests. To
+change a format, edit this module.
+
+See docs/specs/2026-04-19-drift-sync-logging-design.md §2.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import IO, Literal
+
+from pythonjsonlogger.jsonlogger import JsonFormatter
+
+LogLevel = Literal["debug", "info", "warning", "error"]
+
+_LOG_LEVELS: dict[str, int] = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+}
+
+_PLAIN_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+_PLAIN_DATEFMT = "%Y-%m-%d %H:%M:%S"
+_JSON_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
+_JSON_DATEFMT = "%Y-%m-%dT%H:%M:%S"
+
+_TRUTHY = {"1", "true", "yes"}
+
+
+def _env_says_json() -> bool:
+    raw = os.environ.get("GH_MANAGE_LOG_JSON", "").strip().lower()
+    return raw in _TRUTHY
+
+
+def configure_logging(
+    level: LogLevel = "warning",
+    json: bool | None = None,
+    stream: IO[str] | None = None,
+) -> None:
+    """Configure gh_manage's root logger tree. Idempotent.
+
+    See module docstring and spec §2 for rationale and full contract.
+    """
+    if json is None:
+        json = _env_says_json()
+
+    if stream is None:
+        stream = sys.stderr
+
+    formatter: logging.Formatter
+    if json:
+        formatter = JsonFormatter(_JSON_FORMAT, datefmt=_JSON_DATEFMT)
+    else:
+        formatter = logging.Formatter(_PLAIN_FORMAT, datefmt=_PLAIN_DATEFMT)
+
+    handler = logging.StreamHandler(stream=stream)
+    handler.setFormatter(formatter)
+
+    gh_logger = logging.getLogger("gh_manage")
+    # Drop prior handlers so repeat calls (idempotent contract) don't stack.
+    gh_logger.handlers[:] = [handler]
+    gh_logger.setLevel(_LOG_LEVELS[level])
+    # Don't propagate to the root logger — otherwise a user who
+    # configures a root handler for third-party logs would see our
+    # records duplicated.
+    gh_logger.propagate = False
+```
+
+- [ ] **Step 4: Run tests — confirm they PASS**
+
+```bash
+uv run pytest tests/unit/test_logging_config.py -v 2>&1 | tail -15
+```
+
+Expected: 8 passed. (Green phase.)
+
+- [ ] **Step 5: Full suite + lint + types**
+
+```bash
+uv run pytest -q 2>&1 | tail -3
+uvx ruff@0.8.0 check src/ tests/
+uvx ruff@0.8.0 format --check src/ tests/
+uv run mypy src/
+```
+
+Expected: 580 passed (572 + 8), ruff clean, mypy clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gh_manage/logging_config.py tests/unit/test_logging_config.py
+git commit -m "$(cat <<'EOF'
+feat(logging): add gh_manage.logging_config module
+
+Central configure_logging(level, json, stream) that sets up the
+`gh_manage` logger tree — not the root — with a stderr handler and a
+frozen format string (plain default, JSON via GH_MANAGE_LOG_JSON env
+or explicit json= arg). Idempotent.
+
+8 tests covering level default + override, plain/JSON format switch,
+env-vs-arg precedence, idempotency, stream override, and root-logger
+isolation.
+
+No call sites yet — wired in cli.py in next commit.
+
+Refs #47 (Theme A item 6), spec docs/specs/2026-04-19-drift-sync-logging-design.md.
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire `configure_logging` into CLI entry
+
+**Files:**
+- Modify: `src/gh_manage/cli.py`
+
+- [ ] **Step 1: Update cli.py**
+
+Replace the current `@click.group(...)` decorator and `main` function with the following (the rest of the file stays unchanged):
+
+```python
+"""Top-level click group for gh-manage."""
+
+from __future__ import annotations
+
+import click
+
+from gh_manage import __version__
+from gh_manage.commands import (
+    apply as apply_cmd,
+    doctor as doctor_cmd,
+    drift as drift_cmd,
+    init as init_cmd,
+    issues as issues_cmd,
+    labels as labels_cmd,
+    protection as protection_cmd,
+)
+from gh_manage.logging_config import LogLevel, configure_logging
+
+
+@click.group(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help=(
+        "gh-manage — GitHub-based CI/CD, Issue management, and operations "
+        "for yakkuro/* repositories."
+    ),
+)
+@click.version_option(version=__version__, prog_name="gh-manage")
+@click.option(
+    "--log-level",
+    type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
+    envvar="GH_MANAGE_LOG_LEVEL",
+    default="warning",
+    show_default=True,
+    help=(
+        "Logging verbosity for gh_manage modules. Also honours "
+        "GH_MANAGE_LOG_LEVEL. For JSON output, set GH_MANAGE_LOG_JSON=1."
+    ),
+)
+def main(log_level: str) -> None:
+    """Root command group. Subcommands are registered below."""
+    configure_logging(level=log_level.lower())  # type: ignore[arg-type]
+
+
+main.add_command(init_cmd.init)
+main.add_command(apply_cmd.apply)
+main.add_command(doctor_cmd.doctor_cmd)
+main.add_command(labels_cmd.labels)
+main.add_command(protection_cmd.protection)
+main.add_command(drift_cmd.drift)
+main.add_command(issues_cmd.issues)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Manual smoke — default and explicit levels**
+
+```bash
+# No log output expected at default WARNING level.
+uv run gh-manage drift . --profile python-service 2>/tmp/stderr.default >/dev/null
+wc -l /tmp/stderr.default
+# Expected: 0 lines of log output (click.echo progress still prints, but there
+# are no INFO/WARN/ERROR loggers emitting at default level in a clean scan).
+
+# Explicit --log-level info shows INFO records we'll add in later tasks.
+# At this point no log points exist yet, so the INFO stream is empty too —
+# that's fine, this task only verifies the CLI wires up.
+uv run gh-manage --log-level info drift . --profile python-service 2>/tmp/stderr.info >/dev/null
+cat /tmp/stderr.info | head -5
+# Expected: runs without error. No log output until Task 4+ adds log points.
+
+# Help text shows the new option.
+uv run gh-manage --help | grep -A 2 log-level
+# Expected: "--log-level [debug|info|warning|error]" visible in help output.
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+uv run pytest -q 2>&1 | tail -3
+uvx ruff@0.8.0 check src/
+uv run mypy src/
+```
+
+Expected: 580 passed, ruff clean, mypy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/gh_manage/cli.py
+git commit -m "$(cat <<'EOF'
+feat(cli): wire --log-level root option + configure_logging on startup
+
+Adds --log-level to the root Click group with envvar GH_MANAGE_LOG_LEVEL
+and default "warning". The group callback invokes configure_logging()
+once so every subcommand benefits without needing per-command setup.
+
+For JSON output, users set GH_MANAGE_LOG_JSON=1 (documented in --help).
+
+Log points will be added in subsequent commits (drift_sync + commands/drift).
+
+Refs #47 (Theme A item 6).
+EOF
+)"
+```
+
+---
+
+## Task 4: Add log points in `drift_sync/registry.py`
+
+**Files:**
+- Modify: `src/gh_manage/drift_sync/registry.py`
+
+- [ ] **Step 1: Update registry.py**
+
+Add a module-level logger and two DEBUG log lines around each check invocation. Edit the file so it reads:
+
+```python
+"""Check registry + severity filter.
+
+Layer 2 of the drift_sync package. Depends on context (for ScanContext)
+and on gh_manage.findings (for Finding/Severity). Does NOT depend on
+adapters, checks, formatters, or issue_state.
+
+The module-level _CHECKS list is the single source of truth for which
+drift checks run. @register_check mutates _CHECKS at import time; every
+submodule that defines a @register_check-decorated function must be
+imported by __init__.py for the check to be registered.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from itertools import chain
+
+from gh_manage.drift_sync.context import ScanContext
+from gh_manage.findings import Finding, Severity
+
+log = logging.getLogger(__name__)
+
+CheckFn = Callable[["ScanContext"], tuple[Finding, ...]]
+_CHECKS: list[CheckFn] = []
+
+
+def register_check(fn: CheckFn) -> CheckFn:
+    """Decorator: register a check function in the global registry.
+
+    Intended usage:
+
+        @register_check
+        def check_labels(ctx: ScanContext) -> tuple[Finding, ...]:
+            ...
+
+    Order of registration determines order of execution in
+    run_all_checks. Phase 8 registers check_labels, check_protection,
+    check_profile_files in that order.
+    """
+    _CHECKS.append(fn)
+    return fn
+
+
+def run_all_checks(ctx: ScanContext) -> tuple[Finding, ...]:
+    """Run every registered check in order and concatenate findings.
+
+    Fail-fast: if a check raises, the exception propagates and no
+    further checks run. MVP does not have a --continue-on-error flag;
+    that is filed as a Phase 8.5+ Issue.
+    """
+    all_findings: list[Finding] = []
+    for check in _CHECKS:
+        log.debug("running check: %s", check.__name__)
+        findings = check(ctx)
+        log.debug("check %s returned %d findings", check.__name__, len(findings))
+        all_findings.extend(findings)
+    return tuple(all_findings)
+
+
+_SEVERITY_RANK = {"critical": 3, "high": 2, "medium": 1, "low": 0}
+
+
+def _filter_by_severity(
+    findings: tuple[Finding, ...], min_severity: Severity
+) -> tuple[Finding, ...]:
+    """Filter findings to those with severity >= min_severity.
+
+    Hierarchy (highest to lowest): critical > high > medium > low.
+    Input order is preserved for stable reporting.
+    """
+    threshold = _SEVERITY_RANK[min_severity]
+    return tuple(f for f in findings if _SEVERITY_RANK[f.severity] >= threshold)
+```
+
+Note the change to `run_all_checks`: previously it used `tuple(chain.from_iterable(check(ctx) for check in _CHECKS))`, which is a single expression. The new implementation uses an explicit loop so `log.debug` can bracket each check.
+
+- [ ] **Step 2: Verify imports still clean (chain no longer used)**
+
+```bash
+uvx ruff@0.8.0 check src/gh_manage/drift_sync/registry.py 2>&1 | tail -5
+```
+
+Expected: `All checks passed!`. If `chain` is flagged as unused, remove the `from itertools import chain` line (it's no longer needed — the new `for`-loop replaced `chain.from_iterable`).
+
+- [ ] **Step 3: Full verify**
+
+```bash
+uv run pytest -q 2>&1 | tail -3
+uv run mypy src/
+```
+
+Expected: 580 passed, mypy clean.
+
+- [ ] **Step 4: Manual — DEBUG visible at debug level**
+
+```bash
+uv run gh-manage --log-level debug drift . --profile python-service 2>&1 | grep -E "DEBUG.+check" | head -6
+```
+
+Expected: 6 lines (3 checks × 2 DEBUG lines each: entry + exit). E.g.:
+
+```
+2026-04-19 10:23:00 DEBUG gh_manage.drift_sync.registry: running check: check_labels
+2026-04-19 10:23:01 DEBUG gh_manage.drift_sync.registry: check check_labels returned 1 findings
+...
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/drift_sync/registry.py
+git commit -m "$(cat <<'EOF'
+feat(drift_sync/registry): DEBUG-level logs around each check call
+
+run_all_checks now logs entry + finding-count-exit for every registered
+check. Loop replaces the `chain.from_iterable` one-liner so log.debug
+can bracket each call. No behavior change to findings output.
+
+Refs #47 (Theme A item 6).
+EOF
+)"
+```
+
+---
+
+## Task 5: Add log points in `drift_sync/checks.py`
+
+**Files:**
+- Modify: `src/gh_manage/drift_sync/checks.py`
+
+- [ ] **Step 1: Update imports + add logger at module top**
+
+At the top of `checks.py`, add `import logging` to the stdlib block and `log = logging.getLogger(__name__)` below the imports (before the `@register_check` decorators). The file currently starts:
+
+```python
+from __future__ import annotations
+
+import hashlib
+from importlib.resources import files as _package_files
+from pathlib import Path
+...
+```
+
+Change the stdlib imports block to include `logging`:
+
+```python
+from __future__ import annotations
+
+import hashlib
+import logging
+from importlib.resources import files as _package_files
+from pathlib import Path
+```
+
+Then after all imports but before the first function, add:
+
+```python
+log = logging.getLogger(__name__)
+```
+
+- [ ] **Step 2: Instrument `check_labels`**
+
+Inside `check_labels`, add a DEBUG line before the API call. Before:
+
+```python
+    current = labels_api.list_labels(ctx.repo)
+```
+
+After:
+
+```python
+    log.debug("fetching labels for %s", ctx.repo)
+    current = labels_api.list_labels(ctx.repo)
+```
+
+- [ ] **Step 3: Instrument `check_protection`**
+
+Inside the `try`/`except GhNotFoundError` block, add a WARNING log before the existing `current = {}` fallback. Before:
+
+```python
+    try:
+        current = protection_api.get_branch_protection(ctx.repo, ctx.default_branch)
+    except GhNotFoundError:
+        current = {}
+```
+
+After:
+
+```python
+    try:
+        current = protection_api.get_branch_protection(ctx.repo, ctx.default_branch)
+    except GhNotFoundError:
+        log.warning(
+            "branch protection not configured on %s@%s; treating as empty",
+            ctx.repo,
+            ctx.default_branch,
+        )
+        current = {}
+```
+
+This is the **one intentional behavior change** called out in spec §4 / §7.
+
+- [ ] **Step 4: Instrument `_read_template_content`**
+
+Add a `log.error` *before* the existing `raise DriftError(...)` (not instead — callers still need the exception). Before:
+
+```python
+    except OSError as e:
+        raise DriftError(
+            f"Cannot read bundled template {source!r} at {template_path}: {e}. "
+            f"This may indicate a packaging bug — the template should be "
+            f"bundled in gh_manage.data.templates."
+        ) from e
+```
+
+After:
+
+```python
+    except OSError as e:
+        log.error(
+            "failed to read bundled template %r at %s: %s", source, template_path, e
+        )
+        raise DriftError(
+            f"Cannot read bundled template {source!r} at {template_path}: {e}. "
+            f"This may indicate a packaging bug — the template should be "
+            f"bundled in gh_manage.data.templates."
+        ) from e
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+uvx ruff@0.8.0 check src/gh_manage/drift_sync/checks.py 2>&1 | tail -3
+uv run pytest -q 2>&1 | tail -3
+uv run mypy src/
+```
+
+Expected: ruff clean, 580 passed, mypy clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gh_manage/drift_sync/checks.py
+git commit -m "$(cat <<'EOF'
+feat(drift_sync/checks): log DEBUG/WARNING/ERROR on fetch + guarded paths
+
+- check_labels: DEBUG before labels_api.list_labels.
+- check_protection: WARNING before the existing GhNotFoundError → empty
+  fallback (intentional behavior change per spec §4 — the findings
+  tuple and exit code are unchanged; only a new log line).
+- _read_template_content: ERROR before the existing `raise DriftError`
+  so packaging bugs leave an operational breadcrumb even when the
+  exception propagates through.
+
+Refs #47 (Theme A item 6).
+EOF
+)"
+```
+
+---
+
+## Task 6: Add log points in `drift_sync/issue_state.py` (#62 HIGH #3)
+
+**Files:**
+- Modify: `src/gh_manage/drift_sync/issue_state.py`
+
+- [ ] **Step 1: Add logger at module top**
+
+Edit the imports block to add `import logging` and below it, `log = logging.getLogger(__name__)`:
+
+```python
+from __future__ import annotations
+
+import logging
+import re as _re
+from datetime import datetime, timedelta
+from typing import Any
+
+from gh_manage.drift_sync.formatters import format_issue_body, format_issue_comment
+from gh_manage.findings import Finding
+from gh_manage.github_api import issues as issues_api
+
+log = logging.getLogger(__name__)
+```
+
+- [ ] **Step 2: #62 HIGH #3 — log malformed timestamps**
+
+In `parse_zero_findings_timestamps`, replace the silent `continue` with a WARNING. Before:
+
+```python
+            try:
+                ts = datetime.fromisoformat(match.group(1))
+                timestamps.append(ts)
+            except ValueError:
+                # Malformed timestamp — skip
+                continue
+```
+
+After:
+
+```python
+            try:
+                ts = datetime.fromisoformat(match.group(1))
+                timestamps.append(ts)
+            except ValueError as e:
+                log.warning(
+                    "malformed zero-findings timestamp %r skipped: %s",
+                    match.group(1),
+                    e,
+                )
+                continue
+```
+
+- [ ] **Step 3: Instrument `resolve_drift_issue` — create/update/close**
+
+Edit `resolve_drift_issue` so each terminal branch logs INFO before returning. Replace the whole function with:
+
+```python
+def resolve_drift_issue(
+    findings: tuple[Finding, ...],
+    repo: str,
+    scan_time: str,
+) -> str:
+    """Issue state machine: search → create/update/close.
+
+    Returns a human-readable status string for CLI output.
+    """
+    issues_api.ensure_drift_label(repo)
+    existing = issues_api.search_drift_issue(repo)
+    has_findings = len(findings) > 0
+
+    if existing is None:
+        # No open Issue
+        if not has_findings:
+            return f"No drift detected for {repo}. No Issue created."
+        # Create new Issue
+        body = format_issue_body(findings, repo, scan_time)
+        comment = format_issue_comment(findings, scan_time)
+        title = _DRIFT_ISSUE_TITLE_TEMPLATE.format(repo=repo)
+        issue = issues_api.create_issue(repo, title, body, [_DRIFT_LABEL])
+        issues_api.add_issue_comment(repo, issue["number"], comment)
+        log.info(
+            "created drift issue #%d on %s (%d findings)",
+            issue["number"],
+            repo,
+            len(findings),
+        )
+        return f"Created issue #{issue['number']} on {repo} ({len(findings)} findings)"
+
+    issue_number = existing["number"]
+
+    # Update existing Issue
+    body = format_issue_body(findings, repo, scan_time)
+    comment = format_issue_comment(findings, scan_time)
+    issues_api.update_issue_body(repo, issue_number, body)
+    issues_api.add_issue_comment(repo, issue_number, comment)
+
+    if not has_findings:
+        # Check 24h close rule
+        comments = issues_api.get_issue_comments(repo, issue_number, per_page=5)
+        if should_close_issue(comments):
+            issues_api.close_issue(repo, issue_number)
+            issues_api.add_issue_comment(
+                repo,
+                issue_number,
+                f"## Auto-closed — {scan_time}\n\n"
+                f"Zero drift detected on 2 consecutive scans ≥24h apart. "
+                f"If drift recurs, a new Issue will be created.",
+            )
+            log.info(
+                "closed drift issue #%d on %s (24h zero-drift rule)",
+                issue_number,
+                repo,
+            )
+            return f"Closed issue #{issue_number} on {repo} (zero drift, 24h rule satisfied)"
+
+    log.info(
+        "updated drift issue #%d on %s (%d findings)",
+        issue_number,
+        repo,
+        len(findings),
+    )
+    return f"Updated issue #{issue_number} on {repo} ({len(findings)} findings)"
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+uvx ruff@0.8.0 check src/gh_manage/drift_sync/issue_state.py 2>&1 | tail -3
+uv run pytest -q 2>&1 | tail -3
+uv run mypy src/
+```
+
+Expected: ruff clean, 580 passed, mypy clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/drift_sync/issue_state.py
+git commit -m "$(cat <<'EOF'
+feat(drift_sync/issue_state): WARN malformed timestamps + INFO state transitions
+
+- parse_zero_findings_timestamps: malformed ISO8601 timestamps now emit
+  WARNING with the raw value and ValueError detail, then continue as
+  before. Resolves #62 HIGH #3.
+- resolve_drift_issue: INFO logs for each create / update / close
+  transition, including finding count. Useful for cron audit trails
+  in JSON mode.
+
+No behavior change beyond the new log lines.
+
+Refs #47 (Theme A item 6), closes part of #62 (HIGH #3).
+EOF
+)"
+```
+
+---
+
+## Task 7: Add log points in `commands/drift.py` (#62 HIGH #5)
+
+**Files:**
+- Modify: `src/gh_manage/commands/drift.py`
+
+- [ ] **Step 1: Add logger at module top**
+
+Add `import logging` to the stdlib imports block and `log = logging.getLogger(__name__)` below the imports:
+
+```python
+# Near the top of commands/drift.py (existing imports preserved).
+import logging
+# ... existing imports ...
+
+log = logging.getLogger(__name__)
+```
+
+- [ ] **Step 2: Instrument `_scan_single_repo` — start + complete**
+
+Find `_scan_single_repo` (it's the per-repo helper). At the entry add an INFO with repo + profile; at the exit (before the final return / before the summary string is built) add an INFO with the finding count. Use Read + Edit: the existing function body looks like:
+
+```python
+def _scan_single_repo(
+    repo: str,
+    profile_name: str,
+    ...,
+) -> str:
+    # ... existing logic ...
+    findings = run_all_checks(ctx)
+    # ... format + return ...
+```
+
+Add at function entry (first statement):
+
+```python
+    log.info("scanning %s (profile=%s)", repo, profile_name)
+```
+
+And directly after `findings = run_all_checks(ctx)`:
+
+```python
+    log.info(
+        "scan complete for %s: %d findings", repo, len(findings)
+    )
+```
+
+(If you can't cleanly identify "first statement" vs "after findings =" due to surrounding control flow, use Read first to get the exact structure.)
+
+- [ ] **Step 3: #62 HIGH #5 — log.exception in `_worker` catch-all**
+
+Inside `_worker` (commands/drift.py:178-208), add `log.exception(...)` in the broad `except Exception` branch. Before:
+
+```python
+        except Exception as e:  # noqa: BLE001 — parallel isolation, spec §2
+            return (entry.name, "FAILED", e)
+```
+
+After:
+
+```python
+        except Exception as e:  # noqa: BLE001 — parallel isolation, spec §2
+            log.exception(
+                "unexpected error scanning %s (%s: %s)",
+                entry.name,
+                type(e).__name__,
+                e,
+            )
+            return (entry.name, "FAILED", e)
+```
+
+`log.exception` automatically attaches the current exception's traceback, which is exactly the operational breadcrumb #62 HIGH #5 requested.
+
+- [ ] **Step 4: Verify**
+
+```bash
+uvx ruff@0.8.0 check src/gh_manage/commands/drift.py 2>&1 | tail -3
+uv run pytest -q 2>&1 | tail -3
+uv run mypy src/
+```
+
+Expected: ruff clean, 580 passed, mypy clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/commands/drift.py
+git commit -m "$(cat <<'EOF'
+feat(commands/drift): INFO scan lifecycle + log.exception for unexpected worker errors
+
+- _scan_single_repo: INFO at start (repo + profile) and completion
+  (finding count). Useful for human and agent observation of parallel
+  --all runs.
+- _worker: the catch-all `except Exception` branch now calls
+  log.exception before materializing the exception as FAILED. Captures
+  full traceback in logs without disturbing parallel isolation
+  semantics. Resolves #62 HIGH #5.
+
+No behavior change to findings output or exit codes.
+
+Refs #47 (Theme A item 6), closes part of #62 (HIGH #5).
+EOF
+)"
+```
+
+---
+
+## Task 8: Event-emission regression tests
+
+**Files:**
+- Create: `tests/unit/drift/test_logging_events.py`
+
+- [ ] **Step 1: Write the test file**
+
+Create `tests/unit/drift/test_logging_events.py`:
+
+```python
+"""Regression guards for the log points added in cli/v1.8.0.
+
+Each test uses pytest's caplog fixture (which captures records
+regardless of stream or handler, so tests don't need configure_logging).
+These tests pin each log point's logger name, level, and key content,
+so future refactors that silently drop a log emission will fail.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+
+@pytest.fixture(autouse=True)
+def _propagate_gh_manage_logger():
+    """caplog captures records via the root logger. configure_logging
+    disables propagation on `gh_manage` to avoid duplicate output in
+    production. Re-enable propagation inside tests so caplog sees our
+    records.
+    """
+    gh_logger = logging.getLogger("gh_manage")
+    prev = gh_logger.propagate
+    gh_logger.propagate = True
+    yield
+    gh_logger.propagate = prev
+
+
+def _make_scan_context(tmp_path: Path):
+    from gh_manage.drift_sync import ScanContext
+    from gh_manage.models.labels import CategorySpec, LabelSpec, LabelsConfig
+    from gh_manage.models.profiles import ProfileSpec
+
+    labels_config = LabelsConfig(
+        version=1,
+        categories={
+            "sentinel": CategorySpec(
+                description="test category",
+                labels=[LabelSpec(name="sentinel", color="ffffff")],
+            ),
+        },
+    )
+    profile = ProfileSpec(
+        version=1,
+        name="python-service",
+        description="test",
+        files=[],
+        protection_policy=None,
+    )
+    return ScanContext(
+        path=tmp_path,
+        repo="yakkuro/sentinel-repo",
+        default_branch="main",
+        profile=profile,
+        labels_config=labels_config,
+        bp_config=None,
+    )
+
+
+def test_check_protection_warns_on_not_found(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """check_protection: GhNotFoundError fallback now emits WARNING
+    (spec §4 behavior change; new log line, unchanged findings)."""
+    from gh_manage.drift_sync import ScanContext
+    from gh_manage.drift_sync.checks import check_protection
+    from gh_manage.github_client import GhNotFoundError
+    from gh_manage.models.branch_protection import (
+        BranchProtectionConfig,
+        ProtectionPolicy,
+    )
+    from gh_manage.models.profiles import ProfileSpec
+    from gh_manage.models.labels import CategorySpec, LabelSpec, LabelsConfig
+
+    # Profile WITH a protection policy, so the code reaches the API call.
+    policy = ProtectionPolicy(
+        require_pull_request=True,
+        require_status_checks=True,
+        required_status_checks=["PR Gate / PR Gate"],
+        require_approvals=0,
+        dismiss_stale_reviews=False,
+        require_code_owner_reviews=False,
+        allow_force_pushes=False,
+        allow_deletions=False,
+        enforce_admins=False,
+    )
+    bp_config = BranchProtectionConfig(version=1, policies={"solo-default": policy})
+    profile = ProfileSpec(
+        version=1,
+        name="python-service",
+        description="test",
+        files=[],
+        protection_policy="solo-default",
+    )
+    labels_config = LabelsConfig(
+        version=1,
+        categories={
+            "sentinel": CategorySpec(
+                description="test",
+                labels=[LabelSpec(name="sentinel", color="ffffff")],
+            ),
+        },
+    )
+    ctx = ScanContext(
+        path=tmp_path,
+        repo="yakkuro/sentinel-repo",
+        default_branch="main",
+        profile=profile,
+        labels_config=labels_config,
+        bp_config=bp_config,
+    )
+
+    mocker.patch(
+        "gh_manage.drift_sync.checks.protection_api.get_branch_protection",
+        side_effect=GhNotFoundError("not found"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gh_manage.drift_sync.checks"):
+        check_protection(ctx)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "branch protection not configured" in r.getMessage() for r in warnings
+    ), f"expected WARNING about branch protection, got: {[r.getMessage() for r in warnings]}"
+
+
+def test_parse_zero_findings_warns_on_malformed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#62 HIGH #3 regression guard: malformed timestamps no longer
+    silently swallowed."""
+    from gh_manage.drift_sync.issue_state import parse_zero_findings_timestamps
+
+    comments = [
+        {"body": "<!-- scan:zero-findings:2026-04-19T09:00:00 -->"},
+        {"body": "<!-- scan:zero-findings:NOT_A_DATE -->"},
+    ]
+    with caplog.at_level(logging.WARNING, logger="gh_manage.drift_sync.issue_state"):
+        result = parse_zero_findings_timestamps(comments)
+
+    # Only the valid timestamp survives.
+    assert len(result) == 1
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARNING for the malformed timestamp"
+    assert "malformed" in warnings[0].getMessage().lower()
+    assert "NOT_A_DATE" in warnings[0].getMessage()
+
+
+def test_resolve_drift_issue_logs_created_event(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from gh_manage.drift_sync.issue_state import resolve_drift_issue
+    from gh_manage.findings import Finding
+
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue", return_value=None
+    )
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.create_issue", return_value={"number": 42}
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+
+    findings = (
+        Finding(
+            severity="high",
+            check="labels",
+            repo="yakkuro/sentinel",
+            field_path="labels[x]",
+            current_value=None,
+            desired_value="x",
+            message="missing",
+            remediation=None,
+        ),
+    )
+    with caplog.at_level(logging.INFO, logger="gh_manage.drift_sync.issue_state"):
+        resolve_drift_issue(findings, "yakkuro/sentinel", "2026-04-19T10:00:00")
+
+    msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    assert any("created drift issue #42" in m for m in msgs)
+
+
+def test_resolve_drift_issue_logs_updated_event(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from gh_manage.drift_sync.issue_state import resolve_drift_issue
+    from gh_manage.findings import Finding
+
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue",
+        return_value={"number": 99},
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.update_issue_body")
+    mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+
+    findings = (
+        Finding(
+            severity="medium",
+            check="labels",
+            repo="yakkuro/sentinel",
+            field_path="labels[y]",
+            current_value=None,
+            desired_value="y",
+            message="drifted",
+            remediation=None,
+        ),
+    )
+    with caplog.at_level(logging.INFO, logger="gh_manage.drift_sync.issue_state"):
+        resolve_drift_issue(findings, "yakkuro/sentinel", "2026-04-19T10:00:00")
+
+    msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    assert any("updated drift issue #99" in m for m in msgs)
+
+
+def test_resolve_drift_issue_logs_closed_event(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from gh_manage.drift_sync.issue_state import resolve_drift_issue
+
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue",
+        return_value={"number": 7},
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.update_issue_body")
+    mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.get_issue_comments",
+        return_value=[
+            {"body": "<!-- scan:zero-findings:2026-04-19T10:00:00 -->"},
+            {"body": "<!-- scan:zero-findings:2026-04-18T09:59:00 -->"},
+        ],
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.close_issue")
+
+    with caplog.at_level(logging.INFO, logger="gh_manage.drift_sync.issue_state"):
+        resolve_drift_issue((), "yakkuro/sentinel", "2026-04-19T10:00:00")
+
+    msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    assert any("closed drift issue #7" in m for m in msgs)
+
+
+def test_worker_logs_exception_with_traceback(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#62 HIGH #5 regression guard: unexpected exceptions in the
+    parallel worker now leave a traceback in the logs."""
+    from gh_manage.commands.drift import _worker
+    from gh_manage.models.repos import RepoEntry
+
+    mocker.patch(
+        "gh_manage.commands.drift._scan_single_repo",
+        side_effect=TypeError("sentinel"),
+    )
+    entry = RepoEntry(name="yakkuro/sentinel-repo", profile="python-service")
+
+    with caplog.at_level(logging.ERROR, logger="gh_manage.commands.drift"):
+        name, status, payload = _worker(entry)
+
+    assert name == "yakkuro/sentinel-repo"
+    assert status == "FAILED"
+    assert isinstance(payload, TypeError)
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert errors, "expected an ERROR record for the unexpected exception"
+    last = errors[-1]
+    assert last.name == "gh_manage.commands.drift"
+    assert last.exc_info is not None
+    assert last.exc_info[0] is TypeError
+
+
+def test_debug_events_hidden_at_warning_level(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """At default WARNING level, DEBUG events from registry/checks are
+    not captured. This is a floor sanity check; if it fails, every
+    `gh-manage drift .` invocation would spew debug output."""
+    from gh_manage.drift_sync import run_all_checks
+
+    mocker.patch(
+        "gh_manage.drift_sync.checks.labels_api.list_labels", return_value=[]
+    )
+    mocker.patch(
+        "gh_manage.drift_sync.checks.protection_api.get_branch_protection",
+        return_value={},
+    )
+
+    ctx = _make_scan_context(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="gh_manage.drift_sync"):
+        run_all_checks(ctx)
+
+    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    assert not debug_records, (
+        "DEBUG records were captured at WARNING level — logger config "
+        "is letting them through. Records: "
+        f"{[r.getMessage() for r in debug_records]}"
+    )
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+uv run pytest tests/unit/drift/test_logging_events.py -v 2>&1 | tail -15
+```
+
+Expected: 7 passed. If `_propagate_gh_manage_logger` isn't enough to get caplog to see records (some test runners require `-p logging`), inspect the first failing test's output — the fixture ensures `gh_manage`'s `propagate=False` (set by `configure_logging`) is flipped back on for the duration of each test.
+
+- [ ] **Step 3: Full verify**
+
+```bash
+uv run pytest -q 2>&1 | tail -3
+uvx ruff@0.8.0 check src/ tests/
+uv run mypy src/
+```
+
+Expected: 587 passed (572 + 8 logging_config + 7 logging_events), ruff clean, mypy clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/drift/test_logging_events.py
+git commit -m "$(cat <<'EOF'
+test(drift): 7 regression guards for logging event emission
+
+- test_check_protection_warns_on_not_found (§4 behavior change)
+- test_parse_zero_findings_warns_on_malformed (#62 HIGH #3 guard)
+- test_resolve_drift_issue_logs_created_event
+- test_resolve_drift_issue_logs_updated_event
+- test_resolve_drift_issue_logs_closed_event
+- test_worker_logs_exception_with_traceback (#62 HIGH #5 guard)
+- test_debug_events_hidden_at_warning_level
+
+All use caplog. Autouse fixture re-enables gh_manage logger propagation
+so caplog's root-level capture sees our records (configure_logging
+disables propagation in production to avoid third-party duplication).
+
+Refs #47 (Theme A item 6).
+EOF
+)"
+```
+
+---
+
+## Task 9: Integration verification + version bump
+
+**Files:**
+- Modify: `pyproject.toml` (version), `src/gh_manage/__init__.py`, `tests/test_sanity.py`, `uv.lock`.
+
+- [ ] **Step 1: Manual AC — default, debug, JSON modes**
+
+```bash
+# 1. Default: no log output (WARNING floor on clean repo). click.echo summary still prints.
+uv run gh-manage drift . --profile python-service 2> /tmp/default.stderr > /tmp/default.stdout
+grep -E "INFO|DEBUG|WARNING|ERROR" /tmp/default.stderr | head -5
+# Expected: possibly 1-2 WARNINGs (e.g., branch protection not configured on the
+# gh-manage repo itself). Zero INFO or DEBUG.
+
+# 2. --log-level info: INFO lines from scan lifecycle + issue state appear.
+uv run gh-manage --log-level info drift . --profile python-service 2>&1 | grep -E "INFO gh_manage" | head -5
+# Expected: at least 2 INFO lines (scanning ..., scan complete ...).
+
+# 3. --log-level debug: check-entry/exit DEBUG visible.
+uv run gh-manage --log-level debug drift . --profile python-service 2>&1 | grep -E "DEBUG.+registry" | head -6
+# Expected: 6 lines (3 checks × 2 debug logs).
+
+# 4. JSON mode: every log line parses as JSON.
+GH_MANAGE_LOG_JSON=1 uv run gh-manage --log-level info drift . --profile python-service 2>&1 | \
+  grep -E "^\{" | head -3 | jq . > /tmp/json-out
+cat /tmp/json-out
+# Expected: valid JSON records with keys: timestamp, level, name, message.
+```
+
+- [ ] **Step 2: Full-fleet scan — no unexpected errors, no regressions**
+
+```bash
+uv run gh-manage drift --all --concurrency 4 2>&1 | grep -E "scanned|FAILED" | tail -5
+```
+
+Expected: `22/22 scanned`, no FAILED. Logs from the parallel workers appear interleaved; that's fine.
+
+- [ ] **Step 3: Bump version**
+
+Use Edit to change these three strings:
+
+- `src/gh_manage/__init__.py`: `__version__ = "1.7.0"` → `"1.8.0"`
+- `pyproject.toml`: `version = "1.7.0"` → `"1.8.0"`
+- `tests/test_sanity.py`: `== "1.7.0"` → `== "1.8.0"`
+
+- [ ] **Step 4: Regenerate lockfile**
+
+```bash
+uv sync
+```
+
+- [ ] **Step 5: Full verify**
+
+```bash
+uv run pytest -q 2>&1 | tail -3
+uvx ruff@0.8.0 check src/ tests/
+uv run mypy src/
+```
+
+Expected: 587 passed (baseline + 15 new logging tests), clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gh_manage/__init__.py pyproject.toml tests/test_sanity.py uv.lock
+git commit -m "$(cat <<'EOF'
+chore(release): bump to cli/v1.8.0
+
+Adds structured logging to drift_sync/ + commands/drift.py with a
+hybrid plain/JSON format, a root Click --log-level option, and two
+fixes from #62 (HIGH #3 malformed-timestamp WARNING, HIGH #5
+unexpected-exception traceback).
+
+Additive: no public API removed, no existing output changed.
+
+Refs #47 (Theme A item 6), closes part of #62.
+EOF
+)"
+```
+
+---
+
+## Task 10: File 3 follow-up Issues
+
+**Files:** none (GitHub API only).
+
+- [ ] **Step 1: File follow-up Issue A — roll out logging to other commands**
+
+```bash
+gh issue create --title "Roll out structured logging to remaining gh-manage commands (apply/labels/protection/init/doctor)" --body "$(cat <<'EOF'
+Follow-up to cli/v1.8.0 (PR #NN — drift_sync logging). The logging infrastructure (`gh_manage.logging_config`, `--log-level` root option, `GH_MANAGE_LOG_JSON` env var) is in place; this issue tracks applying the same pattern to the remaining commands.
+
+## Scope
+
+Each command gets:
+- `log = logging.getLogger(__name__)` at module top
+- INFO around the entry/exit points (subcommand invoked, completed)
+- WARNING on guarded-but-unexpected branches (e.g., 404 fallbacks, skip-on-error)
+- ERROR / `log.exception` on catch-all branches
+- Caplog-based regression tests for each new log point
+
+## Commands
+
+- `gh_manage.commands.apply`
+- `gh_manage.commands.labels`
+- `gh_manage.commands.protection`
+- `gh_manage.commands.init`
+- `gh_manage.commands.doctor`
+- `gh_manage.commands.issues`
+
+## Out of scope
+
+- Logging in `github_client.py` / API wrappers — that layer should stay silent (HTTP noise would dominate) unless specifically useful.
+- New log levels or formats — reuse the cli/v1.8.0 infrastructure as-is.
+
+## Priority
+
+Low. cli/v1.8.0 already gives operators + agents what they need for the most fragile (drift) path. This is hygiene.
+EOF
+)"
+```
+
+- [ ] **Step 2: File follow-up Issue B — scan_id correlation**
+
+```bash
+gh issue create --title "Add scan_id correlation (UUID4) to drift_sync logs" --body "$(cat <<'EOF'
+Follow-up to cli/v1.8.0. When `drift --all` runs in parallel, records from different scans interleave on stderr. A per-scan UUID4 threaded via `LoggerAdapter` or `ContextVar` would let JSON consumers filter with `jq 'select(.scan_id == \"...\")'`.
+
+## Proposal
+
+- Generate UUID4 at the top of `_scan_single_repo` (one per repo).
+- Use `logging.LoggerAdapter` to inject `{"scan_id": "..."}` into every record's `extra` for the duration of the scan.
+- JSON formatter already propagates `extra` fields, so no config change.
+- Update caplog tests to assert `scan_id` is present on relevant records.
+
+## Out of scope
+
+- Correlation across other CLI commands (use Issue A's logging rollout once it lands).
+- Request IDs threaded through `github_api.*` — adds surface with no current consumer.
+
+## Priority
+
+Medium when fleet debugging becomes noisy. Currently 22 repos is tractable without IDs.
+EOF
+)"
+```
+
+- [ ] **Step 3: File follow-up Issue C — `--log-file` flag**
+
+```bash
+gh issue create --title "Add --log-file destination flag to gh-manage CLI" --body "$(cat <<'EOF'
+Follow-up to cli/v1.8.0. Currently logs go to stderr only. For long cron runs (daily `drift --all`), capturing to a file on disk would avoid losing records if the process is interrupted.
+
+## Proposal
+
+- Add `--log-file PATH` to the root click group, envvar `GH_MANAGE_LOG_FILE`.
+- When set, `configure_logging` attaches a `FileHandler` (in addition to the stderr handler, or as a replacement — decide during spec).
+- No rotation; users can handle that externally with logrotate / GitHub Actions artifacts.
+
+## Out of scope
+
+- Log rotation, size limits, retention policies — leave to external tools.
+- Dual output (stderr + file simultaneously) — maybe; decide during spec.
+
+## Priority
+
+Low. Stderr + GitHub Actions artifact capture currently covers the cron use case. File this as a capability gap, not a blocker.
+EOF
+)"
+```
+
+- [ ] **Step 4: Record the issue numbers for the PR body**
+
+Note down the 3 issue numbers emitted by the `gh issue create` commands. They'll be referenced in Task 11's PR body and release notes.
+
+---
+
+## Task 11: PR + 4-reviewer + merge + tag + release
+
+**Files:** none (orchestration).
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feat/drift-sync-logging
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat: drift_sync structured logging (cli/v1.8.0)" --body "$(cat <<'EOF'
+## Summary
+
+- Introduces `gh_manage.logging_config` + root `--log-level` option with hybrid plain/JSON format (`GH_MANAGE_LOG_JSON=1` switches to JSON).
+- 8 concrete log points across `drift_sync/registry.py`, `drift_sync/checks.py`, `drift_sync/issue_state.py`, `commands/drift.py`.
+- Resolves [#62](https://github.com/yakkuro/gh-manage/issues/62) HIGH #3 (malformed-timestamp WARNING) and HIGH #5 (unexpected-exception traceback).
+- Closes Theme A item 6 of [#47](https://github.com/yakkuro/gh-manage/issues/47).
+
+## One intentional behavior change
+
+`check_protection` currently swallows `GhNotFoundError` silently; it now emits a WARNING before the swallow. Returned findings + exit codes unchanged. Called out in spec §4 and §7 risks table.
+
+## New dep
+
+`python-json-logger>=2.0,<3.0` — single-module stdlib-compatible Formatter subclass.
+
+## Test plan
+
+- [x] `uv run pytest -q` — 587 passed (572 baseline + 15 new across 2 new files)
+- [x] `uvx ruff@0.8.0 check src/ tests/` — clean
+- [x] `uv run mypy src/` — clean
+- [x] Manual: default level produces no log output on clean repo (WARNING floor)
+- [x] Manual: `--log-level debug` shows check entry/exit DEBUGs
+- [x] Manual: `GH_MANAGE_LOG_JSON=1` produces valid JSON lines
+- [x] Manual: crafted malformed-timestamp comment triggers the new WARNING
+- [x] Manual: forced `TypeError` in `_scan_single_repo` reproduces `log.exception` with traceback
+- [x] `drift --all`: 22 repos scanned, 0 FAILED
+
+Spec: [`docs/specs/2026-04-19-drift-sync-logging-design.md`](docs/specs/2026-04-19-drift-sync-logging-design.md)
+Plan: [`docs/plans/2026-04-19-drift-sync-logging-plan.md`](docs/plans/2026-04-19-drift-sync-logging-plan.md)
+
+Follow-ups (Issues filed alongside this PR):
+- #{A}: Roll out logging to remaining commands
+- #{B}: Add scan_id correlation
+- #{C}: Add `--log-file` flag
+
+Refs #47, closes part of #62 (HIGH #3, HIGH #5).
+
+Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+Replace `#{A}`, `#{B}`, `#{C}` with the actual numbers from Task 10.
+
+- [ ] **Step 3: Wait for CI**
+
+```bash
+PR_NUM=$(gh pr view --json number -q .number)
+gh pr checks "$PR_NUM" --watch
+```
+
+- [ ] **Step 4: Dispatch 4-reviewer protocol in parallel**
+
+Per `workflow-review.md`, in ONE message with 4 tool calls:
+
+1. `bash /home/server160/repos/claude-dotfiles/scripts/codex-review-resilient.sh "..."` (background)
+2. `Agent(subagent_type="superpowers:code-reviewer")` — pass plan + spec paths
+3. `Agent(subagent_type="pr-review-toolkit:silent-failure-hunter")` — focus on catch-all + new log points not hiding new failures
+4. `Agent(subagent_type="code-reviewer", model="sonnet")` — diff size is moderate (~600 net LOC), sonnet fits
+
+- [ ] **Step 5: Triage**
+
+- CRITICAL/HIGH: fix and push, re-review.
+- MEDIUM: fix if cheap, document rationale otherwise.
+- LOW/nit: optional.
+
+- [ ] **Step 6: Merge + tag + release**
+
+```bash
+gh pr merge "$PR_NUM" --squash --delete-branch
+git checkout main && git pull
+git tag -a cli/v1.8.0 -m "cli/v1.8.0 — drift_sync structured logging"
+git push origin cli/v1.8.0
+gh release create cli/v1.8.0 --title "cli/v1.8.0 — drift_sync structured logging" --notes "$(cat <<'EOF'
+See [PR #NN](https://github.com/yakkuro/gh-manage/pull/NN) for full details.
+
+## Highlights
+
+- **New**: `--log-level {debug,info,warning,error}` root option (envvar `GH_MANAGE_LOG_LEVEL`, default `warning`).
+- **New**: `GH_MANAGE_LOG_JSON=1` switches log output to JSON lines (python-json-logger under the hood).
+- **New**: 8 log points in `drift_sync/` + `commands/drift.py` for scan lifecycle, malformed-timestamp warnings, and unexpected-exception tracebacks.
+- **Resolved**: [#62](https://github.com/yakkuro/gh-manage/issues/62) HIGH #3 (malformed timestamps no longer silently dropped) and HIGH #5 (parallel worker unexpected exceptions now leave full tracebacks in logs).
+- **Closes** Theme A item 6 from [#47](https://github.com/yakkuro/gh-manage/issues/47).
+
+## One intentional behavior change
+
+`check_protection` now emits a WARNING before its pre-existing `GhNotFoundError` → empty-protection fallback. Findings tuples and exit codes are unchanged; only log output differs.
+
+## Dependency change
+
+Adds `python-json-logger>=2.0,<3.0`.
+
+## Two-track versioning reminder
+
+`cli/v1.8.0` is a **CLI-track** tag. Reusable workflows stay on `v1.1.0`.
+
+## Follow-ups tracked
+
+- #{A}: Roll out logging to remaining commands
+- #{B}: Add scan_id correlation
+- #{C}: Add `--log-file` flag
+EOF
+)"
+```
+
+Replace `NN`, `#{A}/B/C` with actual numbers.
+
+- [ ] **Step 7: Comment on #47**
+
+```bash
+gh issue comment 47 --body "$(cat <<'EOF'
+**Theme A item 6 shipped**: [cli/v1.8.0](https://github.com/yakkuro/gh-manage/releases/tag/cli/v1.8.0) ([PR #NN](https://github.com/yakkuro/gh-manage/pull/NN)).
+
+Structured logging in place for `drift_sync/` + `commands/drift.py` with hybrid plain/JSON format. Two #62 HIGH items resolved inline (malformed-timestamp WARNING; unexpected-exception traceback via `log.exception`).
+
+Follow-up rollouts tracked separately: #{A} (other commands), #{B} (scan_id correlation), #{C} (--log-file flag).
+
+Theme A remaining items after this: item 5 (protection_sync split, parallel to item 4's drift_sync split).
+EOF
+)"
+```
+
+- [ ] **Step 8: Comment on #62**
+
+```bash
+gh issue comment 62 --body "$(cat <<'EOF'
+**HIGH #3 (malformed timestamp logging) and HIGH #5 (worker exception traceback) resolved** in cli/v1.8.0 ([PR #NN](https://github.com/yakkuro/gh-manage/pull/NN)).
+
+Remaining items in this issue: CRITICAL #1 (_CHECKS runtime assert), CRITICAL #2 (non-transactional issue sequence), HIGH #4 (_read_template_content error messages), MEDIUM #6 (fragile `next()`), MEDIUM #7 (formatter single-repo invariant), LOW #8/#9 (docstring + type polish).
+EOF
+)"
+```
+
+---
+
+## Rollback notes
+
+- Each of tasks 1-9 is a single commit. If a regression surfaces, revert from the most suspect commit and work backward; every intermediate commit is green individually.
+- `python-json-logger` is the only new dep. `uv sync` after a dependency revert regenerates `uv.lock`.
+- The intentional `check_protection` WARNING is easy to isolate: remove the `log.warning(...)` call and the `current = {}` assignment is untouched — no functional regression.

--- a/docs/specs/2026-04-19-drift-sync-logging-design.md
+++ b/docs/specs/2026-04-19-drift-sync-logging-design.md
@@ -210,16 +210,18 @@ The existing `click.echo` user-facing summary output is **not** touched. Logging
 
 ### 3.5 JSON output example
 
+`python-json-logger`'s `JsonFormatter` derives field names from the format string tokens: `%(asctime)s` → `asctime`, `%(levelname)s` → `levelname`, `%(name)s` → `name`, `%(message)s` → `message`. These are the actual keys in the emitted JSON; agent consumers filter on them directly.
+
 ```
 $ GH_MANAGE_LOG_JSON=1 gh-manage --log-level info drift yakkuro/llm-kb 2>&1 >/dev/null | jq .
-{"timestamp": "2026-04-19T10:23:00", "level": "INFO", "name": "gh_manage.commands.drift", "message": "scanning yakkuro/llm-kb (profile=python-service)"}
-{"timestamp": "2026-04-19T10:23:02", "level": "INFO", "name": "gh_manage.drift_sync.issue_state", "message": "updated drift issue #42 on yakkuro/llm-kb (5 findings)"}
+{"asctime": "2026-04-19T10:23:00", "levelname": "INFO", "name": "gh_manage.commands.drift", "message": "scanning yakkuro/llm-kb (profile=python-service)"}
+{"asctime": "2026-04-19T10:23:02", "levelname": "INFO", "name": "gh_manage.drift_sync.issue_state", "message": "updated drift issue #42 on yakkuro/llm-kb (5 findings)"}
 ```
 
 Agent queries enabled by JSON:
-- `jq 'select(.level=="ERROR") | .name + ": " + .message'`
+- `jq 'select(.levelname=="ERROR") | .name + ": " + .message'`
 - `jq 'select(.message | contains("yakkuro/llm-kb"))'`
-- Combined with `jq -s 'group_by(.level) | map({level: .[0].level, count: length})'` for severity buckets
+- Combined with `jq -s 'group_by(.levelname) | map({level: .[0].levelname, count: length})'` for severity buckets
 
 ## §4 — Deviation from "pure additive"
 

--- a/docs/specs/2026-04-19-drift-sync-logging-design.md
+++ b/docs/specs/2026-04-19-drift-sync-logging-design.md
@@ -1,0 +1,318 @@
+# drift_sync Structured Logging Design
+
+- **Date**: 2026-04-19
+- **Size**: Medium
+- **Sizing Rationale**: Greenfield logging infrastructure (no existing `logging` usage in `src/`) but limited scope (drift_sync/ + commands/drift.py). Introduces a new dep (`python-json-logger`), a new module (`gh_manage.logging_config`), a root Click option, ~8 log points across 4 modules, and 2 new test files. Not Small because a new dep + new root CLI option touch surfaces other than the files being modified. Not Large because no existing output is being migrated (drift_sync/ has zero `print`/`click.echo`) and all commands except `drift` are out of scope.
+- **Target**: `yakkuro/gh-manage`
+- **Goal**: Introduce standard-library `logging` to `drift_sync/` + `commands/drift.py` with a hybrid format (plain text for humans, JSON via env var for agents/cron), a root-group `--log-level` flag, and concrete log points that address [#62](https://github.com/yakkuro/gh-manage/issues/62) HIGH #3 (malformed-timestamp warning) and HIGH #5 (unexpected-exception traceback). Closes Theme A item 6 from [#47](https://github.com/yakkuro/gh-manage/issues/47).
+
+## Background
+
+`gh-manage` has zero `logging` usage in `src/` as of cli/v1.7.0. Developer-oriented signal currently has nowhere to go — warnings that don't warrant a user-facing error (malformed zero-findings timestamps, unexpected exceptions in parallel workers) are silently swallowed (`continue`) or surface as cryptic error strings stripped of their traceback. PR #61 reviewers flagged three such instances in [#62](https://github.com/yakkuro/gh-manage/issues/62); the HIGH items #3 and #5 are the minimal set a structured-logging rollout can fix at the same time as establishing the infrastructure.
+
+The cli/v1.7.0 `drift_sync` split ([PR #61](https://github.com/yakkuro/gh-manage/pull/61)) separated 6 concerns into dedicated submodules, which is the prerequisite for module-scoped loggers: `logging.getLogger(__name__)` yields `gh_manage.drift_sync.checks`, `gh_manage.drift_sync.issue_state`, etc., making log filtering by concern trivial.
+
+User intent (2026-04-19 brainstorming): "logging は正直エージェントに探索しやすいフォーマットが望ましい" — the primary consumers of logs are (a) humans running `gh-manage drift .` locally and (b) Claude Code agents investigating cron failures. A hybrid format satisfies both without forcing JSON on humans tailing stderr.
+
+## Goals
+
+1. Stand up a minimal, correct `logging` configuration module (`gh_manage.logging_config`) that the CLI entry point invokes once, before any subcommand runs.
+2. Emit concrete log events at appropriate levels from every `drift_sync/` submodule and from `commands/drift.py`, including the #62 HIGH #3/#5 fixes.
+3. Support both plain-text (default) and JSON (opt-in via `GH_MANAGE_LOG_JSON=1`) output on stderr with no runtime-reading format branches in log call sites.
+4. Preserve all existing `click.echo`/`click.secho` user-facing output unchanged (logging is additive, not a migration).
+5. New regression tests covering (a) the configuration module, (b) each new log point, (c) the format-switch env var.
+
+## Non-goals
+
+- **Logging rollout to other commands** (`apply`, `labels`, `protection`, `init`, `doctor`). Tracked separately — see §9 Follow-ups.
+- **Scan correlation (`scan_id` UUID threaded via `LoggerAdapter`)**. YAGNI for single-repo scans; `--all` parallelism interleaves output but `repo` already appears in `_scan_single_repo` messages. Tracked separately.
+- **`--log-file` destination flag**. stderr is sufficient; users can redirect. Tracked separately.
+- **Migration of existing `click.echo` calls to logging**. Those are user-facing UI output, not logs. They stay.
+- **#62's non-scope-A items** (CRITICAL #1/#2, HIGH #4, MEDIUM #6/#7). Still tracked in #62.
+- **Log rotation, log aggregation, Slack/Grafana integration**. Out of scope; the env-var hook makes future JSON consumers straightforward.
+- **`structlog` as the implementation**. `python-json-logger` is smaller, tighter stdlib interop, and doesn't require rewriting log call sites with `log.bind(...)`-style API.
+
+## §1 — Architecture
+
+### 1.1 Module layout
+
+```
+src/gh_manage/
+├── logging_config.py         # NEW — ~60 LOC
+├── cli.py                    # MODIFY — root group option, call configure_logging()
+├── drift_sync/
+│   ├── checks.py             # MODIFY — add log points
+│   ├── issue_state.py        # MODIFY — add log points (incl. #62 HIGH #3)
+│   ├── registry.py           # MODIFY — add log points
+│   └── ... (context, adapters, formatters unchanged)
+└── commands/
+    └── drift.py              # MODIFY — add log points (incl. #62 HIGH #5)
+```
+
+### 1.2 Configuration flow
+
+```
+gh-manage [--log-level X] <subcommand> [...]
+    └── cli.py:main group callback
+         └── configure_logging(level=X_or_default, json=bool(GH_MANAGE_LOG_JSON))
+              ├── handler = logging.StreamHandler(sys.stderr)
+              ├── formatter = JsonFormatter(...) if json else logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+              ├── root_logger = logging.getLogger("gh_manage")
+              ├── root_logger.setLevel(level); root_logger.addHandler(handler)
+              └── (idempotent — safe to call multiple times)
+
+Each module: log = logging.getLogger(__name__)
+    → gh_manage.drift_sync.checks
+    → gh_manage.drift_sync.issue_state
+    → gh_manage.commands.drift
+```
+
+Only the `gh_manage` root is configured — third-party libraries (`click`, `pydantic`, `httpx`, etc.) keep their own loggers untouched. No `logging.basicConfig()` call is made (that would affect every package).
+
+### 1.3 New dependency
+
+`python-json-logger` added to `[project].dependencies` in `pyproject.toml`. Rationale: small (~2kLOC pure Python), stdlib-compatible (`JsonFormatter` is a drop-in `logging.Formatter` subclass), and doesn't require call-site changes (contrast with `structlog` which wants `log.bind(event="x", repo=y)` throughout).
+
+## §2 — Configuration contract
+
+### 2.1 `configure_logging(level, json=False)` signature
+
+```python
+# src/gh_manage/logging_config.py
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Literal
+
+LogLevel = Literal["debug", "info", "warning", "error"]
+_LOG_LEVELS: dict[LogLevel, int] = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+}
+
+
+def configure_logging(
+    level: LogLevel = "warning",
+    json: bool | None = None,
+) -> None:
+    """Configure gh_manage's root logger. Idempotent.
+
+    - level: log level for the `gh_manage` logger tree. Third-party
+      packages' loggers are untouched.
+    - json: if True, emit JSON-line records via python-json-logger.
+      If None (default), read GH_MANAGE_LOG_JSON env var (truthy → JSON).
+      Cron / agent workflows set GH_MANAGE_LOG_JSON=1; humans don't.
+
+    Side effect: clears existing handlers on the `gh_manage` logger and
+    replaces them with a single stderr StreamHandler. Callers should
+    invoke this exactly once, at CLI entry.
+    """
+```
+
+**Idempotency**: called at CLI entry, the function clears any prior handlers attached to the `gh_manage` logger and adds a single fresh one. This avoids duplicate output if the function is somehow called twice (e.g., a test harness that invokes the CLI group callback).
+
+**Format strings** (frozen):
+- Plain: `"%(asctime)s %(levelname)s %(name)s: %(message)s"` with `datefmt="%Y-%m-%d %H:%M:%S"`.
+- JSON: `pythonjsonlogger.jsonlogger.JsonFormatter` configured to include `timestamp`, `level`, `name`, `message`, plus any extra fields passed via `log.info("msg", extra={"repo": "..."})`.
+
+### 2.2 CLI integration
+
+```python
+# src/gh_manage/cli.py (shape sketch)
+@click.group()
+@click.option(
+    "--log-level",
+    type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
+    envvar="GH_MANAGE_LOG_LEVEL",
+    default="warning",
+    show_default=True,
+    help="Logging verbosity for gh_manage modules.",
+)
+@click.pass_context
+def main(ctx: click.Context, log_level: str) -> None:
+    """..."""
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging(level=log_level.lower())  # type: ignore[arg-type]
+```
+
+Env-var precedence: Click's `envvar=` gives `GH_MANAGE_LOG_LEVEL` automatic fallback if `--log-level` is not passed. `GH_MANAGE_LOG_JSON` is read inside `configure_logging` directly (simpler than a separate flag for now).
+
+Defaults matrix:
+
+| Invocation | Effective level | Format |
+|---|---|---|
+| `gh-manage drift .` | WARNING | plain |
+| `gh-manage --log-level info drift .` | INFO | plain |
+| `GH_MANAGE_LOG_LEVEL=debug gh-manage drift .` | DEBUG | plain |
+| `GH_MANAGE_LOG_JSON=1 gh-manage drift .` | WARNING | JSON |
+| `GH_MANAGE_LOG_JSON=1 gh-manage --log-level info drift .` | INFO | JSON |
+
+## §3 — Log points
+
+All log calls use `log = logging.getLogger(__name__)` at module top. Concrete events:
+
+### 3.1 `drift_sync/registry.py`
+
+| Level | When | Example (plain) |
+|---|---|---|
+| DEBUG | Each check entry | `2026-04-19 10:23:00 DEBUG gh_manage.drift_sync.registry: running check: check_labels` |
+| DEBUG | Each check exit w/ count | `DEBUG gh_manage.drift_sync.registry: check_labels returned 2 findings` |
+
+No WARN+ here — registry orchestration is expected to succeed or propagate.
+
+### 3.2 `drift_sync/checks.py`
+
+| Level | When | Example |
+|---|---|---|
+| DEBUG | `check_labels` calls `labels_api.list_labels(repo)` | `DEBUG gh_manage.drift_sync.checks: fetching labels for yakkuro/llm-kb` |
+| WARNING | `check_protection` catches `GhNotFoundError` → treats as empty | `WARNING gh_manage.drift_sync.checks: branch protection not configured on yakkuro/llm-kb@main; treating as empty` (new behavior — previously silent via `except GhNotFoundError: current = {}`) |
+| ERROR | `_read_template_content` raises `DriftError` | `ERROR gh_manage.drift_sync.checks: failed to read bundled template 'ci/python-ci.yml'` (emitted alongside the existing `raise DriftError(...)` — caller still sees the exception) |
+
+Note: the WARNING in `check_protection` is a **behavior addition** — it surfaces a previously-silent 404 as a warning. This is a minimal deviation from "no behavior change" but is the explicit point of the logging rollout. The findings produced are unchanged.
+
+### 3.3 `drift_sync/issue_state.py`
+
+| Level | When | Example |
+|---|---|---|
+| WARNING | **#62 HIGH #3 FIX**: `parse_zero_findings_timestamps` catches `ValueError` | `WARNING gh_manage.drift_sync.issue_state: malformed zero-findings timestamp 'abc123ZZZ' skipped: Invalid isoformat string` |
+| INFO | `resolve_drift_issue` creates new issue | `INFO gh_manage.drift_sync.issue_state: created drift issue #42 on yakkuro/llm-kb (5 findings)` |
+| INFO | `resolve_drift_issue` updates existing | `INFO gh_manage.drift_sync.issue_state: updated drift issue #42 on yakkuro/llm-kb (5 findings)` |
+| INFO | `resolve_drift_issue` auto-closes | `INFO gh_manage.drift_sync.issue_state: closed drift issue #42 on yakkuro/llm-kb (24h zero-drift rule)` |
+
+### 3.4 `commands/drift.py`
+
+| Level | When | Example |
+|---|---|---|
+| INFO | `_scan_single_repo` start | `INFO gh_manage.commands.drift: scanning yakkuro/llm-kb (profile=python-service)` |
+| INFO | `_scan_single_repo` complete | `INFO gh_manage.commands.drift: scan complete for yakkuro/llm-kb: 5 findings (1 high, 3 medium, 1 low)` |
+| ERROR | **#62 HIGH #5 FIX**: `_worker` catch-all branch | `log.exception("unexpected error scanning %s", entry.name)` — emits full traceback at ERROR |
+
+The existing `click.echo` user-facing summary output is **not** touched. Logging sits alongside it.
+
+### 3.5 JSON output example
+
+```
+$ GH_MANAGE_LOG_JSON=1 gh-manage --log-level info drift yakkuro/llm-kb 2>&1 >/dev/null | jq .
+{"timestamp": "2026-04-19T10:23:00", "level": "INFO", "name": "gh_manage.commands.drift", "message": "scanning yakkuro/llm-kb (profile=python-service)"}
+{"timestamp": "2026-04-19T10:23:02", "level": "INFO", "name": "gh_manage.drift_sync.issue_state", "message": "updated drift issue #42 on yakkuro/llm-kb (5 findings)"}
+```
+
+Agent queries enabled by JSON:
+- `jq 'select(.level=="ERROR") | .name + ": " + .message'`
+- `jq 'select(.message | contains("yakkuro/llm-kb"))'`
+- Combined with `jq -s 'group_by(.level) | map({level: .[0].level, count: length})'` for severity buckets
+
+## §4 — Deviation from "pure additive"
+
+**One behavior change, intentional**: `check_protection` currently swallows `GhNotFoundError` silently (`except GhNotFoundError: current = {}`). After this change, it emits a WARNING log before the swallow. The returned findings and exit code are unchanged; only the log output differs.
+
+All other log points are genuinely additive — they sit alongside existing code without altering control flow.
+
+This is called out explicitly so reviewers don't flag it as "scope creep". It's the smallest possible behavior change that makes the GhNotFoundError path debuggable; leaving it silent defeats the purpose of adding logging in the first place.
+
+## §5 — Testing strategy
+
+### 5.1 New test files
+
+**`tests/unit/test_logging_config.py`** (new, ~70 LOC):
+
+- `test_configure_logging_default_level_is_warning`: after calling `configure_logging()`, `logging.getLogger("gh_manage").level == WARNING`.
+- `test_configure_logging_sets_explicit_level`: `configure_logging(level="info")` → INFO.
+- `test_configure_logging_plain_formatter_by_default`: formatter class is `logging.Formatter`.
+- `test_configure_logging_json_via_env`: `GH_MANAGE_LOG_JSON=1` + `configure_logging()` → formatter class is `pythonjsonlogger.jsonlogger.JsonFormatter`.
+- `test_configure_logging_json_explicit_arg`: `configure_logging(json=True)` → JSON regardless of env var.
+- `test_configure_logging_idempotent`: call twice, assert exactly one handler on the `gh_manage` logger.
+- `test_configure_logging_does_not_affect_third_party_loggers`: `logging.getLogger("click").handlers` unchanged; `logging.getLogger("gh_manage.drift_sync").handlers` inherits from `gh_manage`.
+
+**`tests/unit/drift/test_logging_events.py`** (new, ~90 LOC):
+
+Each uses pytest's `caplog` fixture. Tests:
+- `test_check_protection_warns_on_not_found`: mock `protection_api.get_branch_protection` to raise `GhNotFoundError`; assert `WARNING` record at `gh_manage.drift_sync.checks` with `"branch protection not configured"` in message.
+- `test_parse_zero_findings_warns_on_malformed`: pass a comment with `<!-- scan:zero-findings:NOT_A_DATE -->`; assert `WARNING` at `gh_manage.drift_sync.issue_state`. **This is the #62 HIGH #3 regression guard.**
+- `test_resolve_drift_issue_logs_created_event`: mock `issues_api.create_issue` → assert `INFO` record with `"created drift issue"`.
+- `test_resolve_drift_issue_logs_updated_event`: similar.
+- `test_resolve_drift_issue_logs_closed_event`: similar, include the 24h-rule stubbing.
+- `test_worker_logs_exception_with_traceback`: force `_scan_single_repo` to raise `TypeError`; assert `_worker` emits `log.exception` at ERROR with traceback captured (use `caplog.records[-1].exc_info is not None`). **This is the #62 HIGH #5 regression guard.**
+- `test_debug_events_hidden_at_warning_level`: `configure_logging(level="warning")`, run `check_labels` against empty mock, assert no DEBUG records were propagated (verify default quiet behavior).
+
+### 5.2 Integration verification
+
+After implementation:
+- `gh-manage drift .` emits nothing at default level (WARNING floor, no WARNs from a clean repo).
+- `gh-manage --log-level info drift .` emits the INFO `scan complete ...` line on stderr.
+- `GH_MANAGE_LOG_JSON=1 gh-manage drift . 2>&1 >/dev/null | head -1 | jq .` returns valid JSON.
+- `gh-manage drift --all 2>&1 | grep -c ERROR` returns 0 on a clean cron.
+
+### 5.3 Existing suite impact
+
+No existing test modifications required. caplog's default propagation behavior means tests that don't check log output are unaffected.
+
+## §6 — Release plan
+
+- **Tag**: `cli/v1.8.0` — CLI-track minor. Additive (new dep, new CLI option, new log output). No public API removed, no test mock paths changed, no existing output migrated.
+- **Release notes** call out: new dep, new `--log-level` option + env vars, JSON opt-in, #62 HIGH #3/#5 resolved.
+- **Cron workflow update (separate PR, not this one)**: the daily drift scan reusable workflow (`.github/workflows/reusable-pr-gate.yml`?) should set `GH_MANAGE_LOG_JSON=1` and `GH_MANAGE_LOG_LEVEL=info` so the next cron's logs are structured. Tracked as a follow-up — this spec only ships the CLI capability.
+
+## §7 — Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| `configure_logging` called before `sys.stderr` is fully initialized (edge case in testing harness) | StreamHandler binds to wrong stream | Accept `stream` parameter defaulting to `sys.stderr`; unit tests can pass a StringIO. |
+| `python-json-logger` maintenance lapse | New dep becomes stale | Minor risk — package is stable, last update 2025, low surface area. Pin to `>=2.0,<3.0` initially. |
+| Library consumers (not applicable yet) importing `gh_manage.drift_sync` and inheriting our logger config | Pollution of their log setup | We only configure `gh_manage` logger tree, not root. Library consumers calling into our code will see our `gh_manage.*` loggers propagate to their root — standard Python behavior. If they configure a root handler, output appears there; if not, our handler is silent (only fires when `configure_logging` is called by the CLI entry). |
+| Behavior change in `check_protection` (silent 404 → WARNING) surprises a test | Test fails | Search for existing tests that assert log silence; none exist. caplog + expected-warning tests will cover. |
+| Log output on stderr interferes with tests that capture stderr | Test output noise | pytest caplog captures at the logger level, not via stderr capture, so normal test stderr capture is unaffected. |
+| `_worker`'s broad `except Exception` + new `log.exception` duplicates output | Console spam on parallel failures | `log.exception` + the `FAILED ({exc})` user-facing summary are complementary (log is detailed, summary is compact). Accept the minor duplication. |
+
+## §8 — Acceptance Criteria
+
+- [ ] `src/gh_manage/logging_config.py` exists, ≤100 LOC, with the signature from §2.1.
+- [ ] `pyproject.toml` adds `python-json-logger` to `[project].dependencies`; `uv sync` regenerates `uv.lock`.
+- [ ] `cli.py`'s root group accepts `--log-level` with `envvar="GH_MANAGE_LOG_LEVEL"` and default `"warning"`.
+- [ ] Each `drift_sync/` submodule and `commands/drift.py` has `log = logging.getLogger(__name__)` at module top.
+- [ ] The 8 log points from §3 are emitted at the specified levels.
+- [ ] `uv run pytest -q` passes — baseline + ~14 new tests across 2 new files.
+- [ ] `uvx ruff@0.8.0 check src/ tests/` clean.
+- [ ] `uv run mypy src/` clean.
+- [ ] Manual: `gh-manage drift .` produces no log output (WARNING floor on a clean local repo).
+- [ ] Manual: `gh-manage --log-level debug drift .` emits DEBUG lines for each check entry/exit.
+- [ ] Manual: `GH_MANAGE_LOG_JSON=1 gh-manage drift . 2>&1 >/dev/null | jq .` returns valid JSON for every line.
+- [ ] Manual: crafting an Issue comment with a malformed `<!-- scan:zero-findings:XXX -->` and running scan emits the WARNING (#62 HIGH #3).
+- [ ] Manual: forcing a `TypeError` in `_scan_single_repo` via a deliberate bug reproduces `log.exception` with full traceback on stderr (#62 HIGH #5).
+- [ ] Version bumped to `1.8.0` across `__init__.py`, `pyproject.toml`, `test_sanity.py`, `uv.lock`.
+- [ ] PR open, 4-reviewer protocol clean, merged, `cli/v1.8.0` tagged + released.
+- [ ] 3 follow-up Issues filed: (a) other-commands logging, (b) scan_id correlation, (c) `--log-file` flag.
+
+## §9 — Follow-ups (out of scope, filed as separate Issues)
+
+Before this spec is marked done:
+- **Issue A**: "Roll out structured logging to remaining gh-manage commands" — apply/labels/protection/init/doctor. Pattern is set by cli/v1.8.0; follow-up is mechanical.
+- **Issue B**: "Add scan_id correlation to drift_sync logs" — `LoggerAdapter` or `ContextVar` thread of a UUID4 through the scan, visible in every log record's `extra`. Enables per-scan log filtering in JSON mode.
+- **Issue C**: "Add `--log-file` flag to gh-manage CLI" — write logs to a file instead of (or in addition to) stderr. Useful for long cron runs.
+
+After this spec ships:
+- **Cron workflow update**: set `GH_MANAGE_LOG_JSON=1` and `GH_MANAGE_LOG_LEVEL=info` in the daily `drift --all` cron so cron run artifacts are structured. Separate consumer-side PR.
+
+## §10 — Open Questions
+
+None. Design decisions resolved during 2026-04-19 brainstorming:
+- Scope: drift_sync/ + commands/drift.py only (per user).
+- Format: hybrid (plain default, JSON via `GH_MANAGE_LOG_JSON` env var).
+- Level config: `--log-level` Click option + `GH_MANAGE_LOG_LEVEL` env var; default `WARNING`.
+- Dep: `python-json-logger` (rejected `structlog` as over-engineered for this scope).
+- `check_protection` GhNotFoundError WARNING: intentional behavior addition, flagged in §4.
+- scan_id correlation, `--log-file`, other-commands rollout: all deferred to follow-up Issues.
+
+## References
+
+- Theme A umbrella: [`#47`](https://github.com/yakkuro/gh-manage/issues/47) (item 6 = this spec).
+- Follow-up to drift_sync split: [`#61`](https://github.com/yakkuro/gh-manage/pull/61) / [`cli/v1.7.0`](https://github.com/yakkuro/gh-manage/releases/tag/cli/v1.7.0).
+- Pre-existing error-handling Issue: [`#62`](https://github.com/yakkuro/gh-manage/issues/62) (this spec resolves HIGH #3 and HIGH #5).
+- `python-json-logger`: https://github.com/madzak/python-json-logger
+- Current `drift_sync.py` tree: `src/gh_manage/drift_sync/{checks,issue_state,registry}.py` at `b6a5047` on main.
+- Current CLI entry: `src/gh_manage/cli.py`.

--- a/docs/specs/2026-04-19-drift-sync-logging-design.md
+++ b/docs/specs/2026-04-19-drift-sync-logging-design.md
@@ -84,7 +84,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from typing import Literal
+from typing import IO, Literal
 
 LogLevel = Literal["debug", "info", "warning", "error"]
 _LOG_LEVELS: dict[LogLevel, int] = {
@@ -98,6 +98,7 @@ _LOG_LEVELS: dict[LogLevel, int] = {
 def configure_logging(
     level: LogLevel = "warning",
     json: bool | None = None,
+    stream: IO[str] | None = None,
 ) -> None:
     """Configure gh_manage's root logger. Idempotent.
 
@@ -106,18 +107,21 @@ def configure_logging(
     - json: if True, emit JSON-line records via python-json-logger.
       If None (default), read GH_MANAGE_LOG_JSON env var (truthy → JSON).
       Cron / agent workflows set GH_MANAGE_LOG_JSON=1; humans don't.
+    - stream: destination for log output. Defaults to sys.stderr.
+      Overridable so unit tests can capture via StringIO without
+      touching real stderr (addresses spec-critique HIGH 1).
 
     Side effect: clears existing handlers on the `gh_manage` logger and
-    replaces them with a single stderr StreamHandler. Callers should
-    invoke this exactly once, at CLI entry.
+    replaces them with a single StreamHandler bound to `stream`.
+    Callers should invoke this exactly once, at CLI entry.
     """
 ```
 
-**Idempotency**: called at CLI entry, the function clears any prior handlers attached to the `gh_manage` logger and adds a single fresh one. This avoids duplicate output if the function is somehow called twice (e.g., a test harness that invokes the CLI group callback).
-
 **Format strings** (frozen):
 - Plain: `"%(asctime)s %(levelname)s %(name)s: %(message)s"` with `datefmt="%Y-%m-%d %H:%M:%S"`.
-- JSON: `pythonjsonlogger.jsonlogger.JsonFormatter` configured to include `timestamp`, `level`, `name`, `message`, plus any extra fields passed via `log.info("msg", extra={"repo": "..."})`.
+- JSON: `pythonjsonlogger.jsonlogger.JsonFormatter` with explicit `datefmt="%Y-%m-%dT%H:%M:%S"` and format string `"%(asctime)s %(levelname)s %(name)s %(message)s"` so the JSON output contains `timestamp`, `level`, `name`, `message` fields plus any `extra={...}` passed by callers. ISO-8601 without microseconds for jq/grep stability (addresses spec-critique MEDIUM #3).
+
+**Idempotency**: called at CLI entry, the function clears any prior handlers attached to the `gh_manage` logger and adds a single fresh one. This avoids duplicate output if the function is somehow called twice (e.g., a test harness that invokes the CLI group callback).
 
 ### 2.2 CLI integration
 
@@ -209,11 +213,11 @@ Agent queries enabled by JSON:
 
 ## §4 — Deviation from "pure additive"
 
-**One behavior change, intentional**: `check_protection` currently swallows `GhNotFoundError` silently (`except GhNotFoundError: current = {}`). After this change, it emits a WARNING log before the swallow. The returned findings and exit code are unchanged; only the log output differs.
+**One intentional behavior change**: `check_protection` currently swallows `GhNotFoundError` silently (`except GhNotFoundError: current = {}`). After this change, it emits a WARNING log before the swallow. The returned findings and exit code are unchanged; only the log output differs.
 
 All other log points are genuinely additive — they sit alongside existing code without altering control flow.
 
-This is called out explicitly so reviewers don't flag it as "scope creep". It's the smallest possible behavior change that makes the GhNotFoundError path debuggable; leaving it silent defeats the purpose of adding logging in the first place.
+Full rationale + risk mitigation in [§7](#7--risks--mitigations) under "Behavior change in `check_protection`".
 
 ## §5 — Testing strategy
 
@@ -237,7 +241,7 @@ Each uses pytest's `caplog` fixture. Tests:
 - `test_resolve_drift_issue_logs_created_event`: mock `issues_api.create_issue` → assert `INFO` record with `"created drift issue"`.
 - `test_resolve_drift_issue_logs_updated_event`: similar.
 - `test_resolve_drift_issue_logs_closed_event`: similar, include the 24h-rule stubbing.
-- `test_worker_logs_exception_with_traceback`: force `_scan_single_repo` to raise `TypeError`; assert `_worker` emits `log.exception` at ERROR with traceback captured (use `caplog.records[-1].exc_info is not None`). **This is the #62 HIGH #5 regression guard.**
+- `test_worker_logs_exception_with_traceback`: patch `gh_manage.commands.drift._scan_single_repo` with `mocker.patch(..., side_effect=TypeError("sentinel"))`; invoke `_worker` directly with a stub `RepoEntry`; assert `caplog.records[-1].levelno == logging.ERROR`, `caplog.records[-1].name == "gh_manage.commands.drift"`, `caplog.records[-1].exc_info is not None`, and `caplog.records[-1].exc_info[0] is TypeError`. **This is the #62 HIGH #5 regression guard.**
 - `test_debug_events_hidden_at_warning_level`: `configure_logging(level="warning")`, run `check_labels` against empty mock, assert no DEBUG records were propagated (verify default quiet behavior).
 
 ### 5.2 Integration verification
@@ -262,10 +266,10 @@ No existing test modifications required. caplog's default propagation behavior m
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| `configure_logging` called before `sys.stderr` is fully initialized (edge case in testing harness) | StreamHandler binds to wrong stream | Accept `stream` parameter defaulting to `sys.stderr`; unit tests can pass a StringIO. |
+| `configure_logging` called before `sys.stderr` is fully initialized (edge case in testing harness) | StreamHandler binds to wrong stream | `configure_logging` accepts a `stream` parameter (default `None` → `sys.stderr` resolved at call time). Unit tests pass a `StringIO`; the signature is part of the contract (§2.1). |
 | `python-json-logger` maintenance lapse | New dep becomes stale | Minor risk — package is stable, last update 2025, low surface area. Pin to `>=2.0,<3.0` initially. |
 | Library consumers (not applicable yet) importing `gh_manage.drift_sync` and inheriting our logger config | Pollution of their log setup | We only configure `gh_manage` logger tree, not root. Library consumers calling into our code will see our `gh_manage.*` loggers propagate to their root — standard Python behavior. If they configure a root handler, output appears there; if not, our handler is silent (only fires when `configure_logging` is called by the CLI entry). |
-| Behavior change in `check_protection` (silent 404 → WARNING) surprises a test | Test fails | Search for existing tests that assert log silence; none exist. caplog + expected-warning tests will cover. |
+| **Behavior change in `check_protection`** (silent 404 → WARNING) surprises a test | Test fails, or users perceive "scope creep" | **Justification**: swallowing `GhNotFoundError` silently defeats the entire point of adding logging — the path that most warrants operational visibility (branch protection absent on a repo we expect it on) is exactly where drift_sync previously emitted no signal. The change is strictly log-side: findings, returned tuples, and exit codes are unchanged. **Coverage**: `test_check_protection_warns_on_not_found` (§5.1) asserts the WARNING; no existing tests assert log silence on this path (verified by grep). **Scope**: this is the ONLY behavior change in the PR; all other logging is additive. Called out in §4 so reviewers can accept it upfront. |
 | Log output on stderr interferes with tests that capture stderr | Test output noise | pytest caplog captures at the logger level, not via stderr capture, so normal test stderr capture is unaffected. |
 | `_worker`'s broad `except Exception` + new `log.exception` duplicates output | Console spam on parallel failures | `log.exception` + the `FAILED ({exc})` user-facing summary are complementary (log is detailed, summary is compact). Accept the minor duplication. |
 

--- a/docs/specs/2026-04-19-drift-sync-logging-design.md
+++ b/docs/specs/2026-04-19-drift-sync-logging-design.md
@@ -104,16 +104,26 @@ def configure_logging(
 
     - level: log level for the `gh_manage` logger tree. Third-party
       packages' loggers are untouched.
-    - json: if True, emit JSON-line records via python-json-logger.
-      If None (default), read GH_MANAGE_LOG_JSON env var (truthy → JSON).
-      Cron / agent workflows set GH_MANAGE_LOG_JSON=1; humans don't.
+    - json: tri-state. Precedence: explicit `json=True/False` wins
+      over env var. If `json is None` (default), read
+      `GH_MANAGE_LOG_JSON` env var; truthy values ("1", "true", "yes",
+      case-insensitive) → JSON, everything else → plain. No env var +
+      no explicit arg → plain.
     - stream: destination for log output. Defaults to sys.stderr.
-      Overridable so unit tests can capture via StringIO without
-      touching real stderr (addresses spec-critique HIGH 1).
+      Production callers (cli.py) should omit this argument. Unit
+      tests pass a StringIO to capture output without touching real
+      stderr (addresses spec-critique round 1 HIGH).
 
     Side effect: clears existing handlers on the `gh_manage` logger and
     replaces them with a single StreamHandler bound to `stream`.
     Callers should invoke this exactly once, at CLI entry.
+
+    Immutability: the plain and JSON formatter strings (including
+    datefmt) are fixed by this module — not runtime-configurable.
+    Changing them requires editing logging_config.py, so `caplog`-based
+    tests can rely on the record shape. This is intentional: runtime
+    format customization would bloat the contract without real user
+    demand (addresses spec-critique round 2 MEDIUM #2).
     """
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
     "click>=8.1,<9",
     "pydantic>=2.5,<3",
+    "python-json-logger>=2.0,<3",
     "pyyaml>=6.0,<7",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gh-manage"
-version = "1.7.0"
+version = "1.8.0"
 description = "GitHub-based CI/CD, Issue management, and operational system for yakkuro/* repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gh_manage/__init__.py
+++ b/src/gh_manage/__init__.py
@@ -1,3 +1,3 @@
 """gh-manage: GitHub-based CI/CD, Issue management, and operational system."""
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"

--- a/src/gh_manage/cli.py
+++ b/src/gh_manage/cli.py
@@ -14,6 +14,7 @@ from gh_manage.commands import (
     labels as labels_cmd,
     protection as protection_cmd,
 )
+from gh_manage.logging_config import LogLevel, configure_logging
 
 
 @click.group(
@@ -24,8 +25,21 @@ from gh_manage.commands import (
     ),
 )
 @click.version_option(version=__version__, prog_name="gh-manage")
-def main() -> None:
+@click.option(
+    "--log-level",
+    type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
+    envvar="GH_MANAGE_LOG_LEVEL",
+    default="warning",
+    show_default=True,
+    help=(
+        "Logging verbosity for gh_manage modules. Also honours "
+        "GH_MANAGE_LOG_LEVEL. For JSON output, set GH_MANAGE_LOG_JSON=1."
+    ),
+)
+def main(log_level: str) -> None:
     """Root command group. Subcommands are registered below."""
+    level: LogLevel = log_level.lower()  # type: ignore[assignment]
+    configure_logging(level=level)
 
 
 main.add_command(init_cmd.init)

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -41,6 +41,7 @@ from gh_manage.github_client import GhError
 from gh_manage.models.branch_protection import BranchProtectionConfig
 from gh_manage.models.labels import LabelsConfig
 from gh_manage.models.profiles import ProfileSpec
+from gh_manage.models.repos import RepoEntry
 from gh_manage.profile_sync import ProfileError
 from gh_manage.protection_sync import ProtectionError
 
@@ -149,6 +150,59 @@ def _scan_single_repo(
             raise ValueError(f"Unknown report mode: {report_mode!r}")
 
 
+def _scan_worker(
+    entry: RepoEntry,
+    severity: str,
+    report_mode: str,
+    output: Path | None,
+) -> tuple[str, str, str | Exception]:
+    """Scan one repo for --all mode. Returns (name, status, payload_or_exc).
+
+    The broad `except Exception` fallback is intentional for parallel
+    isolation (spec §2): one repo's failure — even from an unexpected
+    exception type like OSError on tempdir creation — must NOT abort
+    the whole --all run. Domain exceptions are caught first for
+    specific error messages; anything else is caught and materialized
+    as FAILED so `future.result()` never raises.
+
+    Module-level (not a closure) so tests can invoke the real production
+    function directly without replicating its shape inline.
+    """
+    try:
+        result_str = _scan_single_repo(
+            entry.name,
+            entry.profile,
+            severity,
+            report_mode,
+            output,
+            skip_profile_check=True,
+        )
+        return (entry.name, "OK", result_str)
+    except (
+        GhError,
+        ConfigError,
+        GitError,
+        ProfileError,
+        ProtectionError,
+        DriftError,
+    ) as e:
+        log.warning(
+            "expected error scanning %s (%s): %s",
+            entry.name,
+            type(e).__name__,
+            e,
+        )
+        return (entry.name, "FAILED", e)
+    except Exception as e:  # noqa: BLE001 — parallel isolation, spec §2
+        log.exception(
+            "unexpected error scanning %s (%s: %s)",
+            entry.name,
+            type(e).__name__,
+            e,
+        )
+        return (entry.name, "FAILED", e)
+
+
 def _scan_all_repos(
     severity: str,
     report_mode: str,
@@ -164,7 +218,7 @@ def _scan_all_repos(
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    from gh_manage.models.repos import RepoEntry, ReposConfig
+    from gh_manage.models.repos import ReposConfig
 
     repos_path = resolve_repos_path()
     config = load_config(repos_path, ReposConfig)
@@ -180,44 +234,6 @@ def _scan_all_repos(
     for e in disabled_entries:
         per_repo_results[e.name] = f"  {e.name}: SKIPPED (disabled)"
 
-    def _worker(entry: RepoEntry) -> tuple[str, str, str | Exception]:
-        """Scan one repo. Returns (name, status, payload_or_exc).
-
-        The broad `except Exception` fallback is intentional for parallel
-        isolation (spec §2): one repo's failure — even from an unexpected
-        exception type like OSError on tempdir creation — must NOT abort
-        the whole --all run. Domain exceptions are caught first for
-        specific error messages; anything else is caught and materialized
-        as FAILED so `future.result()` never raises.
-        """
-        try:
-            result_str = _scan_single_repo(
-                entry.name,
-                entry.profile,
-                severity,
-                report_mode,
-                output,
-                skip_profile_check=True,
-            )
-            return (entry.name, "OK", result_str)
-        except (
-            GhError,
-            ConfigError,
-            GitError,
-            ProfileError,
-            ProtectionError,
-            DriftError,
-        ) as e:
-            return (entry.name, "FAILED", e)
-        except Exception as e:  # noqa: BLE001 — parallel isolation, spec §2
-            log.exception(
-                "unexpected error scanning %s (%s: %s)",
-                entry.name,
-                type(e).__name__,
-                e,
-            )
-            return (entry.name, "FAILED", e)
-
     if enabled_entries and concurrency > 1:
         click.echo(
             f"[drift --all] {len(enabled_entries)} repos, concurrency={concurrency}",
@@ -225,7 +241,10 @@ def _scan_all_repos(
         )
 
     with ThreadPoolExecutor(max_workers=concurrency) as pool:
-        future_to_entry = {pool.submit(_worker, e): e for e in enabled_entries}
+        future_to_entry = {
+            pool.submit(_scan_worker, e, severity, report_mode, output): e
+            for e in enabled_entries
+        }
         completed = 0
         for future in as_completed(future_to_entry):
             name, status, payload = future.result()

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -13,6 +13,7 @@ Architecture:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import click
@@ -43,6 +44,8 @@ from gh_manage.models.profiles import ProfileSpec
 from gh_manage.profile_sync import ProfileError
 from gh_manage.protection_sync import ProtectionError
 
+log = logging.getLogger(__name__)
+
 
 def _scan_single_repo(
     owner_repo: str,
@@ -66,6 +69,7 @@ def _scan_single_repo(
     Returns:
         Status/result string for the repo.
     """
+    log.info("scanning %s (profile=%s)", owner_repo, profile_name)
     # Get default branch
     default_branch = repo_info.get_default_branch(owner_repo)
 
@@ -110,6 +114,7 @@ def _scan_single_repo(
     )
 
     all_findings = drift_sync.run_all_checks(ctx)
+    log.info("scan complete for %s: %d findings", owner_repo, len(all_findings))
     filtered = drift_sync._filter_by_severity(all_findings, severity)  # type: ignore[arg-type]
 
     match report_mode:
@@ -205,6 +210,12 @@ def _scan_all_repos(
         ) as e:
             return (entry.name, "FAILED", e)
         except Exception as e:  # noqa: BLE001 — parallel isolation, spec §2
+            log.exception(
+                "unexpected error scanning %s (%s: %s)",
+                entry.name,
+                type(e).__name__,
+                e,
+            )
             return (entry.name, "FAILED", e)
 
     if enabled_entries and concurrency > 1:

--- a/src/gh_manage/drift_sync/checks.py
+++ b/src/gh_manage/drift_sync/checks.py
@@ -15,6 +15,7 @@ with unittest.mock.patch affects every caller. See spec §4 Option P1.
 from __future__ import annotations
 
 import hashlib
+import logging
 from importlib.resources import files as _package_files
 from pathlib import Path
 
@@ -30,6 +31,8 @@ from gh_manage.github_api import protection as protection_api
 from gh_manage.github_client import GhNotFoundError
 from gh_manage.labels_sync import compute_diff as _compute_labels_diff
 from gh_manage.protection_sync import compute_protection_diff
+
+log = logging.getLogger(__name__)
 
 
 @register_check
@@ -48,6 +51,7 @@ def check_labels(ctx: ScanContext) -> tuple[Finding, ...]:
     can see extras, and the adapter marks them low-severity with no
     remediation command.
     """
+    log.debug("fetching labels for %s", ctx.repo)
     current = labels_api.list_labels(ctx.repo)
     diff = _compute_labels_diff(current, ctx.labels_config, prune=True)
     return _labels_diff_to_findings(diff, ctx.repo)
@@ -80,6 +84,11 @@ def check_protection(ctx: ScanContext) -> tuple[Finding, ...]:
     try:
         current = protection_api.get_branch_protection(ctx.repo, ctx.default_branch)
     except GhNotFoundError:
+        log.warning(
+            "branch protection not configured on %s@%s; treating as empty",
+            ctx.repo,
+            ctx.default_branch,
+        )
         current = {}
 
     diff = compute_protection_diff(current, policy, ctx.profile, ctx.default_branch)
@@ -98,6 +107,9 @@ def _read_template_content(source: str) -> str:
     try:
         return template_path.read_text(encoding="utf-8")
     except OSError as e:
+        log.error(
+            "failed to read bundled template %r at %s: %s", source, template_path, e
+        )
         raise DriftError(
             f"Cannot read bundled template {source!r} at {template_path}: {e}. "
             f"This may indicate a packaging bug — the template should be "

--- a/src/gh_manage/drift_sync/issue_state.py
+++ b/src/gh_manage/drift_sync/issue_state.py
@@ -7,6 +7,7 @@ Top of the drift_sync DAG.
 
 from __future__ import annotations
 
+import logging
 import re as _re
 from datetime import datetime, timedelta
 from typing import Any
@@ -14,6 +15,8 @@ from typing import Any
 from gh_manage.drift_sync.formatters import format_issue_body, format_issue_comment
 from gh_manage.findings import Finding
 from gh_manage.github_api import issues as issues_api
+
+log = logging.getLogger(__name__)
 
 _ZERO_FINDINGS_RE = _re.compile(r"<!-- scan:zero-findings:(\S+) -->")
 
@@ -25,7 +28,7 @@ def parse_zero_findings_timestamps(
 
     Returns a list of datetime objects (newest first, matching the
     comment order from get_issue_comments which returns newest first).
-    Malformed timestamps are silently skipped.
+    Malformed timestamps are logged at WARNING and skipped.
     """
     timestamps: list[datetime] = []
     for comment in comments:
@@ -35,8 +38,12 @@ def parse_zero_findings_timestamps(
             try:
                 ts = datetime.fromisoformat(match.group(1))
                 timestamps.append(ts)
-            except ValueError:
-                # Malformed timestamp — skip
+            except ValueError as e:
+                log.warning(
+                    "malformed zero-findings timestamp %r skipped: %s",
+                    match.group(1),
+                    e,
+                )
                 continue
     return timestamps
 
@@ -85,6 +92,12 @@ def resolve_drift_issue(
         title = _DRIFT_ISSUE_TITLE_TEMPLATE.format(repo=repo)
         issue = issues_api.create_issue(repo, title, body, [_DRIFT_LABEL])
         issues_api.add_issue_comment(repo, issue["number"], comment)
+        log.info(
+            "created drift issue #%d on %s (%d findings)",
+            issue["number"],
+            repo,
+            len(findings),
+        )
         return f"Created issue #{issue['number']} on {repo} ({len(findings)} findings)"
 
     issue_number = existing["number"]
@@ -107,6 +120,17 @@ def resolve_drift_issue(
                 f"Zero drift detected on 2 consecutive scans ≥24h apart. "
                 f"If drift recurs, a new Issue will be created.",
             )
+            log.info(
+                "closed drift issue #%d on %s (24h zero-drift rule)",
+                issue_number,
+                repo,
+            )
             return f"Closed issue #{issue_number} on {repo} (zero drift, 24h rule satisfied)"
 
+    log.info(
+        "updated drift issue #%d on %s (%d findings)",
+        issue_number,
+        repo,
+        len(findings),
+    )
     return f"Updated issue #{issue_number} on {repo} ({len(findings)} findings)"

--- a/src/gh_manage/drift_sync/registry.py
+++ b/src/gh_manage/drift_sync/registry.py
@@ -12,11 +12,13 @@ imported by __init__.py for the check to be registered.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
-from itertools import chain
 
 from gh_manage.drift_sync.context import ScanContext
 from gh_manage.findings import Finding, Severity
+
+log = logging.getLogger(__name__)
 
 CheckFn = Callable[["ScanContext"], tuple[Finding, ...]]
 _CHECKS: list[CheckFn] = []
@@ -46,7 +48,13 @@ def run_all_checks(ctx: ScanContext) -> tuple[Finding, ...]:
     further checks run. MVP does not have a --continue-on-error flag;
     that is filed as a Phase 8.5+ Issue.
     """
-    return tuple(chain.from_iterable(check(ctx) for check in _CHECKS))
+    all_findings: list[Finding] = []
+    for check in _CHECKS:
+        log.debug("running check: %s", check.__name__)
+        findings = check(ctx)
+        log.debug("check %s returned %d findings", check.__name__, len(findings))
+        all_findings.extend(findings)
+    return tuple(all_findings)
 
 
 _SEVERITY_RANK = {"critical": 3, "high": 2, "medium": 1, "low": 0}

--- a/src/gh_manage/logging_config.py
+++ b/src/gh_manage/logging_config.py
@@ -1,0 +1,94 @@
+"""Central logging configuration for gh_manage.
+
+Invoked once from cli.py's root group callback. Configures only the
+`gh_manage` logger tree — third-party packages' loggers (click,
+pydantic, httpx, etc.) are left alone. Output goes to stderr by
+default; tests pass a StringIO via the `stream` argument.
+
+Format is selected at configuration time and cannot be changed at
+runtime. This keeps the caplog record shape stable for tests. To
+change a format, edit this module.
+
+See docs/specs/2026-04-19-drift-sync-logging-design.md §2.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import IO, Literal
+
+from pythonjsonlogger.jsonlogger import JsonFormatter
+
+LogLevel = Literal["debug", "info", "warning", "error"]
+
+_LOG_LEVELS: dict[str, int] = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+}
+
+_PLAIN_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+_PLAIN_DATEFMT = "%Y-%m-%d %H:%M:%S"
+_JSON_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
+_JSON_DATEFMT = "%Y-%m-%dT%H:%M:%S"
+
+_TRUTHY = {"1", "true", "yes"}
+
+
+def _env_says_json() -> bool:
+    raw = os.environ.get("GH_MANAGE_LOG_JSON", "").strip().lower()
+    return raw in _TRUTHY
+
+
+def configure_logging(
+    level: LogLevel = "warning",
+    json: bool | None = None,
+    stream: IO[str] | None = None,
+) -> None:
+    """Configure gh_manage's root logger tree. Idempotent.
+
+    - level: log level for the `gh_manage` logger tree. Third-party
+      packages' loggers are untouched.
+    - json: tri-state. Precedence: explicit `json=True/False` wins
+      over env var. If `json is None` (default), read
+      `GH_MANAGE_LOG_JSON` env var; truthy values ("1", "true", "yes",
+      case-insensitive) → JSON, everything else → plain.
+    - stream: destination for log output. Defaults to sys.stderr.
+      Production callers (cli.py) should omit this argument. Unit
+      tests pass a StringIO to capture output without touching real
+      stderr.
+
+    Side effect: clears existing handlers on the `gh_manage` logger and
+    replaces them with a single StreamHandler bound to `stream`.
+    Callers should invoke this exactly once, at CLI entry.
+
+    Immutability: the plain and JSON formatter strings (including
+    datefmt) are fixed by this module — not runtime-configurable.
+    Changing them requires editing logging_config.py, so caplog-based
+    tests can rely on the record shape.
+    """
+    if json is None:
+        json = _env_says_json()
+
+    if stream is None:
+        stream = sys.stderr
+
+    formatter: logging.Formatter
+    if json:
+        formatter = JsonFormatter(_JSON_FORMAT, datefmt=_JSON_DATEFMT)
+    else:
+        formatter = logging.Formatter(_PLAIN_FORMAT, datefmt=_PLAIN_DATEFMT)
+
+    handler = logging.StreamHandler(stream=stream)
+    handler.setFormatter(formatter)
+
+    gh_logger = logging.getLogger("gh_manage")
+    # Drop prior handlers so repeat calls (idempotent contract) don't stack.
+    gh_logger.handlers[:] = [handler]
+    gh_logger.setLevel(_LOG_LEVELS[level])
+    # Don't propagate to root — otherwise a user who configures a root
+    # handler for third-party logs would see our records duplicated.
+    gh_logger.propagate = False

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -8,7 +8,7 @@ import gh_manage
 def test_package_version_is_defined() -> None:
     assert hasattr(gh_manage, "__version__")
     assert isinstance(gh_manage.__version__, str)
-    assert gh_manage.__version__ == "1.7.0"
+    assert gh_manage.__version__ == "1.8.0"
 
 
 def test_cli_module_is_importable() -> None:

--- a/tests/unit/drift/test_logging_events.py
+++ b/tests/unit/drift/test_logging_events.py
@@ -1,0 +1,338 @@
+"""Regression guards for the log points added in cli/v1.8.0.
+
+Each test uses pytest's caplog fixture (which captures records
+regardless of stream or handler, so tests don't need configure_logging).
+These tests pin each log point's logger name, level, and key content,
+so future refactors that silently drop a log emission will fail.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+
+@pytest.fixture(autouse=True)
+def _propagate_gh_manage_logger():
+    """caplog captures records via the root logger. configure_logging
+    disables propagation on `gh_manage` to avoid duplicate output in
+    production. Re-enable propagation inside tests so caplog sees our
+    records.
+    """
+    gh_logger = logging.getLogger("gh_manage")
+    prev = gh_logger.propagate
+    gh_logger.propagate = True
+    yield
+    gh_logger.propagate = prev
+
+
+def _make_scan_context(tmp_path: Path):
+    from gh_manage.drift_sync import ScanContext
+    from gh_manage.models.labels import CategorySpec, LabelSpec, LabelsConfig
+    from gh_manage.models.profiles import ProfileSpec
+
+    labels_config = LabelsConfig(
+        version=1,
+        categories={
+            "sentinel": CategorySpec(
+                description="test category",
+                labels=[LabelSpec(name="sentinel", color="ffffff")],
+            ),
+        },
+    )
+    profile = ProfileSpec(
+        version=1,
+        name="python-service",
+        description="test",
+        files=[],
+        protection_policy=None,
+    )
+    return ScanContext(
+        path=tmp_path,
+        repo="yakkuro/sentinel-repo",
+        default_branch="main",
+        profile=profile,
+        labels_config=labels_config,
+        bp_config=None,
+    )
+
+
+def test_check_protection_warns_on_not_found(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """check_protection: GhNotFoundError fallback now emits WARNING
+    (spec §4 behavior change; new log line, unchanged findings)."""
+    from gh_manage.drift_sync import ScanContext
+    from gh_manage.drift_sync.checks import check_protection
+    from gh_manage.github_client import GhNotFoundError
+    from gh_manage.models.branch_protection import (
+        BranchProtectionConfig,
+        PolicySpec,
+        RequiredStatusChecks,
+    )
+    from gh_manage.models.labels import CategorySpec, LabelSpec, LabelsConfig
+    from gh_manage.models.profiles import ProfileSpec
+
+    # Profile WITH a protection policy, so the code reaches the API call.
+    policy = PolicySpec(
+        description="solo default",
+        target_branches=["main"],
+        required_status_checks=RequiredStatusChecks(
+            strict=True, contexts=["PR Gate / PR Gate"]
+        ),
+        enforce_admins=False,
+        required_pull_request_reviews=None,
+        required_conversation_resolution=False,
+        required_linear_history=False,
+        allow_force_pushes=False,
+        allow_deletions=False,
+    )
+    bp_config = BranchProtectionConfig(version=1, policies={"solo-default": policy})
+    profile = ProfileSpec(
+        version=1,
+        name="python-service",
+        description="test",
+        files=[],
+        protection_policy="solo-default",
+    )
+    labels_config = LabelsConfig(
+        version=1,
+        categories={
+            "sentinel": CategorySpec(
+                description="test",
+                labels=[LabelSpec(name="sentinel", color="ffffff")],
+            ),
+        },
+    )
+    ctx = ScanContext(
+        path=tmp_path,
+        repo="yakkuro/sentinel-repo",
+        default_branch="main",
+        profile=profile,
+        labels_config=labels_config,
+        bp_config=bp_config,
+    )
+
+    mocker.patch(
+        "gh_manage.drift_sync.checks.protection_api.get_branch_protection",
+        side_effect=GhNotFoundError("not found"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="gh_manage.drift_sync.checks"):
+        check_protection(ctx)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "branch protection not configured" in r.getMessage() for r in warnings
+    ), f"expected WARNING about branch protection, got: {[r.getMessage() for r in warnings]}"
+
+
+def test_parse_zero_findings_warns_on_malformed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#62 HIGH #3 regression guard: malformed timestamps no longer
+    silently swallowed."""
+    from gh_manage.drift_sync.issue_state import parse_zero_findings_timestamps
+
+    comments = [
+        {"body": "<!-- scan:zero-findings:2026-04-19T09:00:00 -->"},
+        {"body": "<!-- scan:zero-findings:NOT_A_DATE -->"},
+    ]
+    with caplog.at_level(logging.WARNING, logger="gh_manage.drift_sync.issue_state"):
+        result = parse_zero_findings_timestamps(comments)
+
+    # Only the valid timestamp survives.
+    assert len(result) == 1
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARNING for the malformed timestamp"
+    assert "malformed" in warnings[0].getMessage().lower()
+    assert "NOT_A_DATE" in warnings[0].getMessage()
+
+
+def test_resolve_drift_issue_logs_created_event(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from gh_manage.drift_sync.issue_state import resolve_drift_issue
+    from gh_manage.findings import Finding
+
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue", return_value=None
+    )
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.create_issue", return_value={"number": 42}
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+
+    findings = (
+        Finding(
+            severity="high",
+            check="labels",
+            repo="yakkuro/sentinel",
+            field_path="labels[x]",
+            current_value=None,
+            desired_value="x",
+            message="missing",
+            remediation=None,
+        ),
+    )
+    with caplog.at_level(logging.INFO, logger="gh_manage.drift_sync.issue_state"):
+        resolve_drift_issue(findings, "yakkuro/sentinel", "2026-04-19T10:00:00")
+
+    msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    assert any("created drift issue #42" in m for m in msgs)
+
+
+def test_resolve_drift_issue_logs_updated_event(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from gh_manage.drift_sync.issue_state import resolve_drift_issue
+    from gh_manage.findings import Finding
+
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue",
+        return_value={"number": 99},
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.update_issue_body")
+    mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+
+    findings = (
+        Finding(
+            severity="medium",
+            check="labels",
+            repo="yakkuro/sentinel",
+            field_path="labels[y]",
+            current_value=None,
+            desired_value="y",
+            message="drifted",
+            remediation=None,
+        ),
+    )
+    with caplog.at_level(logging.INFO, logger="gh_manage.drift_sync.issue_state"):
+        resolve_drift_issue(findings, "yakkuro/sentinel", "2026-04-19T10:00:00")
+
+    msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    assert any("updated drift issue #99" in m for m in msgs)
+
+
+def test_resolve_drift_issue_logs_closed_event(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from gh_manage.drift_sync.issue_state import resolve_drift_issue
+
+    mocker.patch("gh_manage.drift_sync.issues_api.ensure_drift_label")
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.search_drift_issue",
+        return_value={"number": 7},
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.update_issue_body")
+    mocker.patch("gh_manage.drift_sync.issues_api.add_issue_comment")
+    mocker.patch(
+        "gh_manage.drift_sync.issues_api.get_issue_comments",
+        return_value=[
+            {"body": "<!-- scan:zero-findings:2026-04-19T10:00:00 -->"},
+            {"body": "<!-- scan:zero-findings:2026-04-18T09:59:00 -->"},
+        ],
+    )
+    mocker.patch("gh_manage.drift_sync.issues_api.close_issue")
+
+    with caplog.at_level(logging.INFO, logger="gh_manage.drift_sync.issue_state"):
+        resolve_drift_issue((), "yakkuro/sentinel", "2026-04-19T10:00:00")
+
+    msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+    assert any("closed drift issue #7" in m for m in msgs)
+
+
+def test_worker_logs_exception_with_traceback(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#62 HIGH #5 regression guard: unexpected exceptions in the
+    parallel worker now leave a traceback in the logs."""
+    import gh_manage.commands.drift as drift_cmd
+    from gh_manage.models.repos import RepoEntry
+
+    mocker.patch.object(
+        drift_cmd,
+        "_scan_single_repo",
+        side_effect=TypeError("sentinel"),
+    )
+
+    # _worker is defined inside `drift` command body and closes over
+    # severity/report_mode/output. We construct a minimal callable by
+    # invoking the same code path: the commands/drift._worker replica
+    # here mirrors the production shape for test isolation.
+    def _worker(entry: RepoEntry) -> tuple[str, str, str | Exception]:
+        try:
+            result_str = drift_cmd._scan_single_repo(
+                entry.name,
+                entry.profile,
+                "low",
+                "stdout",
+                None,
+                skip_profile_check=True,
+            )
+            return (entry.name, "OK", result_str)
+        except Exception as exc:  # noqa: BLE001
+            drift_cmd.log.exception(
+                "unexpected error scanning %s (%s: %s)",
+                entry.name,
+                type(exc).__name__,
+                exc,
+            )
+            return (entry.name, "FAILED", exc)
+
+    entry = RepoEntry(name="yakkuro/sentinel-repo", profile="python-service")
+
+    with caplog.at_level(logging.ERROR, logger="gh_manage.commands.drift"):
+        name, status, payload = _worker(entry)
+
+    assert name == "yakkuro/sentinel-repo"
+    assert status == "FAILED"
+    assert isinstance(payload, TypeError)
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert errors, "expected an ERROR record for the unexpected exception"
+    last = errors[-1]
+    assert last.name == "gh_manage.commands.drift"
+    assert last.exc_info is not None
+    assert last.exc_info[0] is TypeError
+
+
+def test_debug_events_hidden_at_warning_level(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
+    """At default WARNING level, DEBUG events from registry/checks are
+    not captured. This is a floor sanity check; if it fails, every
+    `gh-manage drift .` invocation would spew debug output."""
+    from gh_manage.drift_sync import run_all_checks
+
+    mocker.patch("gh_manage.drift_sync.checks.labels_api.list_labels", return_value=[])
+    mocker.patch(
+        "gh_manage.drift_sync.checks.protection_api.get_branch_protection",
+        return_value={},
+    )
+
+    ctx = _make_scan_context(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="gh_manage.drift_sync"):
+        run_all_checks(ctx)
+
+    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    assert not debug_records, (
+        "DEBUG records were captured at WARNING level — logger config "
+        "is letting them through. Records: "
+        f"{[r.getMessage() for r in debug_records]}"
+    )

--- a/tests/unit/drift/test_logging_events.py
+++ b/tests/unit/drift/test_logging_events.py
@@ -258,7 +258,12 @@ def test_worker_logs_exception_with_traceback(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """#62 HIGH #5 regression guard: unexpected exceptions in the
-    parallel worker now leave a traceback in the logs."""
+    parallel worker now leave a traceback in the logs.
+
+    Tests the actual module-level `_scan_worker` (not a test replica),
+    so removal or regression of the production log.exception call will
+    fail this test (addresses Codex review MEDIUM #1).
+    """
     import gh_manage.commands.drift as drift_cmd
     from gh_manage.models.repos import RepoEntry
 
@@ -268,34 +273,10 @@ def test_worker_logs_exception_with_traceback(
         side_effect=TypeError("sentinel"),
     )
 
-    # _worker is defined inside `drift` command body and closes over
-    # severity/report_mode/output. We construct a minimal callable by
-    # invoking the same code path: the commands/drift._worker replica
-    # here mirrors the production shape for test isolation.
-    def _worker(entry: RepoEntry) -> tuple[str, str, str | Exception]:
-        try:
-            result_str = drift_cmd._scan_single_repo(
-                entry.name,
-                entry.profile,
-                "low",
-                "stdout",
-                None,
-                skip_profile_check=True,
-            )
-            return (entry.name, "OK", result_str)
-        except Exception as exc:  # noqa: BLE001
-            drift_cmd.log.exception(
-                "unexpected error scanning %s (%s: %s)",
-                entry.name,
-                type(exc).__name__,
-                exc,
-            )
-            return (entry.name, "FAILED", exc)
-
     entry = RepoEntry(name="yakkuro/sentinel-repo", profile="python-service")
 
     with caplog.at_level(logging.ERROR, logger="gh_manage.commands.drift"):
-        name, status, payload = _worker(entry)
+        name, status, payload = drift_cmd._scan_worker(entry, "low", "stdout", None)
 
     assert name == "yakkuro/sentinel-repo"
     assert status == "FAILED"
@@ -311,13 +292,20 @@ def test_worker_logs_exception_with_traceback(
 
 def test_debug_events_hidden_at_warning_level(
     mocker: MockerFixture,
-    caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:
-    """At default WARNING level, DEBUG events from registry/checks are
-    not captured. This is a floor sanity check; if it fails, every
-    `gh-manage drift .` invocation would spew debug output."""
+    """Default configure_logging() level (WARNING) suppresses DEBUG
+    emissions at the logger itself, before any handler sees them. If
+    configure_logging's default is broken to DEBUG, this test fails.
+
+    Drives the actual production configuration (addresses Codex review
+    MEDIUM #2: the previous version used caplog.at_level to force
+    WARNING, making the test tautological).
+    """
+    import io
+
     from gh_manage.drift_sync import run_all_checks
+    from gh_manage.logging_config import configure_logging
 
     mocker.patch("gh_manage.drift_sync.checks.labels_api.list_labels", return_value=[])
     mocker.patch(
@@ -327,12 +315,15 @@ def test_debug_events_hidden_at_warning_level(
 
     ctx = _make_scan_context(tmp_path)
 
-    with caplog.at_level(logging.WARNING, logger="gh_manage.drift_sync"):
-        run_all_checks(ctx)
+    # Call configure_logging WITHOUT a level arg so the defaulting path
+    # is exercised; writes to a StringIO so we can inspect emitted text.
+    buf = io.StringIO()
+    configure_logging(stream=buf)  # default level="warning"
 
-    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
-    assert not debug_records, (
-        "DEBUG records were captured at WARNING level — logger config "
-        "is letting them through. Records: "
-        f"{[r.getMessage() for r in debug_records]}"
+    run_all_checks(ctx)
+
+    emitted = buf.getvalue()
+    assert "DEBUG" not in emitted, (
+        "DEBUG line reached the configured handler — configure_logging's "
+        f"default level is not filtering them. Output:\n{emitted}"
     )

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -102,3 +102,18 @@ def test_configure_logging_does_not_add_handler_to_root_logger() -> None:
     assert (
         root_handlers_before == root_handlers_after
     ), "configure_logging must not touch the root logger — only the `gh_manage` tree."
+
+
+def test_configure_logging_sets_propagate_false() -> None:
+    """configure_logging must set gh_manage.propagate = False to prevent
+    duplicate output when a caller also configures a root handler.
+
+    This is a separate assertion from the root-handler test above because
+    a logger can have no root handler yet still propagate records up
+    through the logging tree — testing both is necessary to fully lock
+    down the isolation contract (addresses Codex review LOW).
+    """
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging()
+    assert logging.getLogger("gh_manage").propagate is False

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,104 @@
+"""Tests for gh_manage.logging_config.
+
+All tests clean up the `gh_manage` logger's handler state after each run
+so tests don't interfere with each other or with pytest's own logger.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_gh_manage_logger():
+    """Save/restore the gh_manage logger state around each test."""
+    gh_logger = logging.getLogger("gh_manage")
+    saved_handlers = list(gh_logger.handlers)
+    saved_level = gh_logger.level
+    saved_propagate = gh_logger.propagate
+    yield
+    gh_logger.handlers[:] = saved_handlers
+    gh_logger.setLevel(saved_level)
+    gh_logger.propagate = saved_propagate
+
+
+def test_configure_logging_default_level_is_warning() -> None:
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging()
+    assert logging.getLogger("gh_manage").level == logging.WARNING
+
+
+def test_configure_logging_sets_explicit_level() -> None:
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging(level="info")
+    assert logging.getLogger("gh_manage").level == logging.INFO
+
+
+def test_configure_logging_plain_formatter_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GH_MANAGE_LOG_JSON", raising=False)
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging()
+    handler = logging.getLogger("gh_manage").handlers[0]
+    # Plain-text formatter is the stdlib class, not JsonFormatter.
+    assert type(handler.formatter).__name__ == "Formatter"
+
+
+def test_configure_logging_json_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_MANAGE_LOG_JSON", "1")
+    from gh_manage.logging_config import configure_logging
+    from pythonjsonlogger.jsonlogger import JsonFormatter
+
+    configure_logging()
+    handler = logging.getLogger("gh_manage").handlers[0]
+    assert isinstance(handler.formatter, JsonFormatter)
+
+
+def test_configure_logging_json_explicit_arg_overrides_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env says yes; explicit arg says no. Explicit wins."""
+    monkeypatch.setenv("GH_MANAGE_LOG_JSON", "1")
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging(json=False)
+    handler = logging.getLogger("gh_manage").handlers[0]
+    assert type(handler.formatter).__name__ == "Formatter"
+
+
+def test_configure_logging_idempotent() -> None:
+    from gh_manage.logging_config import configure_logging
+
+    configure_logging(level="info")
+    configure_logging(level="debug")
+    gh_logger = logging.getLogger("gh_manage")
+    assert len(gh_logger.handlers) == 1
+    assert gh_logger.level == logging.DEBUG
+
+
+def test_configure_logging_writes_to_stream_argument() -> None:
+    """Stream override is how unit tests isolate from real stderr."""
+    from gh_manage.logging_config import configure_logging
+
+    buf = io.StringIO()
+    configure_logging(level="info", stream=buf)
+    logging.getLogger("gh_manage.test").info("sentinel-msg-xyz")
+    assert "sentinel-msg-xyz" in buf.getvalue()
+
+
+def test_configure_logging_does_not_add_handler_to_root_logger() -> None:
+    from gh_manage.logging_config import configure_logging
+
+    root_handlers_before = list(logging.getLogger().handlers)
+    configure_logging()
+    root_handlers_after = list(logging.getLogger().handlers)
+    assert root_handlers_before == root_handlers_after, (
+        "configure_logging must not touch the root logger — only the `gh_manage` tree."
+    )

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -99,6 +99,6 @@ def test_configure_logging_does_not_add_handler_to_root_logger() -> None:
     root_handlers_before = list(logging.getLogger().handlers)
     configure_logging()
     root_handlers_after = list(logging.getLogger().handlers)
-    assert root_handlers_before == root_handlers_after, (
-        "configure_logging must not touch the root logger — only the `gh_manage` tree."
-    )
+    assert (
+        root_handlers_before == root_handlers_after
+    ), "configure_logging must not touch the root logger — only the `gh_manage` tree."

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "gh-manage"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -123,6 +123,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "pydantic" },
+    { name = "python-json-logger" },
     { name = "pyyaml" },
 ]
 
@@ -139,6 +140,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1,<9" },
     { name = "pydantic", specifier = ">=2.5,<3" },
+    { name = "python-json-logger", specifier = ">=2.0,<3" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
 ]
 
@@ -433,6 +435,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/da/95963cebfc578dabd323d7263958dfb68898617912bb09327dd30e9c8d13/python-json-logger-2.0.7.tar.gz", hash = "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c", size = 10508, upload-time = "2023-02-21T17:40:06.209Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/a6/145655273568ee78a581e734cf35beb9e33a370b29c5d3c8fee3744de29f/python_json_logger-2.0.7-py3-none-any.whl", hash = "sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd", size = 8067, upload-time = "2023-02-21T17:40:05.117Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Introduces \`gh_manage.logging_config\` + root \`--log-level\` option with hybrid plain/JSON format (\`GH_MANAGE_LOG_JSON=1\` switches to JSON).
- 8 concrete log points across \`drift_sync/registry.py\`, \`drift_sync/checks.py\`, \`drift_sync/issue_state.py\`, \`commands/drift.py\`.
- Resolves [#62](https://github.com/yakkuro/gh-manage/issues/62) HIGH #3 (malformed-timestamp WARNING) and HIGH #5 (unexpected-exception traceback).
- Closes Theme A item 6 of [#47](https://github.com/yakkuro/gh-manage/issues/47).

## One intentional behavior change

\`check_protection\` currently swallows \`GhNotFoundError\` silently; it now emits a WARNING before the swallow. Returned findings + exit codes unchanged. Called out in spec §4 and §7 risks table.

## New dep

\`python-json-logger>=2.0,<3.0\` — single-module stdlib-compatible Formatter subclass.

## Test plan

- [x] \`uv run pytest -q\` — 587 passed (572 baseline + 15 new across 2 new files)
- [x] \`uvx ruff@0.8.0 check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [x] Manual: default level produces no log output on clean repo (WARNING floor) — verified 0 lines
- [x] Manual: \`--log-level debug\` shows check entry/exit DEBUGs
- [x] Manual: \`GH_MANAGE_LOG_JSON=1\` produces valid JSON lines (verified via json.loads)
- [x] Manual: crafted malformed-timestamp comment triggers the new WARNING (test_parse_zero_findings_warns_on_malformed)
- [x] Manual: forced \`TypeError\` in \`_scan_single_repo\` reproduces \`log.exception\` with traceback (test_worker_logs_exception_with_traceback)
- [x] \`drift --all\`: 22 repos scanned, 0 FAILED

Spec: [\`docs/specs/2026-04-19-drift-sync-logging-design.md\`](docs/specs/2026-04-19-drift-sync-logging-design.md)
Plan: [\`docs/plans/2026-04-19-drift-sync-logging-plan.md\`](docs/plans/2026-04-19-drift-sync-logging-plan.md)

Follow-ups (Issues filed alongside this PR):
- #63: Roll out logging to remaining commands
- #64: Add scan_id correlation
- #65: Add \`--log-file\` flag

Refs #47, closes part of #62 (HIGH #3, HIGH #5).

Generated with [Claude Code](https://claude.ai/code)