### PR TITLE
feat: structured logging follow-ups (cli/v1.9.0) — #63 #64 #65

### DIFF
--- a/docs/plans/2026-04-20-structured-logging-followups-plan.md
+++ b/docs/plans/2026-04-20-structured-logging-followups-plan.md
@@ -1,0 +1,2398 @@
+# Structured Logging Follow-ups Implementation Plan (cli/v1.9.0)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Each task has Red → Green → Commit cycle; do not skip the Red phase.
+
+**Goal:** Ship cli/v1.9.0 bundling Issues #63 (command rollout), #64 (scan_id ContextVar), #65 (`--log-file` flag + fail-fast validate).
+
+**Architecture:** Additive to cli/v1.8.0 baseline. Extend `logging_config.py` with dual handler + `_ScanIdJsonFormatter`; add `scan_id_var` ContextVar in `drift_sync/context.py`; wrap `_scan_single_repo` body with set/reset; add log points to 5 commands (`apply`, `labels`, `protection`, `init`, `doctor`); add `--log-file` root option with fail-fast validate.
+
+**Tech Stack:** Python 3.12, `uv` for deps, `click` 8.x, `pydantic` v2, `pytest` 8 + `pytest-mock`, `ruff` pinned at 0.8.0, `python-json-logger >=2.0,<3.0` (already installed via cli/v1.8.0).
+
+**Spec:** `docs/specs/2026-04-20-structured-logging-followups-design.md`
+
+---
+
+## Pre-flight
+
+Branch `feat/structured-logging-followups-spec` already exists (spec committed at `c3f4c67`). Continue implementation on the same branch.
+
+Verify clean state:
+
+```bash
+git status                         # expect clean
+git log --oneline main..HEAD       # expect: c3f4c67 (critique fixes), 154cb93 (spec)
+uv run pytest -q 2>&1 | tail -3    # expect baseline: 587 passed
+```
+
+If any of the above is not satisfied, stop and resolve before starting Task 1.
+
+---
+
+## Task 1: Add `scan_id_var` ContextVar
+
+**Files:**
+- Modify: `src/gh_manage/drift_sync/context.py`
+- Modify: `src/gh_manage/drift_sync/__init__.py`
+- Create: `tests/unit/drift/test_context.py`
+
+**Spec ref:** §2.1
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/unit/drift/test_context.py`:
+
+```python
+"""Tests for drift_sync/context.py — scan_id ContextVar."""
+
+from __future__ import annotations
+
+from contextvars import copy_context
+
+from gh_manage.drift_sync.context import scan_id_var
+
+
+def test_scan_id_var_defaults_to_empty_string():
+    ctx = copy_context()
+    assert ctx.run(scan_id_var.get) == ""
+
+
+def test_scan_id_var_set_and_reset():
+    token = scan_id_var.set("test-uuid")
+    try:
+        assert scan_id_var.get() == "test-uuid"
+    finally:
+        scan_id_var.reset(token)
+    assert scan_id_var.get() == ""
+
+
+def test_scan_id_var_importable_from_drift_sync_namespace():
+    from gh_manage.drift_sync import scan_id_var as exported
+
+    assert exported is scan_id_var
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/drift/test_context.py -v
+```
+
+Expected: `ImportError: cannot import name 'scan_id_var'` (or AttributeError).
+
+- [ ] **Step 3: Implement ContextVar in context.py**
+
+In `src/gh_manage/drift_sync/context.py`, add `from contextvars import ContextVar` to the imports (keep existing `from dataclasses import dataclass`, etc.), then append at module level after the `DriftOutputError` class:
+
+```python
+scan_id_var: ContextVar[str] = ContextVar("scan_id", default="")
+```
+
+- [ ] **Step 4: Re-export from `drift_sync/__init__.py`**
+
+Read `src/gh_manage/drift_sync/__init__.py`. Find the existing `from gh_manage.drift_sync.context import ...` line (it re-exports `ScanContext`, `DriftError`, `DriftOutputError`). Add `scan_id_var` to that import:
+
+```python
+from gh_manage.drift_sync.context import (
+    DriftError,
+    DriftOutputError,
+    ScanContext,
+    scan_id_var,
+)
+```
+
+If an `__all__` list exists in the module, add `"scan_id_var"` to it.
+
+- [ ] **Step 5: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/drift/test_context.py -v
+```
+
+Expected: 3 PASSED.
+
+- [ ] **Step 6: Full suite regression check**
+
+```bash
+uv run pytest -q 2>&1 | tail -3
+```
+
+Expected: 590 passed (587 baseline + 3 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gh_manage/drift_sync/context.py src/gh_manage/drift_sync/__init__.py tests/unit/drift/test_context.py
+git commit -m "$(cat <<'EOF'
+feat(drift_sync): add scan_id_var ContextVar
+
+Per-scan correlation id; default empty string means not inside a scan.
+Re-exported from drift_sync namespace.
+
+Refs #64
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `_ScanIdJsonFormatter` class
+
+**Files:**
+- Modify: `src/gh_manage/logging_config.py`
+- Modify: `tests/unit/test_logging_config.py`
+
+**Spec ref:** §2.3
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_logging_config.py` (read it first to see the existing imports/fixtures, then append):
+
+```python
+
+# ---- scan_id injection tests (cli/v1.9.0) ----
+
+import io as _io
+import json as _json
+import logging as _logging
+
+from gh_manage.drift_sync.context import scan_id_var
+from gh_manage.logging_config import configure_logging as _configure_logging
+
+
+def _parse_first_json(stream: _io.StringIO) -> dict:
+    text = stream.getvalue().strip()
+    assert text, "expected at least one log line"
+    return _json.loads(text.splitlines()[0])
+
+
+def test_json_formatter_includes_scan_id_when_set():
+    stream = _io.StringIO()
+    _configure_logging(level="info", json=True, stream=stream)
+    token = scan_id_var.set("test-uuid-123")
+    try:
+        _logging.getLogger("gh_manage.test").info("hello")
+    finally:
+        scan_id_var.reset(token)
+    assert _parse_first_json(stream)["scan_id"] == "test-uuid-123"
+
+
+def test_json_formatter_omits_scan_id_when_unset():
+    stream = _io.StringIO()
+    _configure_logging(level="info", json=True, stream=stream)
+    _logging.getLogger("gh_manage.test").info("hello")
+    assert "scan_id" not in _parse_first_json(stream)
+
+
+def test_plain_formatter_omits_scan_id():
+    stream = _io.StringIO()
+    _configure_logging(level="info", json=False, stream=stream)
+    token = scan_id_var.set("would-be-visible-if-not-omitted")
+    try:
+        _logging.getLogger("gh_manage.test").info("hello")
+    finally:
+        scan_id_var.reset(token)
+    assert "would-be-visible" not in stream.getvalue()
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/test_logging_config.py -v -k "scan_id or plain_formatter_omits"
+```
+
+Expected: 3 FAILED.
+
+- [ ] **Step 3: Implement `_ScanIdJsonFormatter`**
+
+Edit `src/gh_manage/logging_config.py`:
+
+Change the existing import line from:
+
+```python
+from pythonjsonlogger.jsonlogger import JsonFormatter
+```
+
+to:
+
+```python
+from pythonjsonlogger.jsonlogger import JsonFormatter as _BaseJsonFormatter
+
+from gh_manage.drift_sync.context import scan_id_var
+```
+
+Add the class definition after the `_TRUTHY` constant and before `_env_says_json`:
+
+```python
+class _ScanIdJsonFormatter(_BaseJsonFormatter):
+    """JSON formatter that injects the current scan_id ContextVar.
+
+    When called outside a drift scan, scan_id_var.get() returns the
+    default empty string, and the field is omitted from the JSON
+    output. See docs/specs/2026-04-20-structured-logging-followups-design.md §2.
+    """
+
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        sid = scan_id_var.get()
+        if sid:
+            log_record["scan_id"] = sid
+```
+
+Update the formatter-selection branch inside `configure_logging`:
+
+```python
+    formatter: logging.Formatter
+    if json:
+        formatter = _ScanIdJsonFormatter(_JSON_FORMAT, datefmt=_JSON_DATEFMT)
+    else:
+        formatter = logging.Formatter(_PLAIN_FORMAT, datefmt=_PLAIN_DATEFMT)
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/test_logging_config.py -v
+```
+
+Expected: all pass (existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/logging_config.py tests/unit/test_logging_config.py
+git commit -m "$(cat <<'EOF'
+feat(logging): _ScanIdJsonFormatter auto-injects scan_id
+
+JSON output gets scan_id field when the ContextVar is set (inside a
+drift scan). Plain-text formatter never includes scan_id.
+
+Refs #64
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `configure_logging` log_file kwarg + dual handler
+
+**Files:**
+- Modify: `src/gh_manage/logging_config.py`
+- Modify: `tests/unit/test_logging_config.py`
+
+**Spec ref:** §3.3
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_logging_config.py`:
+
+```python
+
+# ---- log_file + dual handler tests (cli/v1.9.0) ----
+
+from pathlib import Path as _Path
+
+
+def test_configure_logging_with_log_file_adds_file_handler(tmp_path):
+    log_path = tmp_path / "x.log"
+    _configure_logging(level="info", log_file=log_path)
+    handlers = _logging.getLogger("gh_manage").handlers
+    assert len(handlers) == 2
+    types = {type(h).__name__ for h in handlers}
+    assert types == {"StreamHandler", "FileHandler"}
+
+
+def test_log_file_mode_is_append(tmp_path):
+    log_path = tmp_path / "x.log"
+    log_path.write_text("pre-existing\n", encoding="utf-8")
+    _configure_logging(level="info", log_file=log_path)
+    _logging.getLogger("gh_manage.test").info("new-entry")
+    for h in _logging.getLogger("gh_manage").handlers:
+        h.flush()
+    content = log_path.read_text(encoding="utf-8")
+    assert content.startswith("pre-existing\n")
+    assert "new-entry" in content
+
+
+def test_log_file_encoding_is_utf8(tmp_path):
+    log_path = tmp_path / "x.log"
+    _configure_logging(level="info", log_file=log_path)
+    _logging.getLogger("gh_manage.test").info("日本語テスト")
+    for h in _logging.getLogger("gh_manage").handlers:
+        h.flush()
+    content = log_path.read_bytes().decode("utf-8")
+    assert "日本語テスト" in content
+
+
+def test_log_file_and_stderr_get_same_record(tmp_path):
+    log_path = tmp_path / "x.log"
+    stream = _io.StringIO()
+    _configure_logging(level="info", log_file=log_path, stream=stream)
+    _logging.getLogger("gh_manage.test").info("dual-msg")
+    for h in _logging.getLogger("gh_manage").handlers:
+        h.flush()
+    assert "dual-msg" in stream.getvalue()
+    assert "dual-msg" in log_path.read_text(encoding="utf-8")
+
+
+def test_file_handler_inherits_scan_id_formatter(tmp_path):
+    log_path = tmp_path / "x.log"
+    _configure_logging(level="info", json=True, log_file=log_path)
+    token = scan_id_var.set("file-scan-id")
+    try:
+        _logging.getLogger("gh_manage.test").info("msg")
+    finally:
+        scan_id_var.reset(token)
+    for h in _logging.getLogger("gh_manage").handlers:
+        h.flush()
+    first_line = log_path.read_text(encoding="utf-8").splitlines()[0]
+    assert _json.loads(first_line)["scan_id"] == "file-scan-id"
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/test_logging_config.py -v -k "log_file or inherits_scan_id"
+```
+
+Expected: FAIL with `TypeError: ... got an unexpected keyword argument 'log_file'`.
+
+- [ ] **Step 3: Extend `configure_logging`**
+
+Edit `src/gh_manage/logging_config.py`:
+
+Add `from pathlib import Path` to imports if not already present.
+
+Update `configure_logging` signature to:
+
+```python
+def configure_logging(
+    level: LogLevel = "warning",
+    json: bool | None = None,
+    stream: IO[str] | None = None,
+    log_file: Path | None = None,
+) -> None:
+```
+
+Replace the docstring entirely with:
+
+```python
+    """Configure gh_manage's root logger tree.
+
+    Handler-replacement semantics (not merge-idempotent across
+    differing args): each call replaces the existing handler list on
+    the `gh_manage` logger with a fresh set built from the arguments.
+    Calling twice with the same arguments produces the same resulting
+    configuration (end-state idempotent), but calling twice with
+    different log_file values does NOT merge — the second call
+    replaces the first. The CLI invokes this exactly once per process.
+
+    - level: log level for the `gh_manage` logger tree. Third-party
+      packages' loggers are untouched.
+    - json: tri-state. Explicit True/False wins over env var
+      GH_MANAGE_LOG_JSON; None reads env.
+    - stream: destination for stderr handler. Defaults to sys.stderr.
+      Tests pass a StringIO to capture output.
+    - log_file: optional destination for a FileHandler (append mode,
+      utf-8). When set, a FileHandler is added alongside the stderr
+      StreamHandler; both handlers share the same formatter. Caller is
+      responsible for validating the path (cli.py uses _validate_log_file).
+
+    Immutability: the plain and JSON formatter strings (including
+    datefmt) are fixed by this module — not runtime-configurable.
+    """
+```
+
+Replace the handler-construction block with:
+
+```python
+    handlers: list[logging.Handler] = [logging.StreamHandler(stream=stream)]
+    if log_file is not None:
+        handlers.append(
+            logging.FileHandler(str(log_file), mode="a", encoding="utf-8")
+        )
+    for h in handlers:
+        h.setFormatter(formatter)
+
+    gh_logger = logging.getLogger("gh_manage")
+    gh_logger.handlers[:] = handlers
+    gh_logger.setLevel(_LOG_LEVELS[level])
+    gh_logger.propagate = False
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/test_logging_config.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/logging_config.py tests/unit/test_logging_config.py
+git commit -m "$(cat <<'EOF'
+feat(logging): configure_logging log_file kwarg (dual stderr+file)
+
+Optional FileHandler (append, utf-8) attached alongside stderr when
+log_file is set. Docstring clarifies handler-replacement semantics.
+
+Refs #65
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `_validate_log_file` function
+
+**Files:**
+- Modify: `src/gh_manage/cli.py`
+- Create: `tests/unit/test_cli_log_file.py`
+
+**Spec ref:** §3.2
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_cli_log_file.py`:
+
+```python
+"""Tests for cli.py --log-file validation and option wiring."""
+
+from __future__ import annotations
+
+import os
+import stat
+
+import click
+import pytest
+
+from gh_manage.cli import _validate_log_file
+
+
+def test_validate_log_file_rejects_missing_parent(tmp_path):
+    missing = tmp_path / "nonexistent-dir" / "x.log"
+    with pytest.raises(click.UsageError) as exc:
+        _validate_log_file(missing)
+    assert "parent directory does not exist" in str(exc.value)
+
+
+def test_validate_log_file_rejects_unwritable(tmp_path):
+    if os.geteuid() == 0:
+        pytest.skip("root bypasses permission bits")
+    tmp_path.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        target = tmp_path / "x.log"
+        with pytest.raises(click.UsageError) as exc:
+            _validate_log_file(target)
+        assert "Cannot write" in str(exc.value)
+    finally:
+        tmp_path.chmod(stat.S_IRWXU)
+
+
+def test_validate_log_file_accepts_new_path(tmp_path):
+    target = tmp_path / "new.log"
+    assert not target.exists()
+    _validate_log_file(target)
+    assert target.exists()
+
+
+def test_validate_log_file_accepts_existing_path(tmp_path):
+    target = tmp_path / "existing.log"
+    target.write_text("pre-existing content\n", encoding="utf-8")
+    _validate_log_file(target)
+    assert target.read_text(encoding="utf-8") == "pre-existing content\n"
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/test_cli_log_file.py -v
+```
+
+Expected: `ImportError: cannot import name '_validate_log_file' from 'gh_manage.cli'`.
+
+- [ ] **Step 3: Implement `_validate_log_file`**
+
+Edit `src/gh_manage/cli.py`:
+
+Add `from pathlib import Path` to imports.
+
+Add the function just before the `@click.group(...)` decorator:
+
+```python
+def _validate_log_file(path: Path) -> None:
+    """Raise UsageError if the log file cannot be written to.
+
+    Runs at CLI startup, before any subcommand. Rejects missing parent
+    directory and write-permission failures with actionable messages.
+    Creating the file (0-byte touch via append-open) is intentional —
+    users who pass --log-file have opted into file creation.
+    """
+    parent = path.parent.resolve()
+    if not parent.is_dir():
+        raise click.UsageError(
+            f"--log-file parent directory does not exist: {parent}. "
+            f"Create it or choose a different path."
+        )
+    try:
+        with path.open("a", encoding="utf-8"):
+            pass
+    except OSError as e:
+        raise click.UsageError(
+            f"Cannot write to --log-file {path}: {e}. "
+            f"Check permissions and disk space."
+        ) from e
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/test_cli_log_file.py -v
+```
+
+Expected: 4 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/cli.py tests/unit/test_cli_log_file.py
+git commit -m "$(cat <<'EOF'
+feat(cli): _validate_log_file fail-fast validator
+
+Rejects missing parent and unwritable paths with UsageError before any
+subcommand runs.
+
+Refs #65
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `--log-file` option wired into root group
+
+**Files:**
+- Modify: `src/gh_manage/cli.py`
+- Modify: `tests/unit/test_cli_log_file.py`
+
+**Spec ref:** §3.1
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_cli_log_file.py`:
+
+```python
+
+# ---- CLI integration tests (Task 5) ----
+
+from pathlib import Path as _Path
+
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+
+
+def test_cli_log_file_env_var_honored(tmp_path, monkeypatch):
+    log_path = tmp_path / "x.log"
+    monkeypatch.setenv("GH_MANAGE_LOG_FILE", str(log_path))
+    runner = CliRunner()
+    # Invoke --help to trigger the root callback once the option has
+    # defaulted from envvar. --help short-circuits subcommand dispatch
+    # but the root callback still fires in click.
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    # _validate_log_file touched the file via open("a").
+    assert log_path.exists()
+
+
+def test_cli_log_file_rejects_bad_path(tmp_path):
+    bad = tmp_path / "nonexistent-parent" / "x.log"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["--log-file", str(bad), "labels", "show", "owner/repo"],
+    )
+    assert result.exit_code != 0
+    combined = result.output + (str(result.exception) if result.exception else "")
+    assert "parent directory does not exist" in combined
+
+
+def test_cli_log_file_env_var_rejects_bad_path(tmp_path, monkeypatch):
+    bad = tmp_path / "nonexistent-parent" / "x.log"
+    monkeypatch.setenv("GH_MANAGE_LOG_FILE", str(bad))
+    runner = CliRunner()
+    result = runner.invoke(main, ["labels", "show", "owner/repo"])
+    assert result.exit_code != 0
+    combined = result.output + (str(result.exception) if result.exception else "")
+    assert "parent directory does not exist" in combined
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/test_cli_log_file.py -v -k "env_var or rejects_bad"
+```
+
+Expected: FAIL — `--log-file` option not yet wired in root group.
+
+- [ ] **Step 3: Wire `--log-file` into root group**
+
+Edit `src/gh_manage/cli.py`. Find the `@click.group(...)` decorator stack on `main` and the `def main(log_level: str) -> None:` signature.
+
+Add a new `@click.option("--log-file", ...)` decorator between `--log-level` and `def main`:
+
+```python
+@click.option(
+    "--log-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    envvar="GH_MANAGE_LOG_FILE",
+    default=None,
+    help=(
+        "Write logs to this file in addition to stderr. Also honours "
+        "GH_MANAGE_LOG_FILE. Parent directory must exist and be writable; "
+        "otherwise the command exits with a usage error."
+    ),
+)
+def main(log_level: str, log_file: Path | None) -> None:
+    """Root command group. Subcommands are registered below."""
+    level: LogLevel = log_level.lower()  # type: ignore[assignment]
+    if log_file is not None:
+        _validate_log_file(log_file)
+    configure_logging(level=level, log_file=log_file)
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/test_cli_log_file.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/cli.py tests/unit/test_cli_log_file.py
+git commit -m "$(cat <<'EOF'
+feat(cli): --log-file root option + GH_MANAGE_LOG_FILE envvar
+
+Wires _validate_log_file into the root group callback; invalid paths
+from either flag or envvar exit with UsageError before subcommand dispatch.
+
+Refs #65
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: scan_id set/reset in `_scan_single_repo`
+
+**Files:**
+- Modify: `src/gh_manage/commands/drift.py`
+- Create: `tests/unit/drift/test_scan_id_propagation.py`
+
+**Spec ref:** §2.2, §5.3
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/drift/test_scan_id_propagation.py`:
+
+```python
+"""Tests for scan_id ContextVar propagation via _scan_single_repo."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
+
+import pytest
+
+from gh_manage.drift_sync.context import scan_id_var
+
+
+@pytest.fixture
+def mock_scan_deps(monkeypatch):
+    """Patch heavy dependencies of _scan_single_repo."""
+    from gh_manage.commands import drift as drift_cmd
+
+    mock_profile = MagicMock(protection_policy=None)
+    mock_labels_config = MagicMock()
+
+    monkeypatch.setattr(
+        drift_cmd.repo_info, "get_default_branch", lambda repo: "main"
+    )
+    monkeypatch.setattr(
+        drift_cmd,
+        "load_config",
+        lambda path, cls: (
+            mock_profile if "profile" in str(path) else mock_labels_config
+        ),
+    )
+    monkeypatch.setattr(
+        drift_cmd, "resolve_profile_path", lambda name: "/tmp/fake-profile.yml"
+    )
+    monkeypatch.setattr(
+        drift_cmd, "resolve_default_labels_path", lambda: "/tmp/fake-labels.yml"
+    )
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "format_stdout_report", lambda findings: "report"
+    )
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "_filter_by_severity", lambda findings, sev: findings
+    )
+    return drift_cmd
+
+
+def _make_capturing_stub(captured: dict, key: str):
+    def _stub(ctx):
+        captured[key] = scan_id_var.get()
+        return ()
+
+    return _stub
+
+
+def test_scan_id_set_at_single_repo_entry(mock_scan_deps, monkeypatch):
+    drift_cmd = mock_scan_deps
+    captured: dict = {}
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "run_all_checks", _make_capturing_stub(captured, "a")
+    )
+    drift_cmd._scan_single_repo(
+        "owner/repo", "python-service", "low", "stdout", None,
+        skip_profile_check=True,
+    )
+    sid = captured["a"]
+    uuid.UUID(sid, version=4)
+
+
+def test_scan_id_reset_after_single_repo_exit(mock_scan_deps, monkeypatch):
+    drift_cmd = mock_scan_deps
+    monkeypatch.setattr(drift_cmd.drift_sync, "run_all_checks", lambda ctx: ())
+    drift_cmd._scan_single_repo(
+        "owner/repo", "python-service", "low", "stdout", None,
+        skip_profile_check=True,
+    )
+    assert scan_id_var.get() == ""
+
+
+def test_scan_id_reset_even_on_exception(mock_scan_deps, monkeypatch):
+    drift_cmd = mock_scan_deps
+
+    def _raise(ctx):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(drift_cmd.drift_sync, "run_all_checks", _raise)
+    with pytest.raises(RuntimeError, match="boom"):
+        drift_cmd._scan_single_repo(
+            "owner/repo", "python-service", "low", "stdout", None,
+            skip_profile_check=True,
+        )
+    assert scan_id_var.get() == ""
+
+
+def test_scan_id_differs_across_sequential_scans_in_same_thread(
+    mock_scan_deps, monkeypatch
+):
+    drift_cmd = mock_scan_deps
+    captured: dict = {}
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "run_all_checks", _make_capturing_stub(captured, "seq")
+    )
+    drift_cmd._scan_single_repo(
+        "owner/repo-1", "python-service", "low", "stdout", None,
+        skip_profile_check=True,
+    )
+    first = captured["seq"]
+    drift_cmd._scan_single_repo(
+        "owner/repo-2", "python-service", "low", "stdout", None,
+        skip_profile_check=True,
+    )
+    second = captured["seq"]
+    assert first != second
+    uuid.UUID(first, version=4)
+    uuid.UUID(second, version=4)
+
+
+def test_scan_id_isolated_per_worker_thread(mock_scan_deps, monkeypatch):
+    drift_cmd = mock_scan_deps
+    captured: dict = {}
+    lock = threading.Lock()
+    counter = {"n": 0}
+
+    def _stub(ctx):
+        with lock:
+            counter["n"] += 1
+            key = f"worker_{counter['n']}"
+        captured[key] = scan_id_var.get()
+        return ()
+
+    monkeypatch.setattr(drift_cmd.drift_sync, "run_all_checks", _stub)
+
+    def _call():
+        drift_cmd._scan_single_repo(
+            "owner/repo", "python-service", "low", "stdout", None,
+            skip_profile_check=True,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(_call) for _ in range(2)]
+        for f in futures:
+            f.result()
+
+    vals = list(captured.values())
+    assert len(vals) == 2
+    assert vals[0] != vals[1]
+    for v in vals:
+        uuid.UUID(v, version=4)
+    assert scan_id_var.get() == ""
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/drift/test_scan_id_propagation.py -v
+```
+
+Expected: FAIL — `scan_id_var.get()` returns `""` (set/reset not yet wired).
+
+- [ ] **Step 3: Wrap `_scan_single_repo` body with set/reset**
+
+Edit `src/gh_manage/commands/drift.py`:
+
+Add imports near existing imports:
+
+```python
+from uuid import uuid4
+
+from gh_manage.drift_sync.context import scan_id_var
+```
+
+Refactor `_scan_single_repo` so its entire body runs inside `try:` with `finally: scan_id_var.reset(token)`. The existing function signature and return value are unchanged.
+
+Exact transform — before:
+
+```python
+def _scan_single_repo(
+    owner_repo: str,
+    profile_name: str,
+    severity: str,
+    report_mode: str,
+    output: Path | None,
+    skip_profile_check: bool = False,
+) -> str:
+    """..."""
+    log.info("scanning %s (profile=%s)", owner_repo, profile_name)
+    # Get default branch
+    default_branch = repo_info.get_default_branch(owner_repo)
+    # ... ~70 more lines ending in match statement returning a string ...
+```
+
+After:
+
+```python
+def _scan_single_repo(
+    owner_repo: str,
+    profile_name: str,
+    severity: str,
+    report_mode: str,
+    output: Path | None,
+    skip_profile_check: bool = False,
+) -> str:
+    """..."""
+    token = scan_id_var.set(str(uuid4()))
+    try:
+        log.info("scanning %s (profile=%s)", owner_repo, profile_name)
+        # Get default branch
+        default_branch = repo_info.get_default_branch(owner_repo)
+        # ... ~70 more lines, indented one additional level ...
+        # ... ending at the `match report_mode:` block ...
+        match report_mode:
+            case "stdout":
+                rendered = drift_sync.format_stdout_report(filtered)
+                return rendered
+            case "json":
+                rendered = drift_sync.format_json_report(filtered)
+                return rendered
+            case "markdown-file":
+                # ... existing branch body ...
+                return f"Report written to {output}"
+            case "issue":
+                # ... existing branch body ...
+                return status
+            case _:
+                raise ValueError(f"Unknown report mode: {report_mode!r}")
+    finally:
+        scan_id_var.reset(token)
+```
+
+Indent every existing body line by exactly 4 spaces. Do NOT change any logic. Verify by eye that `return` statements are now 12-space-indented instead of 8-space.
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/drift/test_scan_id_propagation.py -v
+```
+
+Expected: 5 PASSED.
+
+- [ ] **Step 5: Regression check — existing drift tests**
+
+```bash
+uv run pytest tests/ -v -k "drift" 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gh_manage/commands/drift.py tests/unit/drift/test_scan_id_propagation.py
+git commit -m "$(cat <<'EOF'
+feat(drift): set/reset scan_id_var in _scan_single_repo
+
+Per-scan UUID4 via try/finally; covers single-repo and --all paths.
+Reset on exception guarantees no leakage across sequential or parallel
+scans.
+
+Closes #64
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `apply.py` log points
+
+**Files:**
+- Modify: `src/gh_manage/commands/apply.py`
+- Create: `tests/unit/commands/__init__.py` (if missing)
+- Create: `tests/unit/commands/test_apply_logging.py`
+
+**Spec ref:** §4.2 (apply row)
+
+- [ ] **Step 1: Ensure test dir exists**
+
+```bash
+test -d tests/unit/commands || mkdir -p tests/unit/commands
+touch tests/unit/commands/__init__.py
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Create `tests/unit/commands/test_apply_logging.py`:
+
+```python
+"""caplog-based regression tests for commands/apply.py log points."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+
+
+@pytest.fixture
+def mock_apply_deps(monkeypatch):
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo", lambda p: "owner/repo"
+    )
+    fake_profile = MagicMock(protection_policy=None)
+    fake_profile.name = "python-service"
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.load_config",
+        lambda path, cls: fake_profile,
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_profile_path",
+        lambda name: "/tmp/fake.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_templates_root",
+        lambda: "/tmp/templates",
+    )
+    fake_diff = MagicMock(
+        creates=[], overwrites=[], skipped=[], noops=[], is_empty=True,
+    )
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.compute_files_diff",
+        lambda *a, **kw: fake_diff,
+    )
+
+
+def test_apply_logs_invocation_at_info(mock_apply_deps, caplog, tmp_path):
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO, logger="gh_manage.commands.apply"):
+        runner.invoke(
+            main,
+            ["--log-level", "info", "apply", str(tmp_path),
+             "--profile", "python-service"],
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.apply"]
+    assert any("apply invoked" in m and "owner/repo" in m for m in msgs), msgs
+
+
+def test_apply_logs_completion_at_info(
+    mock_apply_deps, caplog, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.apply_files_diff",
+        lambda *a, **kw: [],
+    )
+    monkeypatch.setattr(
+        "gh_manage.doctor.run_on_path",
+        lambda *a, **kw: (),
+    )
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO, logger="gh_manage.commands.apply"):
+        runner.invoke(
+            main,
+            ["--log-level", "info", "apply", str(tmp_path),
+             "--profile", "python-service", "--apply"],
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.apply"]
+    assert any("apply complete" in m for m in msgs), msgs
+
+
+def test_apply_logs_warning_on_ghnotfound_protection_fallback(
+    caplog, tmp_path, monkeypatch
+):
+    from gh_manage.github_client import GhNotFoundError
+
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo", lambda p: "owner/repo"
+    )
+    fake_profile = MagicMock()
+    fake_profile.name = "python-service"
+    fake_profile.protection_policy = "standard"
+    fake_bp = MagicMock(policies={"standard": MagicMock()})
+
+    def _load(path, cls):
+        return fake_profile if "profile" in str(path) else fake_bp
+
+    monkeypatch.setattr("gh_manage.commands.apply.load_config", _load)
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_profile_path",
+        lambda name: "/tmp/fake.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_templates_root",
+        lambda: "/tmp/templates",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_branch_protection_path",
+        lambda: "/tmp/bp.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_default_labels_path",
+        lambda: "/tmp/labels.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.compute_files_diff",
+        lambda *a, **kw: MagicMock(
+            creates=[], overwrites=[], skipped=[], noops=[], is_empty=True,
+        ),
+    )
+
+    def _raise_404(*a, **kw):
+        raise GhNotFoundError("404")
+
+    monkeypatch.setattr(
+        "gh_manage.github_api.protection.get_branch_protection", _raise_404
+    )
+    monkeypatch.setattr(
+        "gh_manage.protection_sync.compute_protection_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True, changes=(), has_downgrades=False,
+        ),
+    )
+
+    runner = CliRunner()
+    with caplog.at_level(logging.WARNING, logger="gh_manage.commands.apply"):
+        runner.invoke(
+            main,
+            ["apply", str(tmp_path), "--profile", "python-service",
+             "--also-protection"],
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.apply"]
+    assert any(
+        "branch protection not configured" in m and "owner/repo" in m
+        for m in msgs
+    ), msgs
+```
+
+- [ ] **Step 3: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/commands/test_apply_logging.py -v
+```
+
+Expected: FAIL (no records captured).
+
+- [ ] **Step 4: Add log points to apply.py**
+
+Edit `src/gh_manage/commands/apply.py`:
+
+Add at top-level imports (after the click import):
+
+```python
+import logging
+```
+
+Add after the imports block:
+
+```python
+log = logging.getLogger(__name__)
+```
+
+Inside `apply()`, immediately after `owner_repo = git_cli.get_origin_owner_repo(target)`:
+
+```python
+    log.info(
+        "apply invoked: repo=%s profile=%s apply=%s also_labels=%s also_protection=%s",
+        owner_repo, profile_name, apply_flag, also_labels, also_protection,
+    )
+```
+
+Inside the existing `except GhNotFoundError:` block that precedes `current_protection = {}`:
+
+```python
+        except GhNotFoundError:
+            log.warning(
+                "branch protection not configured on %s@main; treating as empty",
+                owner_repo,
+            )
+            current_protection = {}
+```
+
+Inside the existing `except DoctorCheckError as exc:` block (before the click.echo):
+
+```python
+    except DoctorCheckError as exc:
+        log.warning("post-apply doctor check failed: %s", exc)
+        click.echo(f"WARNING: post-apply doctor check failed: {exc}", err=True)
+        findings = ()
+```
+
+Immediately after the final `click.echo(f"\nApplied {n_file_changes} file changes" ...)` (before the post-apply doctor comment block):
+
+```python
+    click.echo(
+        f"\nApplied {n_file_changes} file changes"
+        + (f" + {n_label_changes} label changes" if also_labels else "")
+        + "."
+    )
+
+    log.info(
+        "apply complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d",
+        owner_repo, n_file_changes, n_label_changes, n_protection_changes,
+    )
+
+    # Post-apply doctor warnings ...
+```
+
+- [ ] **Step 5: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/commands/test_apply_logging.py -v
+```
+
+Expected: 3 PASSED.
+
+- [ ] **Step 6: Full suite regression**
+
+```bash
+uv run pytest -q 2>&1 | tail -3
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gh_manage/commands/apply.py tests/unit/commands/__init__.py tests/unit/commands/test_apply_logging.py
+git commit -m "$(cat <<'EOF'
+feat(apply): log points (invocation, completion, 404 fallback, doctor)
+
+INFO on entry/exit; WARNING on silent GhNotFoundError protection
+fallback and DoctorCheckError catch.
+
+Refs #63
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `labels.py` log points + decorator consolidation
+
+**Files:**
+- Modify: `src/gh_manage/commands/labels.py`
+- Create: `tests/unit/commands/test_labels_logging.py`
+
+**Spec ref:** §4.2 (labels row), §4.3
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/commands/test_labels_logging.py`:
+
+```python
+"""caplog-based regression tests for commands/labels.py log points."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+import gh_manage.commands.labels as labels_mod
+from gh_manage.cli import main
+from gh_manage.config import ConfigError
+from gh_manage.github_client import GhError
+
+
+def test_labels_uses_shared_handle_errors():
+    assert not hasattr(labels_mod, "_handle_errors"), (
+        "commands/labels.py should use _shared.handle_errors; "
+        "remove the local _handle_errors decorator."
+    )
+
+
+@pytest.fixture
+def mock_labels_deps(monkeypatch):
+    monkeypatch.setattr(
+        "gh_manage.github_api.labels.list_labels", lambda repo: ()
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.labels.load_config",
+        lambda path, cls: MagicMock(labels=[]),
+    )
+    monkeypatch.setattr(
+        "gh_manage.labels_sync.compute_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True, total_changes=0,
+            creates=[], updates=[], renames=[], deletes=[],
+        ),
+    )
+
+
+def test_labels_sync_logs_invocation(mock_labels_deps, caplog):
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO, logger="gh_manage.commands.labels"):
+        runner.invoke(
+            main, ["--log-level", "info", "labels", "sync", "owner/repo"]
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.labels"]
+    assert any("labels sync invoked" in m and "owner/repo" in m
+               for m in msgs), msgs
+
+
+def test_labels_show_logs_invocation(mock_labels_deps, caplog):
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO, logger="gh_manage.commands.labels"):
+        runner.invoke(
+            main, ["--log-level", "info", "labels", "show", "owner/repo"]
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.labels"]
+    assert any("labels show invoked" in m and "owner/repo" in m
+               for m in msgs), msgs
+
+
+def test_labels_diff_logs_invocation(mock_labels_deps, caplog):
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO, logger="gh_manage.commands.labels"):
+        runner.invoke(
+            main, ["--log-level", "info", "labels", "diff", "owner/repo"]
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.labels"]
+    assert any("labels diff invoked" in m and "owner/repo" in m
+               for m in msgs), msgs
+
+
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        lambda: GhError("upstream api failed"),
+        lambda: ConfigError("config invalid"),
+    ],
+    ids=["GhError", "ConfigError"],
+)
+def test_labels_exception_behavior_preserved_after_decorator_swap(
+    monkeypatch, exc_factory
+):
+    exc = exc_factory()
+
+    def _raise(*a, **kw):
+        raise exc
+
+    monkeypatch.setattr("gh_manage.github_api.labels.list_labels", _raise)
+    runner = CliRunner()
+    result = runner.invoke(main, ["labels", "show", "owner/repo"])
+    assert result.exit_code != 0
+    assert str(exc) in result.output
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/commands/test_labels_logging.py -v
+```
+
+Expected: most FAIL (no log records; `_handle_errors` still present).
+
+- [ ] **Step 3: Edit `labels.py` — remove local decorator, add log points**
+
+Edit `src/gh_manage/commands/labels.py`. Replace the entire file header up to `def _format_diff` with:
+
+```python
+"""gh manage labels — sync, diff, show GitHub repo labels."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from importlib.resources import files
+from pathlib import Path
+
+import click
+
+from gh_manage import labels_sync
+from gh_manage.commands._shared import handle_errors
+from gh_manage.config import load_config
+from gh_manage.github_api import labels as labels_api
+from gh_manage.labels_sync import LabelsDiff
+from gh_manage.models.labels import LabelsConfig
+from gh_manage.repo_ref import parse_repo
+
+DEFAULT_CONFIG_PATH = Path(str(files("gh_manage.data") / "labels.yml"))
+
+log = logging.getLogger(__name__)
+```
+
+Delete the `_F = TypeVar(...)` line, `_handle_errors` decorator definition (L50–63), and the now-unused `functools`/`TypeVar`/`Callable`/`Any` imports.
+
+Keep `_format_diff` unchanged.
+
+Replace `@_handle_errors` with `@handle_errors` on the three commands (`sync`, `diff_cmd`, `show`).
+
+Add log.info at the top of `sync()` body, after the `if apply_flag and dry_run: raise`:
+
+```python
+    log.info(
+        "labels sync invoked: repo=%s apply=%s prune=%s",
+        repo, apply_flag, prune,
+    )
+```
+
+Add log.info just before the final `click.echo(f"\nApplied {diff.total_changes} changes.")`:
+
+```python
+    log.info(
+        "labels sync complete: repo=%s changes=%d",
+        qualified, diff.total_changes,
+    )
+    click.echo(f"\nApplied {diff.total_changes} changes.")
+```
+
+Add log.info at the top of `diff_cmd()` body:
+
+```python
+    log.info("labels diff invoked: repo=%s prune=%s", repo, prune)
+```
+
+Add log.info at the top of `show()` body:
+
+```python
+    log.info("labels show invoked: repo=%s", repo)
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/commands/test_labels_logging.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Regression check**
+
+```bash
+uv run pytest tests/ -v -k "label" 2>&1 | tail -20
+```
+
+Expected: all pre-existing label tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gh_manage/commands/labels.py tests/unit/commands/test_labels_logging.py
+git commit -m "$(cat <<'EOF'
+feat(labels): log points + consolidate handle_errors onto _shared
+
+INFO on sync/diff/show invocation + sync completion. Delete local
+_handle_errors in favor of _shared.handle_errors (wider _DOMAIN_ERRORS
+catch). Exception preservation verified by parametrized test.
+
+Refs #63
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `protection.py` log points
+
+**Files:**
+- Modify: `src/gh_manage/commands/protection.py`
+- Create: `tests/unit/commands/test_protection_logging.py`
+
+**Spec ref:** §4.2 (protection row)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/commands/test_protection_logging.py`:
+
+```python
+"""caplog-based regression tests for commands/protection.py log points."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+from gh_manage.github_client import GhNotFoundError
+
+
+@pytest.fixture
+def mock_protection_deps(monkeypatch):
+    fake_profile = MagicMock()
+    fake_profile.name = "python-service"
+    fake_profile.protection_policy = "standard"
+    fake_policy = MagicMock()
+    fake_bp_config = MagicMock(policies={"standard": fake_policy})
+
+    def _load(path, cls):
+        if "profile" in str(path):
+            return fake_profile
+        return fake_bp_config
+
+    monkeypatch.setattr("gh_manage.commands.protection.load_config", _load)
+    monkeypatch.setattr(
+        "gh_manage.commands.protection.resolve_profile_path",
+        lambda name: "/tmp/fake-profile.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.protection.resolve_branch_protection_path",
+        lambda: "/tmp/fake-bp.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo", lambda p: "owner/repo"
+    )
+    monkeypatch.setattr(
+        "gh_manage.protection_sync.compute_protection_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True, changes=(), has_downgrades=False, downgrades=[],
+        ),
+    )
+    monkeypatch.setattr(
+        "gh_manage.github_api.protection.get_branch_protection",
+        lambda *a, **kw: {},
+    )
+
+
+def test_protection_sync_logs_invocation(
+    mock_protection_deps, caplog, tmp_path
+):
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO,
+                         logger="gh_manage.commands.protection"):
+        runner.invoke(
+            main,
+            ["--log-level", "info", "protection", "sync", str(tmp_path),
+             "--profile", "python-service"],
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.protection"]
+    assert any("protection sync invoked" in m and "owner/repo" in m
+               for m in msgs), msgs
+
+
+def test_protection_diff_logs_invocation(
+    mock_protection_deps, caplog, tmp_path
+):
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO,
+                         logger="gh_manage.commands.protection"):
+        runner.invoke(
+            main,
+            ["--log-level", "info", "protection", "diff", str(tmp_path),
+             "--profile", "python-service"],
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.protection"]
+    assert any("protection diff invoked" in m and "owner/repo" in m
+               for m in msgs), msgs
+
+
+def test_protection_logs_warning_on_ghnotfound(
+    mock_protection_deps, caplog, tmp_path, monkeypatch
+):
+    def _raise(*a, **kw):
+        raise GhNotFoundError("404")
+
+    monkeypatch.setattr(
+        "gh_manage.github_api.protection.get_branch_protection", _raise
+    )
+    runner = CliRunner()
+    with caplog.at_level(logging.WARNING,
+                         logger="gh_manage.commands.protection"):
+        runner.invoke(
+            main,
+            ["protection", "sync", str(tmp_path),
+             "--profile", "python-service"],
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.protection"]
+    assert any("branch protection not configured" in m and "owner/repo" in m
+               for m in msgs), msgs
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/commands/test_protection_logging.py -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add log points to protection.py**
+
+Edit `src/gh_manage/commands/protection.py`:
+
+Add `import logging` to imports.
+
+Add module-level `log = logging.getLogger(__name__)` after imports.
+
+Inside `sync()`, after `owner_repo = git_cli.get_origin_owner_repo(target)`:
+
+```python
+    log.info(
+        "protection sync invoked: repo=%s profile=%s apply=%s downgrade_allowed=%s",
+        owner_repo, profile_name, apply_flag, downgrade_allowed,
+    )
+```
+
+Both `except GhNotFoundError:` blocks in `sync()` and `diff_cmd()`:
+
+```python
+    except GhNotFoundError:
+        log.warning(
+            "branch protection not configured on %s@main; treating as empty",
+            owner_repo,
+        )
+        current = {}
+```
+
+Inside the `if diff.has_downgrades and downgrade_allowed:` branch of `sync()`, immediately before `backup_dir = resolve_backup_dir()`:
+
+```python
+        log.warning(
+            "applying protection downgrade on %s@main: %d field(s) weakened",
+            owner_repo, len(diff.downgrades),
+        )
+```
+
+Just before the final `click.echo(f"\nDone. Protection updated for {owner_repo}:main.")` in `sync()`:
+
+```python
+    log.info(
+        "protection apply complete: repo=%s fields=%d",
+        owner_repo, len(diff.changes),
+    )
+    click.echo(f"\nDone. Protection updated for {owner_repo}:main.")
+```
+
+Inside `diff_cmd()`, after `owner_repo = git_cli.get_origin_owner_repo(target)`:
+
+```python
+    log.info(
+        "protection diff invoked: repo=%s profile=%s",
+        owner_repo, profile_name,
+    )
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/commands/test_protection_logging.py -v
+```
+
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/commands/protection.py tests/unit/commands/test_protection_logging.py
+git commit -m "$(cat <<'EOF'
+feat(protection): log points (invocation, completion, 404, downgrade)
+
+Refs #63
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: `init.py` log points
+
+**Files:**
+- Modify: `src/gh_manage/commands/init.py`
+- Create: `tests/unit/commands/test_init_logging.py`
+
+**Spec ref:** §4.2 (init row)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/commands/test_init_logging.py`:
+
+```python
+"""caplog-based regression tests for commands/init.py log points."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+from gh_manage.github_client import GhNotFoundError
+
+
+@pytest.fixture
+def mock_init_deps(monkeypatch):
+    fake_profile = MagicMock()
+    fake_profile.name = "python-service"
+    fake_profile.protection_policy = None
+
+    monkeypatch.setattr(
+        "gh_manage.commands.init.load_config",
+        lambda path, cls: (
+            fake_profile if "profile" in str(path) else MagicMock()
+        ),
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_profile_path",
+        lambda name: "/tmp/fake.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_default_labels_path",
+        lambda: "/tmp/labels.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_templates_root",
+        lambda: "/tmp/tmpl",
+    )
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo",
+        lambda p: "owner/repo",
+    )
+    monkeypatch.setattr(
+        "gh_manage.github_api.labels.list_labels", lambda repo: ()
+    )
+    monkeypatch.setattr(
+        "gh_manage.labels_sync.compute_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True, total_changes=0,
+            creates=[], updates=[], renames=[],
+        ),
+    )
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.compute_files_diff",
+        lambda *a, **kw: MagicMock(
+            creates=[], overwrites=[], skipped=[], noops=[], is_empty=True,
+        ),
+    )
+
+
+def test_init_logs_invocation(mock_init_deps, caplog, tmp_path):
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO, logger="gh_manage.commands.init"):
+        runner.invoke(
+            main,
+            ["--log-level", "info", "init", str(tmp_path),
+             "--profile", "python-service"],
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.init"]
+    assert any("init invoked" in m and "owner/repo" in m for m in msgs), msgs
+
+
+def test_init_logs_completion(
+    mock_init_deps, caplog, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.apply_files_diff",
+        lambda *a, **kw: [],
+    )
+    monkeypatch.setattr(
+        "gh_manage.labels_sync.apply_diff",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "gh_manage.doctor.run_on_path",
+        lambda *a, **kw: (),
+    )
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO, logger="gh_manage.commands.init"):
+        runner.invoke(
+            main,
+            ["--log-level", "info",
+             "init", str(tmp_path),
+             "--profile", "python-service", "--apply"],
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.init"]
+    assert any("init complete" in m for m in msgs), msgs
+
+
+def test_init_logs_warning_on_ghnotfound(
+    caplog, tmp_path, monkeypatch
+):
+    fake_profile = MagicMock()
+    fake_profile.name = "python-service"
+    fake_profile.protection_policy = "standard"
+    fake_bp = MagicMock(policies={"standard": MagicMock()})
+
+    def _load(path, cls):
+        p = str(path)
+        if "profile" in p:
+            return fake_profile
+        if "bp" in p or "branch" in p:
+            return fake_bp
+        return MagicMock()
+
+    monkeypatch.setattr("gh_manage.commands.init.load_config", _load)
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_profile_path",
+        lambda name: "/tmp/fake.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_branch_protection_path",
+        lambda: "/tmp/bp.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_default_labels_path",
+        lambda: "/tmp/labels.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_templates_root",
+        lambda: "/tmp/tmpl",
+    )
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo",
+        lambda p: "owner/repo",
+    )
+    monkeypatch.setattr(
+        "gh_manage.github_api.labels.list_labels", lambda repo: ()
+    )
+    monkeypatch.setattr(
+        "gh_manage.labels_sync.compute_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True, total_changes=0,
+            creates=[], updates=[], renames=[],
+        ),
+    )
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.compute_files_diff",
+        lambda *a, **kw: MagicMock(
+            creates=[], overwrites=[], skipped=[], noops=[], is_empty=True,
+        ),
+    )
+
+    def _raise_404(*a, **kw):
+        raise GhNotFoundError("404")
+
+    monkeypatch.setattr(
+        "gh_manage.github_api.protection.get_branch_protection", _raise_404
+    )
+    monkeypatch.setattr(
+        "gh_manage.protection_sync.compute_protection_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True, has_downgrades=False, changes=(),
+        ),
+    )
+    runner = CliRunner()
+    with caplog.at_level(logging.WARNING,
+                         logger="gh_manage.commands.init"):
+        runner.invoke(
+            main,
+            ["init", str(tmp_path), "--profile", "python-service"],
+        )
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.init"]
+    assert any("branch protection not configured" in m for m in msgs), msgs
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/commands/test_init_logging.py -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add log points to init.py**
+
+Edit `src/gh_manage/commands/init.py`:
+
+Add `import logging` to imports, `log = logging.getLogger(__name__)` at module level.
+
+Inside `init()`, after `owner_repo = git_cli.get_origin_owner_repo(target)`:
+
+```python
+    log.info(
+        "init invoked: repo=%s profile=%s apply=%s",
+        owner_repo, profile_name, apply_flag,
+    )
+```
+
+Inside the `except GhNotFoundError:` block:
+
+```python
+        except GhNotFoundError:
+            log.warning(
+                "branch protection not configured on %s@main; treating as empty",
+                owner_repo,
+            )
+            current_protection = {}
+```
+
+Inside the `if critical:` block, at the very start (before the existing `click.echo("", err=True)`):
+
+```python
+    if critical:
+        log.warning(
+            "init aborting: critical doctor findings=%d, rolling back %d file(s)",
+            len(critical), len(created_paths),
+        )
+        click.echo("", err=True)
+```
+
+Inside the `except OSError as roll_err:` block:
+
+```python
+            except OSError as roll_err:
+                log.warning(
+                    "init rollback: cannot delete %s: %s", p, roll_err,
+                )
+                failed_deletes.append((p, roll_err))
+```
+
+Immediately before `click.echo("\nDone. Next steps:")` at the bottom of `init()`:
+
+```python
+    n_protection_changes_final = (
+        len(protection_diff.changes) if protection_diff is not None else 0
+    )
+    log.info(
+        "init complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d",
+        owner_repo,
+        len(files_diff.creates) + len(files_diff.overwrites),
+        labels_diff.total_changes,
+        n_protection_changes_final,
+    )
+    click.echo("\nDone. Next steps:")
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/commands/test_init_logging.py -v
+```
+
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/commands/init.py tests/unit/commands/test_init_logging.py
+git commit -m "$(cat <<'EOF'
+feat(init): log points (invocation, 404, rollback warnings, completion)
+
+Refs #63
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: `doctor.py` log points
+
+**Files:**
+- Modify: `src/gh_manage/commands/doctor.py`
+- Create: `tests/unit/commands/test_doctor_logging.py`
+
+**Spec ref:** §4.2 (doctor row)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/commands/test_doctor_logging.py`:
+
+```python
+"""caplog-based regression tests for commands/doctor.py log points."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+
+
+@pytest.fixture
+def mock_doctor_deps(monkeypatch):
+    monkeypatch.setattr(
+        "gh_manage.doctor.run_on_path", lambda *a, **kw: ()
+    )
+    monkeypatch.setattr(
+        "gh_manage.doctor.run_on_remote", lambda *a, **kw: ()
+    )
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo",
+        lambda p: "owner/repo",
+    )
+
+
+def test_doctor_logs_invocation(mock_doctor_deps, caplog, tmp_path):
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO, logger="gh_manage.commands.doctor"):
+        runner.invoke(main, ["--log-level", "info",
+                             "doctor", str(tmp_path), "--exit-zero"])
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.doctor"]
+    assert any("doctor invoked" in m for m in msgs), msgs
+
+
+def test_doctor_logs_completion(mock_doctor_deps, caplog, tmp_path):
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO, logger="gh_manage.commands.doctor"):
+        runner.invoke(main, ["--log-level", "info",
+                             "doctor", str(tmp_path), "--exit-zero"])
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.doctor"]
+    assert any("doctor complete" in m for m in msgs), msgs
+
+
+def test_doctor_logs_warning_on_label_derivation_error(
+    caplog, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "gh_manage.doctor.run_on_path", lambda *a, **kw: ()
+    )
+
+    def _raise(p):
+        raise RuntimeError("no git origin")
+
+    monkeypatch.setattr("gh_manage.git_cli.get_origin_owner_repo", _raise)
+    runner = CliRunner()
+    with caplog.at_level(logging.WARNING,
+                         logger="gh_manage.commands.doctor"):
+        runner.invoke(main, ["doctor", str(tmp_path), "--exit-zero"])
+    msgs = [r.message for r in caplog.records
+            if r.name == "gh_manage.commands.doctor"]
+    assert any("could not derive owner/repo" in m for m in msgs), msgs
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+uv run pytest tests/unit/commands/test_doctor_logging.py -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add log points to doctor.py**
+
+Edit `src/gh_manage/commands/doctor.py`:
+
+Add `import logging`, `log = logging.getLogger(__name__)`.
+
+At the very top of `doctor_cmd()` body (before the `if _looks_like_owner_repo(...):` branch):
+
+```python
+    log.info(
+        "doctor invoked: target=%s profile=%s report_mode=%s",
+        target, profile_name, report_mode,
+    )
+```
+
+In `_derive_repo_label`, modify the except clause:
+
+```python
+def _derive_repo_label(path: Path, *, fallback: str) -> str:
+    from gh_manage import git_cli
+
+    try:
+        return git_cli.get_origin_owner_repo(path)
+    except Exception as e:
+        log.warning("could not derive owner/repo from path %s: %s", path, e)
+        return fallback
+```
+
+Immediately before `if exit_zero: return`:
+
+```python
+    blocking_count = sum(
+        1 for f in findings if f.severity in _BLOCKING_SEVERITIES
+    )
+    log.info(
+        "doctor complete: target=%s findings=%d blocking=%d",
+        target, len(findings), blocking_count,
+    )
+
+    if exit_zero:
+        return
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+uv run pytest tests/unit/commands/test_doctor_logging.py -v
+```
+
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gh_manage/commands/doctor.py tests/unit/commands/test_doctor_logging.py
+git commit -m "$(cat <<'EOF'
+feat(doctor): log points (invocation, completion, label derivation warning)
+
+Refs #63
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Version bump to 1.9.0 + quality gates
+
+**Files:**
+- Modify: `src/gh_manage/__init__.py`
+- Modify: `pyproject.toml`
+- Modify: `tests/test_sanity.py`
+- Regenerate: `uv.lock`
+
+- [ ] **Step 1: Bump __init__.py**
+
+Read `src/gh_manage/__init__.py` (likely just contains `__version__ = "1.8.0"`).
+
+Replace `"1.8.0"` with `"1.9.0"`.
+
+- [ ] **Step 2: Bump pyproject.toml**
+
+Read `pyproject.toml`, locate the `version = "1.8.0"` line in `[project]` section.
+
+Replace with `version = "1.9.0"`.
+
+- [ ] **Step 3: Bump test_sanity.py**
+
+Read `tests/test_sanity.py`, locate the version assertion (e.g., `assert __version__ == "1.8.0"` or similar).
+
+Replace `"1.8.0"` with `"1.9.0"`.
+
+- [ ] **Step 4: Regenerate uv.lock**
+
+```bash
+uv sync
+```
+
+- [ ] **Step 5: Full test suite**
+
+```bash
+uv run pytest -q 2>&1 | tail -5
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Lint + format + type check**
+
+```bash
+uvx ruff@0.8.0 check src/ tests/
+uvx ruff@0.8.0 format --check src/ tests/
+uv run mypy src/
+```
+
+Expected: all clean.
+
+If `format --check` fails, run `uvx ruff@0.8.0 format src/ tests/` and re-run `format --check` to verify clean.
+
+If `check` fails, inspect and fix. Do NOT suppress — fix root causes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gh_manage/__init__.py pyproject.toml tests/test_sanity.py uv.lock
+git commit -m "$(cat <<'EOF'
+chore(release): bump to cli/v1.9.0
+
+Structured logging follow-ups: #63 (command rollout), #64 (scan_id
+ContextVar), #65 (--log-file + fail-fast validate).
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Push, PR, 4-reviewer protocol, merge, tag
+
+**Files:** N/A (orchestration)
+
+**Spec ref:** §6.2, §7, §8
+
+- [ ] **Step 1: Integration smoke (manual, local)**
+
+These are not automated — run them by hand to verify the feature works end-to-end:
+
+```bash
+# 1. dual output
+gh-manage --log-level info --log-file /tmp/ghm-smoke.log labels show yakkuro/gh-manage 2>&1 | head -5
+grep 'labels show invoked' /tmp/ghm-smoke.log
+# Expected: stderr has an INFO line; file has the same INFO line.
+
+# 2. scan_id in JSON mode, proportional to repos.yml
+ENABLED=$(uv run python -c "
+from gh_manage.config import load_config
+from gh_manage.models.repos import ReposConfig
+from gh_manage.commands._shared import resolve_repos_path
+cfg = load_config(resolve_repos_path(), ReposConfig)
+print(sum(1 for r in cfg.repos if r.enabled))
+")
+echo "enabled repos: $ENABLED"
+GH_MANAGE_LOG_JSON=1 gh-manage --log-level info drift --all 2>&1 >/dev/null \
+  | jq -s 'group_by(.scan_id) | map({scan: .[0].scan_id, count: length}) | length'
+# Expected: equals $ENABLED
+
+# 3. Fail-fast on bad --log-file
+gh-manage --log-file /nonexistent-dir/x.log apply .
+# Expected: exit 2, "parent directory does not exist"
+
+# 4. Plain mode does NOT leak scan_id
+gh-manage --log-level info drift . 2>&1 | grep -c 'scan_id' || true
+# Expected: 0
+```
+
+If any smoke test fails, fix before pushing.
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin feat/structured-logging-followups-spec
+```
+
+- [ ] **Step 3: Create PR**
+
+```bash
+gh pr create --title "feat: structured logging follow-ups (cli/v1.9.0) — #63 #64 #65" --body "$(cat <<'EOF'
+## Summary
+
+Bundles three structured-logging follow-ups from PR #66 / cli/v1.8.0 into one cli/v1.9.0 release.
+
+- **#63** (command rollout): INFO/WARNING coverage across `apply`, `labels`, `protection`, `init`, `doctor`
+- **#64** (scan_id): ContextVar-based UUID4 per scan; `_ScanIdJsonFormatter` auto-attaches `scan_id` field to JSON output; plain-text unchanged
+- **#65** (`--log-file`): dual stderr+file output; `GH_MANAGE_LOG_FILE` envvar; fail-fast validate at CLI startup with `UsageError`
+
+Side cleanup: `labels.py` local `_handle_errors` consolidated onto `_shared.handle_errors` (wider exception catch; parametrized preservation test included).
+
+## Design
+
+- Spec: `docs/specs/2026-04-20-structured-logging-followups-design.md`
+- Plan: `docs/plans/2026-04-20-structured-logging-followups-plan.md`
+- Decisions from brainstorming Q1–Q4: single PR, ContextVar with JsonFormatter auto-attach, dual output, fail-fast validate.
+
+## Test plan
+
+- [x] `uv run pytest -q` — baseline 587 + ~44 new tests pass (~631 total)
+- [x] `uvx ruff@0.8.0 check src/ tests/` clean
+- [x] `uvx ruff@0.8.0 format --check src/ tests/` clean
+- [x] `uv run mypy src/` clean
+- [x] Manual: `gh-manage --log-file /tmp/x.log --log-level info` → dual stderr+file output for a command invocation
+- [x] Manual: `GH_MANAGE_LOG_JSON=1 gh-manage drift --all` → distinct UUID4 scan_id per parallel worker, count matches enabled repos in repos.yml
+- [x] Manual: `gh-manage --log-file /nonexistent/x.log apply .` → exits with UsageError
+- [x] Manual: invocation INFO visible for each of apply/labels/protection/init/doctor at `--log-level info`
+
+Closes #63
+Closes #64
+Closes #65
+Refs #47
+
+Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+Capture the returned PR number for the next steps (assume `$PR` = PR number).
+
+- [ ] **Step 4: Run 4-reviewer protocol in parallel**
+
+Per `~/.claude/rules/workflow-review.md`, run all 4 reviewers concurrently by sending one message with 4 Agent tool calls. Give each reviewer:
+
+- The PR diff (`git diff main..HEAD`)
+- The plan path (`docs/plans/2026-04-20-structured-logging-followups-plan.md`) — for superpowers:code-reviewer
+- The spec path (`docs/specs/2026-04-20-structured-logging-followups-design.md`) — for all reviewers
+
+Reviewers:
+1. **Codex** — `bash scripts/codex-review-resilient.sh "review PR #<PR>"` OR `/codex:review` plugin (background)
+2. **superpowers:code-reviewer** via `Agent(subagent_type="superpowers:code-reviewer", ...)` — verify plan-spec alignment
+3. **pr-review-toolkit:silent-failure-hunter** via `Agent(subagent_type="pr-review-toolkit:silent-failure-hunter", ...)` — surface suppressed exceptions, silent fallbacks
+4. **code-reviewer (project conventions)** via `Agent(subagent_type="code-reviewer", model="sonnet", ...)` — diff size likely ~1000-1500 LOC, sonnet appropriate per model-routing rule
+
+- [ ] **Step 5: Address CRITICAL/HIGH findings**
+
+Per convergence across reviewers:
+- Any CRITICAL: stop, fix, re-run only the affected reviewer(s).
+- Any HIGH: fix before merge.
+- MEDIUM / LOW: triage — fix if quick, otherwise defer to a follow-up Issue.
+
+Push fixes with descriptive commit messages referencing the finding.
+
+- [ ] **Step 6: Watch CI**
+
+```bash
+gh pr checks $PR --watch
+```
+
+Expected: all checks green. Fix any CI failures.
+
+- [ ] **Step 7: Merge (squash) after all reviews clean + CI green**
+
+```bash
+gh pr merge $PR --squash --delete-branch
+```
+
+- [ ] **Step 8: Tag release**
+
+```bash
+git checkout main && git pull
+git tag -a cli/v1.9.0 -m "cli/v1.9.0: structured logging follow-ups (#63, #64, #65)"
+git push origin cli/v1.9.0
+```
+
+- [ ] **Step 9: GitHub release**
+
+```bash
+gh release create cli/v1.9.0 --title "cli/v1.9.0" --notes "$(cat <<'EOF'
+## cli/v1.9.0 — structured logging follow-ups
+
+Closes #63, #64, #65.
+
+### Added
+- `--log-file PATH` / `GH_MANAGE_LOG_FILE` envvar: write logs to a file in addition to stderr. Fail-fast validate at startup if the path is invalid.
+- `scan_id` correlation id in JSON log output: per-scan UUID4, auto-attached to every log record emitted during a drift scan. Plain-text output unchanged.
+- Structured logging now covers `apply`, `labels`, `protection`, `init`, `doctor` (cli/v1.8.0 was drift-only).
+
+### Internal
+- Consolidate `commands/labels.py` error decorator onto `_shared.handle_errors` (wider `_DOMAIN_ERRORS` catch; no visible behavior change, verified by parametrized preservation test).
+
+### Migration
+None. Defaults preserve cli/v1.8.0 behavior (WARNING floor, stderr only, no scan_id unless in JSON mode).
+EOF
+)"
+```
+
+- [ ] **Step 10: Close issues with reference**
+
+```bash
+gh issue close 63 64 65 --comment "Resolved in cli/v1.9.0 (PR #$PR)."
+```
+
+- [ ] **Step 11: Verify post-merge state**
+
+```bash
+git log --oneline main | head -5
+# Expected: top commit is the squash-merge of the PR
+git tag --list 'cli/v1.*' | tail -3
+# Expected: cli/v1.9.0 present
+gh issue list --state open --search "label:\"cli/v1.8.0-followup\""
+# Expected: #63, #64, #65 not in list (closed)
+```
+
+---
+
+## Self-review
+
+Post-drafting sanity pass:
+
+- **Spec coverage**:
+  - §2 scan_id: Task 1 (ContextVar), Task 2 (formatter), Task 6 (propagation) ✓
+  - §3 --log-file: Task 3 (configure_logging kwarg), Task 4 (validator), Task 5 (CLI wire) ✓
+  - §4 rollout: Tasks 7–11 (apply, labels, protection, init, doctor) ✓
+  - §4.3 decorator cleanup: Task 8 (labels) ✓
+  - §5 testing: every task has caplog/regression tests; §5.5 integration smoke is Task 13 Step 1 ✓
+  - §6 risks: addressed by tests (ContextVar thread isolation, labels exception preservation) ✓
+  - §7 release: Task 12 (version) + Task 13 (PR/reviews/tag/release notes) ✓
+  - §8 acceptance: covered across Tasks 1–13 ✓
+
+- **Placeholder scan**: no "TBD", "TODO", "similar to Task N". All code concrete.
+
+- **Type consistency**:
+  - `scan_id_var: ContextVar[str]` consistent in Task 1 test, Task 1 impl, Task 2 formatter, Task 6 set/reset
+  - `log_file: Path | None` consistent in Task 3 kwarg, Task 4 validator, Task 5 CLI option (all use `Path`)
+  - Log message templates match §4.2 spec tables exactly
+  - Commit subjects use Conventional Commits (`feat(apply):`, `chore(release):` etc.)
+
+No placeholders, types consistent, coverage complete.
+
+---
+
+## Execution handoff
+
+Per user's `feedback_subagent_driven_default` + `feedback_execution_mode`: **skip the choice gate and proceed directly to `superpowers:subagent-driven-development`**. No "inline vs subagent" prompt.

--- a/docs/specs/2026-04-20-structured-logging-followups-design.md
+++ b/docs/specs/2026-04-20-structured-logging-followups-design.md
@@ -194,9 +194,11 @@ class _ScanIdJsonFormatter(_BaseJsonFormatter):
 
 `configure_logging` switches to `_ScanIdJsonFormatter` in JSON mode (replaces the current `JsonFormatter`). Plain-text mode uses the stdlib `logging.Formatter` unchanged — scan_id is intentionally not included in plain output (the user-intent "agent-friendly format" lives in JSON).
 
-### 2.4 Thread propagation guarantee
+### 2.4 Thread isolation guarantee
 
-`ThreadPoolExecutor.submit` wraps the work item in `contextvars.copy_context().run(...)` (since Python 3.9; our target is 3.12). Each worker runs inside its own copied context. Our design sets `scan_id_var` **inside** the worker (in `_scan_single_repo`), not in the caller — so the `set()` mutates the worker's copy, not the caller's. Even if two workers set at the same wall-clock instant, their mutations are isolated to their own contexts. Parallel `--all` runs therefore do not interleave scan_ids.
+`ContextVar` is thread-local: each thread has its own independent view of the variable. `ThreadPoolExecutor.submit` in CPython 3.12 does **not** automatically `copy_context()` for you — each worker thread simply starts from the default (empty) context. Our design sets `scan_id_var` **inside the worker** (at `_scan_worker` entry, before any `_scan_single_repo` call), so each parallel `--all` worker ends up with its own thread-local id. Two workers setting `scan_id_var` at the same wall-clock instant mutate two independent contexts; they do not interfere. Parallel `--all` runs therefore do not interleave scan_ids.
+
+Why `_scan_worker` (not `_scan_single_repo`) owns the set/reset: `_scan_worker`'s `except` blocks log failure records AFTER the inner function returns/raises. If `_scan_single_repo`'s `finally` had reset scan_id first, those failure logs — the ones an operator most needs to correlate — would arrive with no scan_id. Setting at the worker's outermost scope ensures failure records inherit the correct id. `_scan_single_repo` still conditionally sets scan_id when called directly from the single-repo CLI path (where no outer worker exists).
 
 The test `test_scan_id_isolated_per_worker_thread` (§5.3) asserts this empirically.
 

--- a/docs/specs/2026-04-20-structured-logging-followups-design.md
+++ b/docs/specs/2026-04-20-structured-logging-followups-design.md
@@ -137,7 +137,13 @@ scan_id_var: ContextVar[str] = ContextVar("scan_id", default="")
 
 Re-exported via `src/gh_manage/drift_sync/__init__.py` for external access (tests, future cross-module consumers).
 
-Rationale for `context.py` placement: `logging_config.py` needs to read `scan_id_var` from its formatter. Putting the ContextVar in `drift_sync/context.py` (which has zero downstream drift_sync dependencies) keeps the import DAG one-directional: `logging_config → drift_sync.context`. Placing it in `logging_config.py` would invert the DAG and require lazy imports.
+Rationale for `context.py` placement — considered alternatives:
+
+- **(A) `drift_sync/context.py` (chosen)**: DAG `logging_config → drift_sync.context`. `context.py` depends only on stdlib + `gh_manage.models.*`, never on logging. One-directional, no lazy import needed.
+- **(B) `logging_config.py`**: DAG `drift_sync.context → logging_config → drift_sync.context`. Cycle at module level — `logging_config` must import `scan_id_var` at the top of the file to reference it in the formatter class body, and `drift_sync/context.py` can be imported from any drift_sync consumer that also transitively pulls in logging. Breaking this cycle requires lazy (function-local) imports inside the formatter's `add_fields`, which degrades readability and introduces a per-record import lookup in the hot path.
+- **(C) a third `correlation.py` module at `gh_manage/` root**: DAG `logging_config → correlation`, `drift_sync.context → correlation`. Cleanest from a pure-DAG standpoint but introduces a one-name module solely for the ContextVar. YAGNI: there are no other correlation ids today, and if more emerge later, the module can be promoted then. Placing the single ContextVar in `drift_sync/context.py` co-locates it with its only user.
+
+(A) wins on both DAG cleanliness and co-location with domain.
 
 ### 2.2 Set/reset at scan entry
 
@@ -190,7 +196,7 @@ class _ScanIdJsonFormatter(_BaseJsonFormatter):
 
 ### 2.4 Thread propagation guarantee
 
-`ThreadPoolExecutor.submit` in Python ≥3.9 copies the caller's context to the worker thread at submit time. Our design sets `scan_id_var` **inside** the worker (in `_scan_single_repo`), not in the caller. This means each worker thread's local context holds its own independent value; parallel `--all` runs do not interleave scan_ids.
+`ThreadPoolExecutor.submit` wraps the work item in `contextvars.copy_context().run(...)` (since Python 3.9; our target is 3.12). Each worker runs inside its own copied context. Our design sets `scan_id_var` **inside** the worker (in `_scan_single_repo`), not in the caller — so the `set()` mutates the worker's copy, not the caller's. Even if two workers set at the same wall-clock instant, their mutations are isolated to their own contexts. Parallel `--all` runs therefore do not interleave scan_ids.
 
 The test `test_scan_id_isolated_per_worker_thread` (§5.3) asserts this empirically.
 
@@ -288,7 +294,16 @@ def configure_logging(
     stream: IO[str] | None = None,
     log_file: Path | None = None,
 ) -> None:
-    """Configure gh_manage's logger tree. Idempotent.
+    """Configure gh_manage's logger tree.
+
+    Handler-replacement semantics (not idempotent across differing args):
+    each call replaces the existing handler list on the `gh_manage`
+    logger with a fresh set built from the arguments. Calling twice with
+    the same arguments produces the same resulting configuration
+    (end-state idempotent), but calling twice with different log_file
+    values does NOT merge — the second call replaces the first. The CLI
+    invokes this exactly once per process, so the distinction matters
+    mainly for tests.
 
     New kwarg in cli/v1.9.0:
     - log_file: if not None, a FileHandler (append mode, utf-8) is added
@@ -335,13 +350,16 @@ def configure_logging(
 
 ### 3.5 Defaults matrix
 
+Validation applies identically to the `--log-file` flag and the `GH_MANAGE_LOG_FILE` envvar. Both routes go through `_validate_log_file` at startup; an invalid path from either source fails with `UsageError` before any subcommand runs.
+
 | Invocation | stderr | file |
 |---|---|---|
 | `gh-manage drift .` | WARNING+ plain | — |
 | `gh-manage --log-file /tmp/x.log drift .` | WARNING+ plain | WARNING+ plain |
 | `GH_MANAGE_LOG_JSON=1 gh-manage --log-file /tmp/x.log drift .` | JSON | JSON |
-| `GH_MANAGE_LOG_FILE=/tmp/x.log gh-manage drift --all` | plain | plain (22 scan_ids interleaved) |
+| `GH_MANAGE_LOG_FILE=/tmp/x.log gh-manage drift --all` | plain | plain (N scan_ids interleaved, N = enabled repos in `repos.yml`) |
 | `gh-manage --log-file /nonexistent/x.log apply .` | — | — (`UsageError`, exit 2) |
+| `GH_MANAGE_LOG_FILE=/nonexistent/x.log gh-manage apply .` | — | — (`UsageError`, exit 2 — envvar validation identical to flag) |
 
 ## §4 — Command rollout (#63)
 
@@ -357,14 +375,14 @@ Every `commands/*.py` module (except `issues.py` stub):
 
 ### 4.2 Per-command log points
 
-**`commands/apply.py`**
+**`commands/apply.py`** (locations referenced by code structure, not line numbers, to stay robust against unrelated edits)
 
 | Level | Location | Message template |
 |---|---|---|
-| INFO | `apply()` after UsageError check | `apply invoked: repo=%s profile=%s apply=%s also_labels=%s also_protection=%s` |
-| WARNING | `except GhNotFoundError: current_protection = {}` (L123) | `branch protection not configured on %s@main; treating as empty` |
-| WARNING | `except DoctorCheckError` (L213) | `post-apply doctor check failed: %s` (alongside existing click.echo) |
-| INFO | end of successful body (L195 area) | `apply complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d` |
+| INFO | inside `apply()`, immediately after the `--apply`/`--dry-run` mutual-exclusion check and `target = path.resolve()` | `apply invoked: repo=%s profile=%s apply=%s also_labels=%s also_protection=%s` |
+| WARNING | inside the `except GhNotFoundError` block that precedes `current_protection = {}` (the `--also-protection` branch) | `branch protection not configured on %s@main; treating as empty` |
+| WARNING | inside the `except DoctorCheckError as exc` block (post-apply doctor gate) | `post-apply doctor check failed: %s` (alongside existing `click.echo`) |
+| INFO | just before the final `"Applied {n_file_changes} file changes"` `click.echo` | `apply complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d` |
 
 **`commands/labels.py`**
 
@@ -380,39 +398,39 @@ Every `commands/*.py` module (except `issues.py` stub):
 
 | Level | Location | Message template |
 |---|---|---|
-| INFO | `sync()` entry | `protection sync invoked: repo=%s profile=%s apply=%s downgrade_allowed=%s` |
-| WARNING | `except GhNotFoundError: current = {}` (L152, L240) | `branch protection not configured on %s@main; treating as empty` |
-| WARNING | downgrade path entered with `--apply` | `applying protection downgrade on %s@main: %d field(s) weakened` |
-| INFO | `sync()` successful return (L204) | `protection apply complete: repo=%s fields=%d` |
-| INFO | `diff_cmd()` entry | `protection diff invoked: repo=%s profile=%s` |
+| INFO | inside `sync()`, after the mutual-exclusion check and `owner_repo` resolution | `protection sync invoked: repo=%s profile=%s apply=%s downgrade_allowed=%s` |
+| WARNING | inside each `except GhNotFoundError` block that precedes `current = {}` (both `sync()` and `diff_cmd()`) | `branch protection not configured on %s@main; treating as empty` |
+| WARNING | just before `apply_protection_diff` when `diff.has_downgrades and downgrade_allowed` | `applying protection downgrade on %s@main: %d field(s) weakened` |
+| INFO | just before `sync()`'s final `"Done. Protection updated"` `click.echo` | `protection apply complete: repo=%s fields=%d` |
+| INFO | inside `diff_cmd()`, after `owner_repo` resolution | `protection diff invoked: repo=%s profile=%s` |
 
 **`commands/init.py`**
 
 | Level | Location | Message template |
 |---|---|---|
-| INFO | `init()` after UsageError check | `init invoked: repo=%s profile=%s apply=%s` |
-| WARNING | `except GhNotFoundError: current_protection = {}` (L119) | `branch protection not configured on %s@main; treating as empty` |
-| WARNING | critical findings triggered rollback (L201) | `init aborting: critical doctor findings=%d, rolling back %d file(s)` |
-| WARNING | rollback `unlink` failure (L213) | `init rollback: cannot delete %s: %s` |
-| INFO | end of successful body (L233) | `init complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d` |
+| INFO | inside `init()`, after the `--apply`/`--dry-run` mutual-exclusion check and `target = path.resolve()` | `init invoked: repo=%s profile=%s apply=%s` |
+| WARNING | inside the `except GhNotFoundError` block that precedes `current_protection = {}` (protection diff path) | `branch protection not configured on %s@main; treating as empty` |
+| WARNING | inside the `if critical:` branch of the post-apply doctor gate, before rollback begins | `init aborting: critical doctor findings=%d, rolling back %d file(s)` |
+| WARNING | inside the `except OSError as roll_err` block of the rollback loop | `init rollback: cannot delete %s: %s` |
+| INFO | just before the final `"Done. Next steps:"` `click.echo` | `init complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d` |
 
 **`commands/doctor.py`**
 
 | Level | Location | Message template |
 |---|---|---|
-| INFO | `doctor_cmd()` entry | `doctor invoked: target=%s profile=%s report_mode=%s` |
-| WARNING | `_derive_repo_label` `except Exception` (L43) | `could not derive owner/repo from path %s: %s` |
-| INFO | before final exit decision | `doctor complete: target=%s findings=%d blocking=%d` |
+| INFO | inside `doctor_cmd()`, after target classification (`_looks_like_owner_repo`) | `doctor invoked: target=%s profile=%s report_mode=%s` |
+| WARNING | inside the `except Exception` block of `_derive_repo_label` (before returning fallback) | `could not derive owner/repo from path %s: %s` |
+| INFO | just before the `exit_zero` check at the end of `doctor_cmd()` | `doctor complete: target=%s findings=%d blocking=%d` |
 
 **`commands/issues.py`**: stub (exits 1 "not implemented"). Do not log — the stub will be replaced in cli/v0.5.0 work.
 
 ### 4.3 Decorator cleanup in `labels.py`
 
-`src/gh_manage/commands/labels.py` defines its own `_handle_errors` decorator (L50–63) that is functionally identical to `_shared.handle_errors` (imported by every other command). Under the umbrella of this rollout:
+`src/gh_manage/commands/labels.py` defines its own `_handle_errors` decorator (local, catches `(GhError, ConfigError)`) that overlaps with `_shared.handle_errors` (imported by every other command, catches a wider `_DOMAIN_ERRORS` tuple: `GhError, ConfigError, GitError, ProfileError, ProtectionError, DriftError, DoctorError`). Under the umbrella of this rollout:
 
-- Delete the local `_handle_errors` (L50–63) and its `_F` TypeVar import (L24)
+- Delete the local `_handle_errors` decorator definition and its `_F` `TypeVar` declaration
 - Import `from gh_manage.commands._shared import handle_errors`
-- Replace `@_handle_errors` decorators on `sync`, `diff_cmd`, `show` with `@handle_errors`
+- Replace every `@_handle_errors` decorator (on `sync`, `diff_cmd`, `show`) with `@handle_errors`
 - Delete now-unused imports: `functools`, `TypeVar`, `Callable`, `Any`
 
 Scope limit: only this decorator consolidation. No migration of `click.echo` to `log.info`, no reorganization of `labels.py`, no touching `_format_diff`.
@@ -457,7 +475,8 @@ Log messages do not interpolate `Finding.severity`, `DriftIssue.state`, or any o
 | `test_scan_id_reset_after_single_repo_exit` | call `_scan_single_repo(...)` (with full mocks), after call assert `scan_id_var.get() == ""` |
 | `test_scan_id_reset_even_on_exception` | make `run_all_checks` raise; after the raise propagates, assert `scan_id_var.get() == ""` |
 | `test_scan_id_in_nested_check_logs` | mock a check that captures `scan_id_var.get()`; run via full `_scan_single_repo` path; assert the captured value matches the set UUID |
-| `test_scan_id_isolated_per_worker_thread` | run `_scan_all_repos` with 2 mocked entries + mocked inner functions that capture per-thread scan_id; assert 2 distinct UUID values, both well-formed |
+| `test_scan_id_isolated_per_worker_thread` | run `_scan_all_repos(concurrency=2)` with 2 mocked `RepoEntry` + inner functions that capture `scan_id_var.get()` at their entry and expose it back to the test via a thread-safe collection; assert (a) both captured values parse as valid UUID4 via `uuid.UUID(captured, version=4)`, (b) they are distinct from each other, (c) both are distinct from the ContextVar default (empty string), (d) after the executor shuts down, the main thread's `scan_id_var.get()` is still the default empty string (proves no leakage to caller context) |
+| `test_scan_id_differs_across_sequential_scans_in_same_thread` | run `_scan_single_repo` twice sequentially in the test thread; capture scan_id during each call via mocked inner; assert the two captured UUIDs are distinct (proves `set/reset` cycle issues a fresh UUID per call) |
 
 ### 5.4 `tests/unit/commands/test_<cmd>_logging.py` (5 new files, ~40–50 LOC each)
 
@@ -471,7 +490,8 @@ Template (applied per command):
 | `test_<cmd>_logs_warning_on_doctor_check_error` | (apply only) mock `_doctor.run_on_path` to raise `DoctorCheckError`; caplog has WARNING "post-apply doctor check failed" |
 | `test_<cmd>_logs_warning_on_rollback` | (init only) force rollback path via mocked critical findings; caplog has WARNING "init aborting: critical doctor findings" |
 | `test_<cmd>_logs_warning_on_repo_label_derivation` | (doctor only) pass a path where `get_origin_owner_repo` raises; caplog has WARNING |
-| `test_labels_uses_shared_handle_errors` | (labels only) `assert not hasattr(gh_manage.commands.labels, "_handle_errors")` |
+| `test_labels_uses_shared_handle_errors` | (labels only) `assert not hasattr(gh_manage.commands.labels, "_handle_errors")` — guards the cleanup from regressing |
+| `test_labels_exception_behavior_preserved_after_decorator_swap` | (labels only) parametrize over `GhError("x")`, `ConfigError("y")` — the two types the old `_handle_errors` caught. For each, mock the underlying call site to raise it, invoke the click command via `CliRunner`, assert the result exits non-zero, stderr begins with `"Error: "`, and the original message appears verbatim (proves the wider `_shared.handle_errors` catch is functionally identical on the pre-existing overlap set, not merely type-compatible) |
 
 Total new tests: ~25–30 across 5 files.
 
@@ -483,10 +503,22 @@ gh-manage --log-level info --log-file /tmp/ghm.log drift .
 grep 'scanning' /tmp/ghm.log   # file received records
 # stderr already showed them
 
-# 2. scan_id in JSON mode
+# 2. scan_id in JSON mode (proportional to current repos.yml, not hardcoded)
+#    Grabs enabled-repo count dynamically, then asserts group count matches.
+ENABLED=$(gh-manage --help >/dev/null 2>&1 && \
+  python -c "from gh_manage.config import load_config; \
+             from gh_manage.models.repos import ReposConfig; \
+             from gh_manage.commands._shared import resolve_repos_path; \
+             cfg = load_config(resolve_repos_path(), ReposConfig); \
+             print(sum(1 for r in cfg.repos if r.enabled))")
 GH_MANAGE_LOG_JSON=1 gh-manage --log-level info drift --all 2>&1 >/dev/null \
   | jq -s 'group_by(.scan_id) | map({scan: .[0].scan_id, count: length}) | length'
-# Expected: 22 (one scan_id per enabled repo)
+# Expected: equals $ENABLED (one scan_id per enabled repo, regardless of fleet size).
+# Also validate each group's scan_id is a valid UUID4:
+GH_MANAGE_LOG_JSON=1 gh-manage --log-level info drift --all 2>&1 >/dev/null \
+  | jq -rs 'group_by(.scan_id) | .[] | .[0].scan_id' \
+  | while read -r sid; do python -c "import uuid; uuid.UUID('$sid', version=4)" || exit 1; done
+# Expected: exit 0 (every scan_id parses as UUID4)
 
 # 3. Plain mode does not leak scan_id
 gh-manage --log-level info drift . 2>&1 | grep -c 'scan_id'

--- a/docs/specs/2026-04-20-structured-logging-followups-design.md
+++ b/docs/specs/2026-04-20-structured-logging-followups-design.md
@@ -1,0 +1,589 @@
+# Structured Logging Follow-ups Design (cli/v1.9.0)
+
+- **Date**: 2026-04-20
+- **Size**: Medium
+- **Sizing Rationale**: Three follow-up Issues (#63 rollout, #64 scan_id, #65 `--log-file`) bundled into one CLI-track minor release. Scope: extend `logging_config.py`, add a ContextVar-based correlation id, add a root-group CLI option + validator, and wire `log = getLogger(__name__)` + concrete log points across 5 remaining commands (apply/labels/protection/init/doctor). Estimated ~200 LOC production, ~400 LOC tests, ~10 files modified + ~6 new test files. Not Small because it touches both shared infrastructure (logging_config, cli.py) and command surface, with one new cross-module concept (scan_id ContextVar). Not Large because no breaking change, no schema migration, and the `logging_config.py` baseline from cli/v1.8.0 is reused as-is for format strings.
+- **Target**: `yakkuro/gh-manage`
+- **Goal**: Close out the structured-logging story the cli/v1.8.0 PR (#66) opened — Issues #63, #64, #65 — as a single `cli/v1.9.0` release. Provide (a) consistent INFO/WARNING coverage across every `commands/*.py` module, (b) per-scan correlation via a `scan_id` UUID4 that flows through JSON output, and (c) a `--log-file` destination with fail-fast validation for cron use.
+
+## Background
+
+cli/v1.8.0 (PR #66, commit `e71a9a8`) landed the structured-logging baseline:
+
+- `gh_manage.logging_config.configure_logging(level, json, stream)` — idempotent, stderr-only
+- root `--log-level` Click option + `GH_MANAGE_LOG_LEVEL` / `GH_MANAGE_LOG_JSON` envvars
+- hybrid plain / JSON formatter (immutable format strings so caplog tests remain stable)
+- 8 concrete log points across `drift_sync/` + `commands/drift.py`
+- `_scan_worker` emits `log.warning` for domain errors and `log.exception` for unknown exceptions
+
+Three follow-up Issues were filed alongside that PR:
+
+- **#63** Roll out logging to remaining commands (`apply`, `labels`, `protection`, `init`, `doctor`)
+- **#64** Add scan_id correlation (UUID4) to drift_sync logs
+- **#65** Add `--log-file` destination flag + `GH_MANAGE_LOG_FILE` envvar
+
+They are independent on the code level (non-overlapping files on most points) but share the same logging infrastructure. Bundling them into one spec/PR/release keeps the story coherent, the release-notes audience singular, and the review cost amortized. The tradeoff (larger single PR) is mitigated by per-Issue test isolation — `tests/unit/test_cli_log_file.py`, `tests/unit/drift/test_scan_id_propagation.py`, and `tests/unit/commands/test_<cmd>_logging.py` can be reviewed independently.
+
+User intent (2026-04-20 brainstorming): the three Issues are the natural conclusion of the cli/v1.8.0 work; no new scope. Explicit decisions:
+
+- Q1 (PR structure) → **A: single PR, cli/v1.9.0**
+- Q2 (scan_id mechanism) → **C: ContextVar with JSON formatter auto-attach**
+- Q3 (`--log-file` output) → **A: dual output (stderr + file)**
+- Q4 (file validation) → **A: fail-fast validate at CLI startup → `UsageError`**
+
+## Goals
+
+1. **#63 coverage**: every `commands/{apply,labels,protection,init,doctor}.py` module has `log = getLogger(__name__)`, entry/exit INFO, and WARNING on silent-fallback branches (404 treated as empty, silent exception catches).
+2. **#64 correlation**: drift scans (both single-repo and `--all` parallel) attach a per-scan UUID4 to every log record; JSON output includes the `scan_id` field; plain output is unchanged; non-drift commands are unaffected.
+3. **#65 destination**: `gh-manage --log-file PATH` (and `GH_MANAGE_LOG_FILE` envvar) write to `PATH` **in addition to** stderr; invalid path (missing parent, no write permission) exits with `UsageError` at startup before any subcommand runs.
+4. **No behavior regression**: existing `click.echo` / `click.secho` user-facing output is unchanged; cli/v1.8.0 test suite + drift_sync tests continue to pass.
+5. **Regression coverage**: each new log point has a caplog-based test; each validator branch has a test; scan_id propagation across threads has a test.
+
+## Non-Goals
+
+- **`scan_id` correlation for non-drift commands** (`apply`, `labels`, `protection`, `init`, `doctor`). No operational need today — a single-shot `apply .` has no natural "scan boundary" to correlate against. Tracked as an ad-hoc Issue only if demand arises.
+- **Log rotation, size limits, retention policies**. External tools (logrotate, GitHub Actions artifact retention, systemd journal) handle this. `configure_logging` does not add `RotatingFileHandler`.
+- **Migration of existing `click.echo` output to logging**. The two layers are intentionally distinct: `click.echo` is user-facing UI, `logging` is operational signal. No migration in this PR.
+- **Silent fallback on `--log-file` write failure**. Q4 rejected — fail-fast is the thought-out position.
+- **Rolling out INFO verbosity granularity** (DEBUG per-check, per-field diff). YAGNI — the current 8 drift log points proved sufficient in PR #66 operational testing.
+- **`issues.py`** remains a stub (pre-v0.5.0). No log added there.
+- **Refactoring shared helpers** beyond the one-file decorator cleanup described in §4.3. No broader cleanup.
+
+## §1 — Architecture overview
+
+### 1.1 Module-level surface
+
+```
+src/gh_manage/
+├── logging_config.py                  MODIFY (+~30 LOC)
+│   └── _ScanIdJsonFormatter (new)    # subclass of JsonFormatter
+│   └── configure_logging(..., log_file=None)  # new kwarg
+├── cli.py                             MODIFY (+~15 LOC)
+│   └── --log-file option + envvar    # root click group
+│   └── _validate_log_file(path)      # fail-fast validator
+├── drift_sync/
+│   ├── context.py                    MODIFY (+~5 LOC)
+│   │   └── scan_id_var: ContextVar   # shared across drift_sync
+│   └── __init__.py                   MODIFY (+~1 LOC)
+│       └── re-export scan_id_var
+├── commands/
+│   ├── drift.py                      MODIFY (+~5 LOC)
+│   │   └── scan_id_var.set/reset in _scan_single_repo
+│   ├── apply.py                      MODIFY (+~15 LOC, log points)
+│   ├── labels.py                     MODIFY (+~20 LOC, log + decorator cleanup)
+│   ├── protection.py                 MODIFY (+~15 LOC, log points)
+│   ├── init.py                       MODIFY (+~15 LOC, log points)
+│   └── doctor.py                     MODIFY (+~10 LOC, log points)
+
+tests/unit/
+├── test_logging_config.py             EXTEND (+~60 LOC)
+├── test_cli_log_file.py               NEW     (~50 LOC)
+├── drift/
+│   └── test_scan_id_propagation.py    NEW     (~60 LOC)
+└── commands/
+    ├── test_apply_logging.py          NEW     (~50 LOC)
+    ├── test_labels_logging.py         NEW     (~50 LOC)
+    ├── test_protection_logging.py     NEW     (~50 LOC)
+    ├── test_init_logging.py           NEW     (~40 LOC)
+    └── test_doctor_logging.py         NEW     (~40 LOC)
+```
+
+Estimated total: ~200 LOC production, ~400 LOC tests, 10 files modified + 6 new test files.
+
+### 1.2 Independence across the three Issues
+
+| Concern (Issue) | Files touched | Conflicts with |
+|---|---|---|
+| scan_id (#64) | `drift_sync/context.py`, `drift_sync/__init__.py`, `commands/drift.py`, `logging_config.py` (formatter only) | — |
+| `--log-file` (#65) | `logging_config.py` (configure_logging kwarg), `cli.py` | — |
+| rollout (#63) | `commands/{apply,labels,protection,init,doctor}.py` | — |
+
+Only `logging_config.py` is touched by both #64 and #65, but they hit disjoint sections (`_ScanIdJsonFormatter` class vs `configure_logging` handler list). Implementation order is free.
+
+### 1.3 Invocation flow (after this spec ships)
+
+```
+$ gh-manage --log-level info --log-file /tmp/ghm.log drift --all
+    └── cli.py:main(log_level, log_file)
+         ├── _validate_log_file(Path("/tmp/ghm.log"))  # UsageError on failure
+         └── configure_logging(level="info", log_file=Path("/tmp/ghm.log"))
+              ├── formatter = _ScanIdJsonFormatter(...) if $GH_MANAGE_LOG_JSON else Formatter(...)
+              ├── handlers = [StreamHandler(stderr), FileHandler("/tmp/ghm.log", "a")]
+              └── gh_logger.handlers = handlers
+
+    └── drift.py:_scan_all_repos → ThreadPoolExecutor
+         └── _scan_worker(entry) (per thread)
+              └── _scan_single_repo(entry.name, ...)
+                   ├── scan_id_var.set(str(uuid4()))   # per-repo UUID
+                   ├── log.info("scanning ...")        # scan_id auto-attached
+                   ├── run_all_checks(ctx)             # every sub-log inherits scan_id
+                   └── scan_id_var.reset(token)        # cleanup
+```
+
+## §2 — scan_id propagation (#64)
+
+### 2.1 ContextVar definition
+
+In `src/gh_manage/drift_sync/context.py` (lowest-layer drift_sync module, imports only stdlib + `gh_manage.models.*`):
+
+```python
+from contextvars import ContextVar
+
+# Per-scan correlation id, set at the entry of _scan_single_repo and
+# reset on exit (including exception paths). Default empty string means
+# "not inside a scan" — the JSON formatter skips the field in that case.
+scan_id_var: ContextVar[str] = ContextVar("scan_id", default="")
+```
+
+Re-exported via `src/gh_manage/drift_sync/__init__.py` for external access (tests, future cross-module consumers).
+
+Rationale for `context.py` placement: `logging_config.py` needs to read `scan_id_var` from its formatter. Putting the ContextVar in `drift_sync/context.py` (which has zero downstream drift_sync dependencies) keeps the import DAG one-directional: `logging_config → drift_sync.context`. Placing it in `logging_config.py` would invert the DAG and require lazy imports.
+
+### 2.2 Set/reset at scan entry
+
+In `src/gh_manage/commands/drift.py:_scan_single_repo`:
+
+```python
+from uuid import uuid4
+from gh_manage.drift_sync.context import scan_id_var
+
+
+def _scan_single_repo(owner_repo, ...):
+    token = scan_id_var.set(str(uuid4()))
+    try:
+        log.info("scanning %s (profile=%s)", owner_repo, profile_name)
+        # ... existing body unchanged ...
+    finally:
+        scan_id_var.reset(token)
+```
+
+Key decisions:
+
+- **`_scan_single_repo` (not `_scan_worker`)**: single-repo mode (`gh-manage drift .`) bypasses `_scan_worker`. Setting in `_scan_single_repo` covers both paths.
+- **Full UUID4 (36 chars, hyphenated)**: enough entropy for any conceivable scale (22 repos × N scans/day for years). Hyphenated form is human-scannable in log output and `jq`-friendly.
+- **`try/finally` around set/reset**: guarantees ContextVar cleanup even when a check raises; prevents a stale scan_id from bleeding into subsequent unrelated log calls made in the same thread (relevant to tests, not production since CLI exits after scan).
+
+### 2.3 JSON formatter auto-attach
+
+In `src/gh_manage/logging_config.py`, subclass `JsonFormatter` to read `scan_id_var` at record-format time:
+
+```python
+from pythonjsonlogger.jsonlogger import JsonFormatter as _BaseJsonFormatter
+from gh_manage.drift_sync.context import scan_id_var
+
+
+class _ScanIdJsonFormatter(_BaseJsonFormatter):
+    """JSON formatter that injects the current scan_id ContextVar.
+
+    When called outside a drift scan (e.g., from `apply` / `labels` /
+    etc.), scan_id_var.get() returns the default empty string, and the
+    field is omitted from the JSON output.
+    """
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        sid = scan_id_var.get()
+        if sid:
+            log_record["scan_id"] = sid
+```
+
+`configure_logging` switches to `_ScanIdJsonFormatter` in JSON mode (replaces the current `JsonFormatter`). Plain-text mode uses the stdlib `logging.Formatter` unchanged — scan_id is intentionally not included in plain output (the user-intent "agent-friendly format" lives in JSON).
+
+### 2.4 Thread propagation guarantee
+
+`ThreadPoolExecutor.submit` in Python ≥3.9 copies the caller's context to the worker thread at submit time. Our design sets `scan_id_var` **inside** the worker (in `_scan_single_repo`), not in the caller. This means each worker thread's local context holds its own independent value; parallel `--all` runs do not interleave scan_ids.
+
+The test `test_scan_id_isolated_per_worker_thread` (§5.3) asserts this empirically.
+
+### 2.5 Example JSON output
+
+```
+$ GH_MANAGE_LOG_JSON=1 gh-manage --log-level info drift --all 2>&1 >/dev/null | jq .
+{
+  "asctime": "2026-04-20T10:23:00",
+  "levelname": "INFO",
+  "name": "gh_manage.commands.drift",
+  "message": "scanning yakkuro/llm-kb (profile=python-service)",
+  "scan_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+{
+  "asctime": "2026-04-20T10:23:02",
+  "levelname": "INFO",
+  "name": "gh_manage.drift_sync.issue_state",
+  "message": "updated drift issue #42 on yakkuro/llm-kb (5 findings)",
+  "scan_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+Useful agent queries:
+
+```bash
+# Find all records for one scan
+jq 'select(.scan_id == "550e8400-...")' logs.ndjson
+
+# Count records per scan
+jq -s 'group_by(.scan_id) | map({scan: .[0].scan_id, count: length})' logs.ndjson
+
+# Find scans with ERROR records
+jq -s 'group_by(.scan_id) | map(select(any(.; .levelname == "ERROR")))' logs.ndjson
+```
+
+## §3 — `--log-file` flag (#65)
+
+### 3.1 Root click option
+
+In `src/gh_manage/cli.py`:
+
+```python
+@click.option(
+    "--log-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    envvar="GH_MANAGE_LOG_FILE",
+    default=None,
+    help=(
+        "Write logs to this file in addition to stderr. Also honours "
+        "GH_MANAGE_LOG_FILE. Parent directory must exist and be writable; "
+        "otherwise the command exits with a usage error."
+    ),
+)
+def main(log_level: str, log_file: Path | None) -> None:
+    level: LogLevel = log_level.lower()  # type: ignore[assignment]
+    if log_file is not None:
+        _validate_log_file(log_file)
+    configure_logging(level=level, log_file=log_file)
+```
+
+### 3.2 Fail-fast validator
+
+```python
+def _validate_log_file(path: Path) -> None:
+    """Raise UsageError if the log file cannot be written to.
+
+    Runs at CLI startup, before any subcommand. Rejects missing parent
+    directory and write-permission failures with actionable messages.
+    Creating the file (0-byte touch via append-open) is intentional —
+    users who pass --log-file have opted into file creation.
+    """
+    parent = path.parent.resolve()
+    if not parent.is_dir():
+        raise click.UsageError(
+            f"--log-file parent directory does not exist: {parent}. "
+            f"Create it or choose a different path."
+        )
+    try:
+        with path.open("a", encoding="utf-8"):
+            pass
+    except OSError as e:
+        raise click.UsageError(
+            f"Cannot write to --log-file {path}: {e}. "
+            f"Check permissions and disk space."
+        ) from e
+```
+
+### 3.3 `configure_logging` dual-handler extension
+
+```python
+def configure_logging(
+    level: LogLevel = "warning",
+    json: bool | None = None,
+    stream: IO[str] | None = None,
+    log_file: Path | None = None,
+) -> None:
+    """Configure gh_manage's logger tree. Idempotent.
+
+    New kwarg in cli/v1.9.0:
+    - log_file: if not None, a FileHandler (append mode, utf-8) is added
+      alongside the stderr StreamHandler. Both handlers share the same
+      formatter. Caller is responsible for validating the path before
+      calling this function (cli.py uses _validate_log_file).
+    """
+    if json is None:
+        json = _env_says_json()
+    if stream is None:
+        stream = sys.stderr
+
+    formatter: logging.Formatter = (
+        _ScanIdJsonFormatter(_JSON_FORMAT, datefmt=_JSON_DATEFMT)
+        if json
+        else logging.Formatter(_PLAIN_FORMAT, datefmt=_PLAIN_DATEFMT)
+    )
+
+    handlers: list[logging.Handler] = [logging.StreamHandler(stream=stream)]
+    if log_file is not None:
+        handlers.append(
+            logging.FileHandler(str(log_file), mode="a", encoding="utf-8")
+        )
+    for h in handlers:
+        h.setFormatter(formatter)
+
+    gh_logger = logging.getLogger("gh_manage")
+    gh_logger.handlers[:] = handlers
+    gh_logger.setLevel(_LOG_LEVELS[level])
+    gh_logger.propagate = False
+```
+
+### 3.4 Decisions table
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| FileHandler mode | `"a"` (append) | daily cron appends to existing log; logrotate `copytruncate` compatible |
+| Format for file | same as stderr (plain or JSON) | unified decision; no per-destination formatter |
+| Encoding | `utf-8` | consistent with existing `_shared.format_files_diff`, `DriftOutputError` |
+| Thread safety | rely on `logging.FileHandler` internal lock | 22-repo parallel `--all` uses a single handler; writes are serialized |
+| Log rotation / retention | **out of scope** | external tools (logrotate, GHA artifact retention) |
+| Validation failure | `UsageError` at startup (fail-fast) | Q4 decision |
+| `--log-file` without `--log-level info` | file still receives WARNING floor | same level applies to both handlers (no per-destination level) |
+
+### 3.5 Defaults matrix
+
+| Invocation | stderr | file |
+|---|---|---|
+| `gh-manage drift .` | WARNING+ plain | — |
+| `gh-manage --log-file /tmp/x.log drift .` | WARNING+ plain | WARNING+ plain |
+| `GH_MANAGE_LOG_JSON=1 gh-manage --log-file /tmp/x.log drift .` | JSON | JSON |
+| `GH_MANAGE_LOG_FILE=/tmp/x.log gh-manage drift --all` | plain | plain (22 scan_ids interleaved) |
+| `gh-manage --log-file /nonexistent/x.log apply .` | — | — (`UsageError`, exit 2) |
+
+## §4 — Command rollout (#63)
+
+### 4.1 Pattern
+
+Every `commands/*.py` module (except `issues.py` stub):
+
+1. `log = logging.getLogger(__name__)` at module top
+2. **Entry INFO**: one line at the start of each click command body (after input validation), recording key args
+3. **Completion INFO**: one line before successful return (summary: how many changes applied, etc.)
+4. **WARNING**: existing silent-fallback branches (404 treated as empty, silent `except`)
+5. **No ERROR**: domain errors bubble to `@handle_errors` which converts to `ClickException` (stderr "Error: ..." + exit 1). A second log.error would be duplicative.
+
+### 4.2 Per-command log points
+
+**`commands/apply.py`**
+
+| Level | Location | Message template |
+|---|---|---|
+| INFO | `apply()` after UsageError check | `apply invoked: repo=%s profile=%s apply=%s also_labels=%s also_protection=%s` |
+| WARNING | `except GhNotFoundError: current_protection = {}` (L123) | `branch protection not configured on %s@main; treating as empty` |
+| WARNING | `except DoctorCheckError` (L213) | `post-apply doctor check failed: %s` (alongside existing click.echo) |
+| INFO | end of successful body (L195 area) | `apply complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d` |
+
+**`commands/labels.py`**
+
+| Level | Location | Message template |
+|---|---|---|
+| INFO | `sync()` entry | `labels sync invoked: repo=%s apply=%s prune=%s` |
+| INFO | `sync()` after apply_diff | `labels sync complete: repo=%s changes=%d` |
+| INFO | `diff_cmd()` entry | `labels diff invoked: repo=%s prune=%s` |
+| INFO | `show()` entry | `labels show invoked: repo=%s` |
+| — | (no WARNING — label ops have no silent fallbacks) | — |
+
+**`commands/protection.py`**
+
+| Level | Location | Message template |
+|---|---|---|
+| INFO | `sync()` entry | `protection sync invoked: repo=%s profile=%s apply=%s downgrade_allowed=%s` |
+| WARNING | `except GhNotFoundError: current = {}` (L152, L240) | `branch protection not configured on %s@main; treating as empty` |
+| WARNING | downgrade path entered with `--apply` | `applying protection downgrade on %s@main: %d field(s) weakened` |
+| INFO | `sync()` successful return (L204) | `protection apply complete: repo=%s fields=%d` |
+| INFO | `diff_cmd()` entry | `protection diff invoked: repo=%s profile=%s` |
+
+**`commands/init.py`**
+
+| Level | Location | Message template |
+|---|---|---|
+| INFO | `init()` after UsageError check | `init invoked: repo=%s profile=%s apply=%s` |
+| WARNING | `except GhNotFoundError: current_protection = {}` (L119) | `branch protection not configured on %s@main; treating as empty` |
+| WARNING | critical findings triggered rollback (L201) | `init aborting: critical doctor findings=%d, rolling back %d file(s)` |
+| WARNING | rollback `unlink` failure (L213) | `init rollback: cannot delete %s: %s` |
+| INFO | end of successful body (L233) | `init complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d` |
+
+**`commands/doctor.py`**
+
+| Level | Location | Message template |
+|---|---|---|
+| INFO | `doctor_cmd()` entry | `doctor invoked: target=%s profile=%s report_mode=%s` |
+| WARNING | `_derive_repo_label` `except Exception` (L43) | `could not derive owner/repo from path %s: %s` |
+| INFO | before final exit decision | `doctor complete: target=%s findings=%d blocking=%d` |
+
+**`commands/issues.py`**: stub (exits 1 "not implemented"). Do not log — the stub will be replaced in cli/v0.5.0 work.
+
+### 4.3 Decorator cleanup in `labels.py`
+
+`src/gh_manage/commands/labels.py` defines its own `_handle_errors` decorator (L50–63) that is functionally identical to `_shared.handle_errors` (imported by every other command). Under the umbrella of this rollout:
+
+- Delete the local `_handle_errors` (L50–63) and its `_F` TypeVar import (L24)
+- Import `from gh_manage.commands._shared import handle_errors`
+- Replace `@_handle_errors` decorators on `sync`, `diff_cmd`, `show` with `@handle_errors`
+- Delete now-unused imports: `functools`, `TypeVar`, `Callable`, `Any`
+
+Scope limit: only this decorator consolidation. No migration of `click.echo` to `log.info`, no reorganization of `labels.py`, no touching `_format_diff`.
+
+Rationale: (1) Issue #38 extracted `_shared.handle_errors` specifically to remove this duplication; `labels.py` was missed in that sweep. (2) Noticed naturally while reading for log point placement. (3) Rollout touches every `commands/` file anyway — cleanup cost is marginal.
+
+### 4.4 Issue labels ignored for log messages
+
+Log messages do not interpolate `Finding.severity`, `DriftIssue.state`, or any other pattern-matched enum. Interpolation uses only plain strings (`repo`, `profile`, counts). This keeps log emission cheap and avoids coupling log format to domain types.
+
+## §5 — Testing strategy
+
+### 5.1 `tests/unit/test_logging_config.py` (extend, +~60 LOC)
+
+| Test name | Assertion |
+|---|---|
+| `test_configure_logging_with_log_file_adds_file_handler` | after `configure_logging(log_file=tmp_path/"x.log")`, `getLogger("gh_manage").handlers` has exactly 2 entries (StreamHandler + FileHandler) |
+| `test_log_file_mode_is_append` | write "existing\n" to file, call configure_logging + log a message, assert final file content starts with "existing\n" |
+| `test_log_file_encoding_is_utf8` | log a message containing "日本語テスト", read file as bytes, decode as utf-8, assert substring present |
+| `test_log_file_and_stderr_get_same_record` | StringIO stream + tmp file, log one message, assert both contain the message |
+| `test_json_formatter_includes_scan_id_when_set` | set `scan_id_var`, configure JSON, log → parse output line as JSON, assert `scan_id` field equals the set value |
+| `test_json_formatter_omits_scan_id_when_unset` | ContextVar default, configure JSON, log → parse, assert `"scan_id" not in parsed` |
+| `test_plain_formatter_omits_scan_id` | set `scan_id_var`, configure plain, log → assert scan_id string not present in output |
+| `test_file_handler_inherits_json_formatter` | configure with log_file + GH_MANAGE_LOG_JSON=1 → file handler's formatter is `_ScanIdJsonFormatter` |
+
+### 5.2 `tests/unit/test_cli_log_file.py` (new, ~50 LOC)
+
+| Test name | Assertion |
+|---|---|
+| `test_validate_log_file_rejects_missing_parent` | `_validate_log_file(Path("/nonexistent/dir/x.log"))` → `UsageError` mentioning "parent directory does not exist" |
+| `test_validate_log_file_rejects_unwritable` | tmp dir with `chmod 0o555`, child path → `UsageError` mentioning "Cannot write" |
+| `test_validate_log_file_accepts_new_path` | `tmp_path / "new.log"` → no error, file exists after call (0-byte) |
+| `test_validate_log_file_accepts_existing_path` | pre-existing file → no error, content preserved |
+| `test_env_var_log_file_honored_via_cli` | CliRunner invoke `gh-manage` with `env={"GH_MANAGE_LOG_FILE": str(tmp_path/"x.log")}`, no `--log-file` flag → file gets records |
+| `test_cli_flag_overrides_env_var` | both set with different paths → flag wins (`click.Option(envvar=...)` semantics; assert flag path has records, env path does not) |
+
+### 5.3 `tests/unit/drift/test_scan_id_propagation.py` (new, ~60 LOC)
+
+| Test name | Assertion |
+|---|---|
+| `test_scan_id_set_at_single_repo_entry` | mock `run_all_checks` to capture `scan_id_var.get()` during scan; assert captured value is UUID4 format (`uuid.UUID(captured)` succeeds) |
+| `test_scan_id_reset_after_single_repo_exit` | call `_scan_single_repo(...)` (with full mocks), after call assert `scan_id_var.get() == ""` |
+| `test_scan_id_reset_even_on_exception` | make `run_all_checks` raise; after the raise propagates, assert `scan_id_var.get() == ""` |
+| `test_scan_id_in_nested_check_logs` | mock a check that captures `scan_id_var.get()`; run via full `_scan_single_repo` path; assert the captured value matches the set UUID |
+| `test_scan_id_isolated_per_worker_thread` | run `_scan_all_repos` with 2 mocked entries + mocked inner functions that capture per-thread scan_id; assert 2 distinct UUID values, both well-formed |
+
+### 5.4 `tests/unit/commands/test_<cmd>_logging.py` (5 new files, ~40–50 LOC each)
+
+Template (applied per command):
+
+| Test name | Assertion |
+|---|---|
+| `test_<cmd>_logs_invocation_at_info` | run command via `CliRunner` at `--log-level info`; caplog has at least one INFO record at `gh_manage.commands.<cmd>` matching "... invoked: ..." |
+| `test_<cmd>_logs_completion_at_info` | run successful command; caplog has INFO at completion matching "... complete: ..." |
+| `test_<cmd>_logs_warning_on_ghnotfound_fallback` | (apply / protection / init) mock `protection_api.get_branch_protection` to raise `GhNotFoundError`; caplog has WARNING "branch protection not configured" |
+| `test_<cmd>_logs_warning_on_doctor_check_error` | (apply only) mock `_doctor.run_on_path` to raise `DoctorCheckError`; caplog has WARNING "post-apply doctor check failed" |
+| `test_<cmd>_logs_warning_on_rollback` | (init only) force rollback path via mocked critical findings; caplog has WARNING "init aborting: critical doctor findings" |
+| `test_<cmd>_logs_warning_on_repo_label_derivation` | (doctor only) pass a path where `get_origin_owner_repo` raises; caplog has WARNING |
+| `test_labels_uses_shared_handle_errors` | (labels only) `assert not hasattr(gh_manage.commands.labels, "_handle_errors")` |
+
+Total new tests: ~25–30 across 5 files.
+
+### 5.5 Integration smoke (manual, pre-merge checklist)
+
+```bash
+# 1. dual output
+gh-manage --log-level info --log-file /tmp/ghm.log drift .
+grep 'scanning' /tmp/ghm.log   # file received records
+# stderr already showed them
+
+# 2. scan_id in JSON mode
+GH_MANAGE_LOG_JSON=1 gh-manage --log-level info drift --all 2>&1 >/dev/null \
+  | jq -s 'group_by(.scan_id) | map({scan: .[0].scan_id, count: length}) | length'
+# Expected: 22 (one scan_id per enabled repo)
+
+# 3. Plain mode does not leak scan_id
+gh-manage --log-level info drift . 2>&1 | grep -c 'scan_id'
+# Expected: 0
+
+# 4. Fail-fast on bad --log-file
+gh-manage --log-file /nonexistent/x.log apply .
+# Expected: exit 2, stderr contains "Usage" + "parent directory does not exist"
+
+# 5. Rollout coverage
+gh-manage --log-level info apply . --profile python-service --dry-run 2>&1 | grep 'apply invoked'
+gh-manage --log-level info labels show yakkuro/llm-kb 2>&1 | grep 'labels show invoked'
+# Similar for protection, init, doctor
+```
+
+### 5.6 Existing test impact
+
+- `tests/unit/drift/test_logging_events.py` (added in PR #66): no change required; records still have the same shape plus optional `scan_id` attribute that existing tests do not assert.
+- `tests/unit/test_logging_config.py`: existing tests pass unchanged; new kwargs default to `None`.
+- Any existing command tests using `CliRunner`: unaffected (no new required option).
+
+## §6 — Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| ContextVar not propagating into ThreadPoolExecutor workers | scan_ids leak/collide across parallel scans | Set inside the worker (`_scan_single_repo`), not the main thread. Test `test_scan_id_isolated_per_worker_thread` verifies. |
+| `--log-file` validation breaks existing CI/cron that passes a bad path | CI goes red on the first cron after upgrade | Document in release notes: "verify GH_MANAGE_LOG_FILE path is writable before upgrading cron workflows." Validation message is actionable. |
+| `logging_config.py → drift_sync.context` introduces an import cycle | ImportError at startup | `drift_sync/context.py` imports only stdlib + `gh_manage.models.*`. No logging import. DAG: `logging_config → drift_sync.context` (one-way). |
+| `labels.py` decorator consolidation changes exception behavior | Silently swallow / newly propagate errors | `_shared.handle_errors` catches the full `_DOMAIN_ERRORS` superset (GhError, ConfigError, GitError, ProfileError, ProtectionError, DriftError, DoctorError). Local `_handle_errors` caught only `(GhError, ConfigError)`. Widened catch → no newly-raised exceptions; potentially newly-caught exceptions produce `ClickException` with better message. Verified by `test_labels_uses_shared_handle_errors` + existing label tests. |
+| FileHandler append-mode leaves stale `scan_id` records in long-running log files that confuse future jq queries | operational noise | Out of scope (logrotate). Release notes call out "consider logrotate for `--log-file` destinations". |
+| New INFO/WARNING emit on commands that previously produced zero stderr (e.g., `labels show`) | users scripting against "empty stderr = success" break | INFO is above the default WARNING floor — no change at default level. WARNING additions are in pre-existing silent-fallback branches (e.g., 404 treated as empty) where adding a log line is the correct behavior. Default-level `labels show yakkuro/llm-kb` continues to emit zero stderr. |
+| `_scan_single_repo` `try/finally` around body shadows internal exceptions | harder to debug | `scan_id_var.reset(token)` cannot raise (documented in contextvars). No suppression risk. |
+
+## §7 — Release plan
+
+- **Tag**: `cli/v1.9.0` — CLI-track minor. Additive: new option, new optional field in JSON output, new INFO/WARNING records.
+- **Release notes** (cli/v1.9.0):
+  - Add `--log-file PATH` + `GH_MANAGE_LOG_FILE` envvar for dual stderr+file output; fail-fast validation at startup
+  - Add `scan_id` correlation id to drift scan logs (UUID4 per scan, appears in JSON mode only)
+  - Structured logging now covers `apply`, `labels`, `protection`, `init`, `doctor` (was drift-only in cli/v1.8.0)
+  - Internal: consolidate `labels.py` error decorator onto `_shared.handle_errors` (no behavior change visible to users)
+  - Closes #63, #64, #65
+- **Migration notes**: none. Defaults preserve cli/v1.8.0 behavior (WARNING floor, stderr only, no scan_id in output).
+- **Cron workflow update**: separate consumer-side PR (not this spec) — enable `GH_MANAGE_LOG_FILE` + `GH_MANAGE_LOG_JSON=1` in the daily `drift --all` job so artifacts are durable and machine-readable.
+
+## §8 — Acceptance Criteria
+
+Production code:
+
+- [ ] `src/gh_manage/drift_sync/context.py`: `scan_id_var: ContextVar[str]` defined with default=""
+- [ ] `src/gh_manage/drift_sync/__init__.py`: `scan_id_var` re-exported
+- [ ] `src/gh_manage/logging_config.py`: `_ScanIdJsonFormatter` class; `configure_logging` has `log_file: Path | None = None` kwarg; dual-handler logic
+- [ ] `src/gh_manage/cli.py`: `--log-file` option + envvar; `_validate_log_file` function; called from root group callback
+- [ ] `src/gh_manage/commands/drift.py:_scan_single_repo`: `scan_id_var.set/reset` wrapping the body
+- [ ] `src/gh_manage/commands/{apply,labels,protection,init,doctor}.py`: module-level `log = logging.getLogger(__name__)`; §4.2 log points implemented; §4.3 decorator consolidation in `labels.py`
+
+Tests:
+
+- [ ] `tests/unit/test_logging_config.py` extended with 8 new tests
+- [ ] `tests/unit/test_cli_log_file.py` (new) with 6 tests
+- [ ] `tests/unit/drift/test_scan_id_propagation.py` (new) with 5 tests
+- [ ] `tests/unit/commands/test_{apply,labels,protection,init,doctor}_logging.py` (5 new) with ~25 tests total
+- [ ] `uv run pytest -q` all pass (baseline 587 + ~44 new ≈ 631 tests)
+
+Quality gates:
+
+- [ ] `uvx ruff@0.8.0 check src/ tests/` clean
+- [ ] `uvx ruff@0.8.0 format --check src/ tests/` clean
+- [ ] `uv run mypy src/` clean
+
+Integration:
+
+- [ ] §5.5 manual smoke steps all pass
+- [ ] `gh-manage drift --all 2>&1 | grep -c ERROR` returns 0 on clean fleet
+
+Release:
+
+- [ ] Version bump to `1.9.0` in `__init__.py`, `pyproject.toml`, `tests/test_sanity.py`, `uv.lock`
+- [ ] PR open, 4-reviewer protocol complete, CRITICAL/HIGH findings addressed
+- [ ] `cli/v1.9.0` tag + GitHub release with notes per §7
+- [ ] Issues #63, #64, #65 closed with reference to this PR
+
+## §9 — Open Questions
+
+None. Q1–Q4 (2026-04-20 brainstorming) resolved all design decisions:
+
+- **Q1** (PR structure): A — single cli/v1.9.0 PR bundling all three Issues
+- **Q2** (scan_id mechanism): C — ContextVar + `_ScanIdJsonFormatter` auto-attach
+- **Q3** (--log-file output): A — dual stderr + file, shared formatter
+- **Q4** (validation failure): A — fail-fast at startup via `UsageError`
+
+## References
+
+- Baseline PR: [#66](https://github.com/yakkuro/gh-manage/pull/66) (`cli/v1.8.0`)
+- Issues addressed: [#63](https://github.com/yakkuro/gh-manage/issues/63), [#64](https://github.com/yakkuro/gh-manage/issues/64), [#65](https://github.com/yakkuro/gh-manage/issues/65)
+- Related Theme A umbrella: [#47](https://github.com/yakkuro/gh-manage/issues/47)
+- cli/v1.8.0 design spec: `docs/specs/2026-04-19-drift-sync-logging-design.md`
+- `python-json-logger`: https://github.com/madzak/python-json-logger (pinned `>=2.0,<3.0` in cli/v1.8.0)
+- `contextvars` in ThreadPoolExecutor: PEP 567, Python 3.9+ context copy at submit
+- Current baseline: commit `e71a9a8` on `main`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gh-manage"
-version = "1.8.0"
+version = "1.9.0"
 description = "GitHub-based CI/CD, Issue management, and operational system for yakkuro/* repositories."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/gh_manage/__init__.py
+++ b/src/gh_manage/__init__.py
@@ -1,3 +1,3 @@
 """gh-manage: GitHub-based CI/CD, Issue management, and operational system."""
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"

--- a/src/gh_manage/cli.py
+++ b/src/gh_manage/cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 
 from gh_manage import __version__
@@ -15,6 +17,29 @@ from gh_manage.commands import (
     protection as protection_cmd,
 )
 from gh_manage.logging_config import LogLevel, configure_logging
+
+
+def _validate_log_file(path: Path) -> None:
+    """Raise UsageError if the log file cannot be written to.
+
+    Runs at CLI startup, before any subcommand. Rejects missing parent
+    directory and write-permission failures with actionable messages.
+    Creating the file (0-byte touch via append-open) is intentional —
+    users who pass --log-file have opted into file creation.
+    """
+    parent = path.parent.resolve()
+    if not parent.is_dir():
+        raise click.UsageError(
+            f"--log-file parent directory does not exist: {parent}. "
+            f"Create it or choose a different path."
+        )
+    try:
+        with path.open("a", encoding="utf-8"):
+            pass
+    except OSError as e:
+        raise click.UsageError(
+            f"Cannot write to --log-file {path}: {e}. Check permissions and disk space."
+        ) from e
 
 
 @click.group(

--- a/src/gh_manage/cli.py
+++ b/src/gh_manage/cli.py
@@ -61,10 +61,23 @@ def _validate_log_file(path: Path) -> None:
         "GH_MANAGE_LOG_LEVEL. For JSON output, set GH_MANAGE_LOG_JSON=1."
     ),
 )
-def main(log_level: str) -> None:
+@click.option(
+    "--log-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    envvar="GH_MANAGE_LOG_FILE",
+    default=None,
+    help=(
+        "Write logs to this file in addition to stderr. Also honours "
+        "GH_MANAGE_LOG_FILE. Parent directory must exist and be writable; "
+        "otherwise the command exits with a usage error."
+    ),
+)
+def main(log_level: str, log_file: Path | None) -> None:
     """Root command group. Subcommands are registered below."""
     level: LogLevel = log_level.lower()  # type: ignore[assignment]
-    configure_logging(level=level)
+    if log_file is not None:
+        _validate_log_file(log_file)
+    configure_logging(level=level, log_file=log_file)
 
 
 main.add_command(init_cmd.init)

--- a/src/gh_manage/commands/apply.py
+++ b/src/gh_manage/commands/apply.py
@@ -214,14 +214,6 @@ def apply(
         + "."
     )
 
-    log.info(
-        "apply complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d",
-        owner_repo,
-        n_file_changes,
-        n_label_changes,
-        n_protection_changes,
-    )
-
     # Post-apply doctor warnings (spec §5 enforcement scope).
     # apply NEVER blocks on doctor FINDINGS; critical/high go to stderr
     # for visibility. But apply DOES propagate doctor *setup* errors
@@ -240,7 +232,10 @@ def apply(
         click.echo(f"WARNING: post-apply doctor check failed: {exc}", err=True)
         findings = ()
     # DoctorError / GhError / GitError / ConfigError propagate to
-    # handle_errors and surface as ClickException — intentional.
+    # handle_errors and surface as ClickException — intentional. The
+    # "apply complete" INFO therefore sits AFTER this point so that
+    # monitoring consumers don't misread a successful marker when the
+    # command exits non-zero.
 
     blocking = tuple(f for f in findings if f.severity in ("critical", "high"))
     if blocking:
@@ -257,3 +252,11 @@ def apply(
             "Not failing apply — run `gh-manage doctor` to review.",
             err=True,
         )
+
+    log.info(
+        "apply complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d",
+        owner_repo,
+        n_file_changes,
+        n_label_changes,
+        n_protection_changes,
+    )

--- a/src/gh_manage/commands/apply.py
+++ b/src/gh_manage/commands/apply.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import click
@@ -23,6 +24,8 @@ from gh_manage.github_client import GhNotFoundError
 from gh_manage.models.branch_protection import BranchProtectionConfig
 from gh_manage.models.labels import LabelsConfig
 from gh_manage.models.profiles import ProfileSpec
+
+log = logging.getLogger(__name__)
 
 
 @click.command(
@@ -75,6 +78,15 @@ def apply(
     # Precheck: derive owner/repo from origin
     owner_repo = git_cli.get_origin_owner_repo(target)
 
+    log.info(
+        "apply invoked: repo=%s profile=%s apply=%s also_labels=%s also_protection=%s",
+        owner_repo,
+        profile_name,
+        apply_flag,
+        also_labels,
+        also_protection,
+    )
+
     # Load profile from package data
     profile_path = resolve_profile_path(profile_name)
     profile = load_config(profile_path, ProfileSpec)
@@ -121,6 +133,10 @@ def apply(
                 owner_repo, "main"
             )
         except GhNotFoundError:
+            log.warning(
+                "branch protection not configured on %s@main; treating as empty",
+                owner_repo,
+            )
             current_protection = {}
         protection_diff = protection_sync.compute_protection_diff(
             current_protection, policy, profile, "main"
@@ -198,6 +214,14 @@ def apply(
         + "."
     )
 
+    log.info(
+        "apply complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d",
+        owner_repo,
+        n_file_changes,
+        n_label_changes,
+        n_protection_changes,
+    )
+
     # Post-apply doctor warnings (spec §5 enforcement scope).
     # apply NEVER blocks on doctor FINDINGS; critical/high go to stderr
     # for visibility. But apply DOES propagate doctor *setup* errors
@@ -212,6 +236,7 @@ def apply(
         findings = _doctor.run_on_path(target, profile_name=profile_name)
     except DoctorCheckError as exc:
         # Per-check failure (malformed ci.yml etc.) is a warning only.
+        log.warning("post-apply doctor check failed: %s", exc)
         click.echo(f"WARNING: post-apply doctor check failed: {exc}", err=True)
         findings = ()
     # DoctorError / GhError / GitError / ConfigError propagate to

--- a/src/gh_manage/commands/doctor.py
+++ b/src/gh_manage/commands/doctor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import click
@@ -10,6 +11,8 @@ from gh_manage import doctor as doctor_pkg
 from gh_manage.commands._shared import handle_errors
 from gh_manage.doctor import report as doctor_report
 from gh_manage.findings import Finding, Severity
+
+log = logging.getLogger(__name__)
 
 _REPORT_MODES = ("stdout", "json", "markdown-file")
 _BLOCKING_SEVERITIES: tuple[Severity, ...] = ("critical", "high")
@@ -40,7 +43,8 @@ def _derive_repo_label(path: Path, *, fallback: str) -> str:
 
     try:
         return git_cli.get_origin_owner_repo(path)
-    except Exception:
+    except Exception as e:
+        log.warning("could not derive owner/repo from path %s: %s", path, e)
         return fallback
 
 
@@ -77,6 +81,13 @@ def doctor_cmd(
     output: Path | None,
     exit_zero: bool,
 ) -> None:
+    log.info(
+        "doctor invoked: target=%s profile=%s report_mode=%s",
+        target,
+        profile_name,
+        report_mode,
+    )
+
     if _looks_like_owner_repo(target):
         findings = doctor_pkg.run_on_remote(target, profile_name)
         repo = target
@@ -103,6 +114,14 @@ def doctor_cmd(
             doctor_report.format_markdown(findings, repo=repo),
             encoding="utf-8",
         )
+
+    blocking_count = sum(1 for f in findings if f.severity in _BLOCKING_SEVERITIES)
+    log.info(
+        "doctor complete: target=%s findings=%d blocking=%d",
+        target,
+        len(findings),
+        blocking_count,
+    )
 
     if exit_zero:
         return

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -72,7 +72,11 @@ def _scan_single_repo(
     Returns:
         Status/result string for the repo.
     """
-    token = scan_id_var.set(str(uuid4()))
+    # Only set scan_id if we're the outermost scope. When called from
+    # _scan_worker (--all mode), the worker has already set it so failure
+    # logs in the worker's except blocks inherit the same id. Direct CLI
+    # single-repo invocations hit this branch.
+    token = scan_id_var.set(str(uuid4())) if not scan_id_var.get() else None
     try:
         log.info("scanning %s (profile=%s)", owner_repo, profile_name)
         # Get default branch
@@ -153,7 +157,8 @@ def _scan_single_repo(
             case _:
                 raise ValueError(f"Unknown report mode: {report_mode!r}")
     finally:
-        scan_id_var.reset(token)
+        if token is not None:
+            scan_id_var.reset(token)
 
 
 def _scan_worker(
@@ -173,40 +178,49 @@ def _scan_worker(
 
     Module-level (not a closure) so tests can invoke the real production
     function directly without replicating its shape inline.
+
+    The scan_id ContextVar is set HERE (not only in _scan_single_repo) so
+    the warning/exception logs below inherit the same id as the per-repo
+    scan logs — otherwise `_scan_single_repo`'s finally would have already
+    reset the id by the time the except blocks fire.
     """
+    token = scan_id_var.set(str(uuid4()))
     try:
-        result_str = _scan_single_repo(
-            entry.name,
-            entry.profile,
-            severity,
-            report_mode,
-            output,
-            skip_profile_check=True,
-        )
-        return (entry.name, "OK", result_str)
-    except (
-        GhError,
-        ConfigError,
-        GitError,
-        ProfileError,
-        ProtectionError,
-        DriftError,
-    ) as e:
-        log.warning(
-            "expected error scanning %s (%s): %s",
-            entry.name,
-            type(e).__name__,
-            e,
-        )
-        return (entry.name, "FAILED", e)
-    except Exception as e:  # noqa: BLE001 — parallel isolation, spec §2
-        log.exception(
-            "unexpected error scanning %s (%s: %s)",
-            entry.name,
-            type(e).__name__,
-            e,
-        )
-        return (entry.name, "FAILED", e)
+        try:
+            result_str = _scan_single_repo(
+                entry.name,
+                entry.profile,
+                severity,
+                report_mode,
+                output,
+                skip_profile_check=True,
+            )
+            return (entry.name, "OK", result_str)
+        except (
+            GhError,
+            ConfigError,
+            GitError,
+            ProfileError,
+            ProtectionError,
+            DriftError,
+        ) as e:
+            log.warning(
+                "expected error scanning %s (%s): %s",
+                entry.name,
+                type(e).__name__,
+                e,
+            )
+            return (entry.name, "FAILED", e)
+        except Exception as e:  # noqa: BLE001 — parallel isolation, spec §2
+            log.exception(
+                "unexpected error scanning %s (%s: %s)",
+                entry.name,
+                type(e).__name__,
+                e,
+            )
+            return (entry.name, "FAILED", e)
+    finally:
+        scan_id_var.reset(token)
 
 
 def _scan_all_repos(

--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -15,10 +15,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from uuid import uuid4
 
 import click
 
 from gh_manage import drift_sync, git_cli
+from gh_manage.drift_sync.context import scan_id_var
 from gh_manage.commands._shared import (
     handle_errors,
     resolve_branch_protection_path,
@@ -70,84 +72,88 @@ def _scan_single_repo(
     Returns:
         Status/result string for the repo.
     """
-    log.info("scanning %s (profile=%s)", owner_repo, profile_name)
-    # Get default branch
-    default_branch = repo_info.get_default_branch(owner_repo)
+    token = scan_id_var.set(str(uuid4()))
+    try:
+        log.info("scanning %s (profile=%s)", owner_repo, profile_name)
+        # Get default branch
+        default_branch = repo_info.get_default_branch(owner_repo)
 
-    # Load profile and configs
-    profile = load_config(resolve_profile_path(profile_name), ProfileSpec)
-    labels_config = load_config(resolve_default_labels_path(), LabelsConfig)
+        # Load profile and configs
+        profile = load_config(resolve_profile_path(profile_name), ProfileSpec)
+        labels_config = load_config(resolve_default_labels_path(), LabelsConfig)
 
-    bp_config: BranchProtectionConfig | None = None
-    if profile.protection_policy is not None:
-        bp_config = load_config(
-            resolve_branch_protection_path(), BranchProtectionConfig
-        )
-        if profile.protection_policy not in bp_config.policies:
-            from gh_manage.protection_sync import ProtectionPolicyNotFoundError
-
-            raise ProtectionPolicyNotFoundError(
-                f"Policy {profile.protection_policy!r} not found in "
-                f"branch-protection.yml. Available policies: "
-                f"{sorted(bp_config.policies.keys())}."
+        bp_config: BranchProtectionConfig | None = None
+        if profile.protection_policy is not None:
+            bp_config = load_config(
+                resolve_branch_protection_path(), BranchProtectionConfig
             )
+            if profile.protection_policy not in bp_config.policies:
+                from gh_manage.protection_sync import ProtectionPolicyNotFoundError
 
-    # In --all mode, use a dummy empty path (skip_profile_check=True)
-    # In normal mode, use the actual path
-    if skip_profile_check:
-        import tempfile
+                raise ProtectionPolicyNotFoundError(
+                    f"Policy {profile.protection_policy!r} not found in "
+                    f"branch-protection.yml. Available policies: "
+                    f"{sorted(bp_config.policies.keys())}."
+                )
 
-        scan_path = (
-            Path(tempfile.gettempdir())
-            / f"gh-manage-scan-{owner_repo.replace('/', '-')}"
-        )
-        scan_path.mkdir(exist_ok=True)
-    else:
-        scan_path = Path.cwd().resolve()
+        # In --all mode, use a dummy empty path (skip_profile_check=True)
+        # In normal mode, use the actual path
+        if skip_profile_check:
+            import tempfile
 
-    ctx = ScanContext(
-        path=scan_path,
-        repo=owner_repo,
-        default_branch=default_branch,
-        profile=profile,
-        labels_config=labels_config,
-        bp_config=bp_config,
-    )
-
-    all_findings = drift_sync.run_all_checks(ctx)
-    log.info("scan complete for %s: %d findings", owner_repo, len(all_findings))
-    filtered = drift_sync._filter_by_severity(all_findings, severity)  # type: ignore[arg-type]
-
-    match report_mode:
-        case "stdout":
-            rendered = drift_sync.format_stdout_report(filtered)
-            return rendered
-        case "json":
-            rendered = drift_sync.format_json_report(filtered)
-            return rendered
-        case "markdown-file":
-            rendered = drift_sync.format_markdown_report(filtered)
-            if output is not None:
-                try:
-                    output.write_text(rendered, encoding="utf-8")
-                except OSError as e:
-                    raise DriftOutputError(
-                        f"Cannot write drift report to {output}: {e}. "
-                        f"Check disk space, write permissions, and that the parent "
-                        f"directory exists."
-                    ) from e
-            return f"Report written to {output}"
-        case "issue":
-            from datetime import datetime, timezone
-
-            status = drift_sync.resolve_drift_issue(
-                filtered,
-                owner_repo,
-                datetime.now(timezone.utc).isoformat(),
+            scan_path = (
+                Path(tempfile.gettempdir())
+                / f"gh-manage-scan-{owner_repo.replace('/', '-')}"
             )
-            return status
-        case _:
-            raise ValueError(f"Unknown report mode: {report_mode!r}")
+            scan_path.mkdir(exist_ok=True)
+        else:
+            scan_path = Path.cwd().resolve()
+
+        ctx = ScanContext(
+            path=scan_path,
+            repo=owner_repo,
+            default_branch=default_branch,
+            profile=profile,
+            labels_config=labels_config,
+            bp_config=bp_config,
+        )
+
+        all_findings = drift_sync.run_all_checks(ctx)
+        log.info("scan complete for %s: %d findings", owner_repo, len(all_findings))
+        filtered = drift_sync._filter_by_severity(all_findings, severity)  # type: ignore[arg-type]
+
+        match report_mode:
+            case "stdout":
+                rendered = drift_sync.format_stdout_report(filtered)
+                return rendered
+            case "json":
+                rendered = drift_sync.format_json_report(filtered)
+                return rendered
+            case "markdown-file":
+                rendered = drift_sync.format_markdown_report(filtered)
+                if output is not None:
+                    try:
+                        output.write_text(rendered, encoding="utf-8")
+                    except OSError as e:
+                        raise DriftOutputError(
+                            f"Cannot write drift report to {output}: {e}. "
+                            f"Check disk space, write permissions, and that the parent "
+                            f"directory exists."
+                        ) from e
+                return f"Report written to {output}"
+            case "issue":
+                from datetime import datetime, timezone
+
+                status = drift_sync.resolve_drift_issue(
+                    filtered,
+                    owner_repo,
+                    datetime.now(timezone.utc).isoformat(),
+                )
+                return status
+            case _:
+                raise ValueError(f"Unknown report mode: {report_mode!r}")
+    finally:
+        scan_id_var.reset(token)
 
 
 def _scan_worker(

--- a/src/gh_manage/commands/init.py
+++ b/src/gh_manage/commands/init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import click
@@ -25,6 +26,8 @@ from gh_manage.github_client import GhNotFoundError
 from gh_manage.models.branch_protection import BranchProtectionConfig
 from gh_manage.models.labels import LabelsConfig
 from gh_manage.models.profiles import ProfileSpec
+
+log = logging.getLogger(__name__)
 
 
 @click.command(
@@ -77,6 +80,13 @@ def init(
     # Precheck: derive owner/repo from origin remote
     owner_repo = git_cli.get_origin_owner_repo(target)
 
+    log.info(
+        "init invoked: repo=%s profile=%s apply=%s",
+        owner_repo,
+        profile_name,
+        apply_flag,
+    )
+
     # Load profile from package data
     profile_path = resolve_profile_path(profile_name)
     profile = load_config(profile_path, ProfileSpec)
@@ -117,6 +127,10 @@ def init(
                 owner_repo, "main"
             )
         except GhNotFoundError:
+            log.warning(
+                "branch protection not configured on %s@main; treating as empty",
+                owner_repo,
+            )
             current_protection = {}
         protection_diff = protection_sync.compute_protection_diff(
             current_protection, policy, profile, "main"
@@ -198,6 +212,11 @@ def init(
     findings = doctor_pkg.run_on_path(target, profile_name=profile_name)
     critical = tuple(f for f in findings if f.severity == "critical")
     if critical:
+        log.warning(
+            "init aborting: critical doctor findings=%d, rolling back %d file(s)",
+            len(critical),
+            len(created_paths),
+        )
         click.echo("", err=True)
         click.echo("init post-check found critical findings:", err=True)
         click.echo(
@@ -210,6 +229,11 @@ def init(
                 if p.is_file():
                     p.unlink()
             except OSError as roll_err:
+                log.warning(
+                    "init rollback: cannot delete %s: %s",
+                    p,
+                    roll_err,
+                )
                 failed_deletes.append((p, roll_err))
         if failed_deletes:
             click.echo("", err=True)
@@ -230,6 +254,16 @@ def init(
             "files. See docs/specs/2026-04-17-doctor-guardrail-design.md §5."
         )
 
+    n_protection_changes_final = (
+        len(protection_diff.changes) if protection_diff is not None else 0
+    )
+    log.info(
+        "init complete: repo=%s file_changes=%d label_changes=%d protection_changes=%d",
+        owner_repo,
+        len(files_diff.creates) + len(files_diff.overwrites),
+        labels_diff.total_changes,
+        n_protection_changes_final,
+    )
     click.echo("\nDone. Next steps:")
     click.echo("  git status                # review what gh-manage placed")
     click.echo("  git add <gh-manage paths> # stage only the new files")

--- a/src/gh_manage/commands/labels.py
+++ b/src/gh_manage/commands/labels.py
@@ -2,26 +2,24 @@
 
 from __future__ import annotations
 
-import functools
+import logging
 import sys
-from collections.abc import Callable
 from importlib.resources import files
 from pathlib import Path
-from typing import Any, TypeVar
 
 import click
 
 from gh_manage import labels_sync
-from gh_manage.config import ConfigError, load_config
+from gh_manage.commands._shared import handle_errors
+from gh_manage.config import load_config
 from gh_manage.github_api import labels as labels_api
-from gh_manage.github_client import GhError
 from gh_manage.labels_sync import LabelsDiff
 from gh_manage.models.labels import LabelsConfig
 from gh_manage.repo_ref import parse_repo
 
 DEFAULT_CONFIG_PATH = Path(str(files("gh_manage.data") / "labels.yml"))
 
-_F = TypeVar("_F", bound=Callable[..., Any])
+log = logging.getLogger(__name__)
 
 
 def _format_diff(diff: LabelsDiff) -> str:
@@ -45,22 +43,6 @@ def _format_diff(diff: LabelsDiff) -> str:
     for delete in diff.deletes:
         lines.append(f"- {delete.name}")
     return "\n".join(lines)
-
-
-def _handle_errors(func: _F) -> _F:
-    """Decorator: catch GhError/ConfigError and re-raise as click.ClickException.
-
-    click.ClickException prints `Error: <msg>` to stderr and exits 1.
-    """
-
-    @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        try:
-            return func(*args, **kwargs)
-        except (GhError, ConfigError) as e:
-            raise click.ClickException(str(e)) from e
-
-    return wrapper  # type: ignore[return-value]
 
 
 @click.group(help="Synchronize GitHub repo labels against the bundled labels.yml.")
@@ -98,7 +80,7 @@ def labels() -> None:
     default=DEFAULT_CONFIG_PATH,
     help="Path to labels.yml.",
 )
-@_handle_errors
+@handle_errors
 def sync(
     repo: str,
     apply_flag: bool,
@@ -108,6 +90,8 @@ def sync(
 ) -> None:
     if apply_flag and dry_run:
         raise click.UsageError("--apply and --dry-run are mutually exclusive.")
+
+    log.info("labels sync invoked: repo=%s apply=%s prune=%s", repo, apply_flag, prune)
 
     qualified = parse_repo(repo)
     config = load_config(config_path, LabelsConfig)
@@ -129,6 +113,7 @@ def sync(
 
     click.echo("")
     labels_sync.apply_diff(diff, qualified, progress=click.echo)
+    log.info("labels sync complete: repo=%s changes=%d", qualified, diff.total_changes)
     click.echo(f"\nApplied {diff.total_changes} changes.")
 
 
@@ -151,8 +136,9 @@ def sync(
     type=click.Path(exists=True, path_type=Path),
     default=DEFAULT_CONFIG_PATH,
 )
-@_handle_errors
+@handle_errors
 def diff_cmd(repo: str, prune: bool, config_path: Path) -> None:
+    log.info("labels diff invoked: repo=%s prune=%s", repo, prune)
     qualified = parse_repo(repo)
     config = load_config(config_path, LabelsConfig)
     current = labels_api.list_labels(qualified)
@@ -172,11 +158,12 @@ def diff_cmd(repo: str, prune: bool, config_path: Path) -> None:
     help="List current labels on a repo (read-only).",
 )
 @click.argument("repo")
-@_handle_errors
+@handle_errors
 def show(repo: str) -> None:
     """Show does NOT load config/labels.yml — it lists the repo's current
     state. No --config flag, no config validation. The only failure modes
     are GhError subclasses from the list_labels call."""
+    log.info("labels show invoked: repo=%s", repo)
     qualified = parse_repo(repo)
     current = labels_api.list_labels(qualified)
     for label in sorted(current, key=lambda lb: lb.name):

--- a/src/gh_manage/commands/protection.py
+++ b/src/gh_manage/commands/protection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
@@ -24,6 +25,8 @@ from gh_manage.protection_sync import (
     ProtectionDowngradeError,
     ProtectionPolicyNotFoundError,
 )
+
+log = logging.getLogger(__name__)
 
 
 def _is_tty_stdin() -> bool:
@@ -145,12 +148,24 @@ def sync(
     target = path.resolve()
     owner_repo = git_cli.get_origin_owner_repo(target)
 
+    log.info(
+        "protection sync invoked: repo=%s profile=%s apply=%s downgrade_allowed=%s",
+        owner_repo,
+        profile_name,
+        apply_flag,
+        downgrade_allowed,
+    )
+
     profile, bp_config = _load_profile_and_policy(profile_name)
     policy = bp_config.policies[profile.protection_policy]  # type: ignore[index]
 
     try:
         current = protection_api.get_branch_protection(owner_repo, "main")
     except GhNotFoundError:
+        log.warning(
+            "branch protection not configured on %s@main; treating as empty",
+            owner_repo,
+        )
         current = {}  # no protection yet → treat as empty
 
     diff = protection_sync.compute_protection_diff(current, policy, profile, "main")
@@ -191,6 +206,12 @@ def sync(
                 "downgrade in CI/non-interactive contexts."
             )
 
+        log.warning(
+            "applying protection downgrade on %s@main: %d field(s) weakened",
+            owner_repo,
+            len(diff.downgrades),
+        )
+
     backup_dir = resolve_backup_dir()
     click.echo("")
     protection_sync.apply_protection_diff(
@@ -201,6 +222,13 @@ def sync(
         backup_dir=backup_dir,
         progress=click.echo,
     )
+
+    log.info(
+        "protection apply complete: repo=%s fields=%d",
+        owner_repo,
+        len(diff.changes),
+    )
+
     click.echo(f"\nDone. Protection updated for {owner_repo}:main.")
 
 
@@ -232,12 +260,22 @@ def diff_cmd(path: Path, profile_name: str, downgrade_allowed: bool) -> None:
     target = path.resolve()
     owner_repo = git_cli.get_origin_owner_repo(target)
 
+    log.info(
+        "protection diff invoked: repo=%s profile=%s",
+        owner_repo,
+        profile_name,
+    )
+
     profile, bp_config = _load_profile_and_policy(profile_name)
     policy = bp_config.policies[profile.protection_policy]  # type: ignore[index]
 
     try:
         current = protection_api.get_branch_protection(owner_repo, "main")
     except GhNotFoundError:
+        log.warning(
+            "branch protection not configured on %s@main; treating as empty",
+            owner_repo,
+        )
         current = {}
 
     diff = protection_sync.compute_protection_diff(current, policy, profile, "main")

--- a/src/gh_manage/drift_sync/__init__.py
+++ b/src/gh_manage/drift_sync/__init__.py
@@ -37,6 +37,7 @@ from gh_manage.drift_sync.context import (  # noqa: F401
     DriftError,
     DriftOutputError,
     ScanContext,
+    scan_id_var,
 )
 
 # ---- Registry (drift_sync.registry) ----
@@ -104,6 +105,7 @@ __all__ = [
     "ScanContext",
     "DriftError",
     "DriftOutputError",
+    "scan_id_var",
     # Registry
     "CheckFn",
     "register_check",

--- a/src/gh_manage/drift_sync/context.py
+++ b/src/gh_manage/drift_sync/context.py
@@ -7,6 +7,7 @@ submodules are allowed to import from here.
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -49,3 +50,6 @@ class DriftError(Exception):
 class DriftOutputError(DriftError):
     """Failed to write the drift report to --output <path>. Wraps the
     underlying OSError with an actionable message."""
+
+
+scan_id_var: ContextVar[str] = ContextVar("scan_id", default="")

--- a/src/gh_manage/drift_sync/context.py
+++ b/src/gh_manage/drift_sync/context.py
@@ -52,4 +52,8 @@ class DriftOutputError(DriftError):
     underlying OSError with an actionable message."""
 
 
+# Per-scan correlation id. Set at the entry of _scan_single_repo
+# (commands/drift.py) and reset on exit. Default empty string means
+# "not inside a scan" — the JSON formatter skips the field in that case.
+# See docs/specs/2026-04-20-structured-logging-followups-design.md §2.
 scan_id_var: ContextVar[str] = ContextVar("scan_id", default="")

--- a/src/gh_manage/logging_config.py
+++ b/src/gh_manage/logging_config.py
@@ -19,7 +19,10 @@ import os
 import sys
 from typing import IO, Literal
 
-from pythonjsonlogger.jsonlogger import JsonFormatter
+from pythonjsonlogger.jsonlogger import JsonFormatter as _BaseJsonFormatter
+
+from gh_manage.drift_sync.context import scan_id_var
+
 
 LogLevel = Literal["debug", "info", "warning", "error"]
 
@@ -36,6 +39,21 @@ _JSON_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
 _JSON_DATEFMT = "%Y-%m-%dT%H:%M:%S"
 
 _TRUTHY = {"1", "true", "yes"}
+
+
+class _ScanIdJsonFormatter(_BaseJsonFormatter):
+    """JSON formatter that injects the current scan_id ContextVar.
+
+    When called outside a drift scan, scan_id_var.get() returns the
+    default empty string, and the field is omitted from the JSON
+    output. See docs/specs/2026-04-20-structured-logging-followups-design.md §2.
+    """
+
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        sid = scan_id_var.get()
+        if sid:
+            log_record["scan_id"] = sid
 
 
 def _env_says_json() -> bool:
@@ -78,7 +96,7 @@ def configure_logging(
 
     formatter: logging.Formatter
     if json:
-        formatter = JsonFormatter(_JSON_FORMAT, datefmt=_JSON_DATEFMT)
+        formatter = _ScanIdJsonFormatter(_JSON_FORMAT, datefmt=_JSON_DATEFMT)
     else:
         formatter = logging.Formatter(_PLAIN_FORMAT, datefmt=_PLAIN_DATEFMT)
 

--- a/src/gh_manage/logging_config.py
+++ b/src/gh_manage/logging_config.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import IO, Literal
 
 from pythonjsonlogger.jsonlogger import JsonFormatter as _BaseJsonFormatter
@@ -65,28 +66,31 @@ def configure_logging(
     level: LogLevel = "warning",
     json: bool | None = None,
     stream: IO[str] | None = None,
+    log_file: Path | None = None,
 ) -> None:
-    """Configure gh_manage's root logger tree. Idempotent.
+    """Configure gh_manage's root logger tree.
+
+    Handler-replacement semantics (not merge-idempotent across
+    differing args): each call replaces the existing handler list on
+    the `gh_manage` logger with a fresh set built from the arguments.
+    Calling twice with the same arguments produces the same resulting
+    configuration (end-state idempotent), but calling twice with
+    different log_file values does NOT merge — the second call
+    replaces the first. The CLI invokes this exactly once per process.
 
     - level: log level for the `gh_manage` logger tree. Third-party
       packages' loggers are untouched.
-    - json: tri-state. Precedence: explicit `json=True/False` wins
-      over env var. If `json is None` (default), read
-      `GH_MANAGE_LOG_JSON` env var; truthy values ("1", "true", "yes",
-      case-insensitive) → JSON, everything else → plain.
-    - stream: destination for log output. Defaults to sys.stderr.
-      Production callers (cli.py) should omit this argument. Unit
-      tests pass a StringIO to capture output without touching real
-      stderr.
-
-    Side effect: clears existing handlers on the `gh_manage` logger and
-    replaces them with a single StreamHandler bound to `stream`.
-    Callers should invoke this exactly once, at CLI entry.
+    - json: tri-state. Explicit True/False wins over env var
+      GH_MANAGE_LOG_JSON; None reads env.
+    - stream: destination for stderr handler. Defaults to sys.stderr.
+      Tests pass a StringIO to capture output.
+    - log_file: optional destination for a FileHandler (append mode,
+      utf-8). When set, a FileHandler is added alongside the stderr
+      StreamHandler; both handlers share the same formatter. Caller is
+      responsible for validating the path (cli.py uses _validate_log_file).
 
     Immutability: the plain and JSON formatter strings (including
     datefmt) are fixed by this module — not runtime-configurable.
-    Changing them requires editing logging_config.py, so caplog-based
-    tests can rely on the record shape.
     """
     if json is None:
         json = _env_says_json()
@@ -100,13 +104,13 @@ def configure_logging(
     else:
         formatter = logging.Formatter(_PLAIN_FORMAT, datefmt=_PLAIN_DATEFMT)
 
-    handler = logging.StreamHandler(stream=stream)
-    handler.setFormatter(formatter)
+    handlers: list[logging.Handler] = [logging.StreamHandler(stream=stream)]
+    if log_file is not None:
+        handlers.append(logging.FileHandler(str(log_file), mode="a", encoding="utf-8"))
+    for h in handlers:
+        h.setFormatter(formatter)
 
     gh_logger = logging.getLogger("gh_manage")
-    # Drop prior handlers so repeat calls (idempotent contract) don't stack.
-    gh_logger.handlers[:] = [handler]
+    gh_logger.handlers[:] = handlers
     gh_logger.setLevel(_LOG_LEVELS[level])
-    # Don't propagate to root — otherwise a user who configures a root
-    # handler for third-party logs would see our records duplicated.
     gh_logger.propagate = False

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -8,7 +8,7 @@ import gh_manage
 def test_package_version_is_defined() -> None:
     assert hasattr(gh_manage, "__version__")
     assert isinstance(gh_manage.__version__, str)
-    assert gh_manage.__version__ == "1.8.0"
+    assert gh_manage.__version__ == "1.9.0"
 
 
 def test_cli_module_is_importable() -> None:

--- a/tests/unit/commands/test_apply_logging.py
+++ b/tests/unit/commands/test_apply_logging.py
@@ -168,3 +168,33 @@ def test_apply_logs_warning_on_ghnotfound_protection_fallback(tmp_path, monkeypa
     )
     assert "branch protection not configured" in result.output
     assert "owner/repo" in result.output
+
+
+def test_apply_logs_warning_on_doctor_check_error(
+    mock_apply_deps, tmp_path, monkeypatch
+):
+    from gh_manage.doctor.errors import DoctorCheckError
+
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.apply_files_diff",
+        lambda *a, **kw: [],
+    )
+
+    def _raise_doctor_check(*a, **kw):
+        raise DoctorCheckError("bad ci.yml")
+
+    monkeypatch.setattr("gh_manage.doctor.run_on_path", _raise_doctor_check)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "apply",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--apply",
+        ],
+    )
+    assert "post-apply doctor check failed" in result.output
+    assert "bad ci.yml" in result.output

--- a/tests/unit/commands/test_apply_logging.py
+++ b/tests/unit/commands/test_apply_logging.py
@@ -1,0 +1,170 @@
+"""Regression tests for commands/apply.py log points.
+
+Scope: log emission only. Command behavior is covered by existing tests.
+
+Note: `gh_manage` logger has `propagate=False` (set by configure_logging),
+so pytest's caplog — which attaches at root — cannot see records. These
+tests check `result.output` instead, which CliRunner captures from stderr
+(where configure_logging's StreamHandler writes).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+
+
+@pytest.fixture
+def mock_apply_deps(monkeypatch):
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo", lambda p: "owner/repo"
+    )
+    fake_profile = MagicMock(protection_policy=None)
+    fake_profile.name = "python-service"
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.load_config",
+        lambda path, cls: fake_profile,
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_profile_path",
+        lambda name: "/tmp/fake.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_templates_root",
+        lambda: "/tmp/templates",
+    )
+    fake_diff = MagicMock(
+        creates=[],
+        overwrites=[],
+        skipped=[],
+        noops=[],
+        is_empty=True,
+    )
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.compute_files_diff",
+        lambda *a, **kw: fake_diff,
+    )
+
+
+def test_apply_logs_invocation_at_info(mock_apply_deps, tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--log-level",
+            "info",
+            "apply",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+        ],
+    )
+    assert "apply invoked" in result.output
+    assert "owner/repo" in result.output
+
+
+def test_apply_logs_completion_at_info(mock_apply_deps, tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.apply_files_diff",
+        lambda *a, **kw: [],
+    )
+    monkeypatch.setattr(
+        "gh_manage.doctor.run_on_path",
+        lambda *a, **kw: (),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--log-level",
+            "info",
+            "apply",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--apply",
+        ],
+    )
+    assert "apply complete" in result.output
+
+
+def test_apply_logs_warning_on_ghnotfound_protection_fallback(tmp_path, monkeypatch):
+    from gh_manage.github_client import GhNotFoundError
+
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo", lambda p: "owner/repo"
+    )
+    fake_profile = MagicMock()
+    fake_profile.name = "python-service"
+    fake_profile.protection_policy = "standard"
+    fake_bp = MagicMock(policies={"standard": MagicMock()})
+
+    def _load(path, cls):
+        # Dispatch on the config class, not path string — paths don't
+        # contain "profile" so substring matching is unreliable.
+        if cls.__name__ == "ProfileSpec":
+            return fake_profile
+        if cls.__name__ == "BranchProtectionConfig":
+            return fake_bp
+        return MagicMock()  # LabelsConfig fallback
+
+    monkeypatch.setattr("gh_manage.commands.apply.load_config", _load)
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_profile_path",
+        lambda name: "/tmp/fake.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_templates_root",
+        lambda: "/tmp/templates",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_branch_protection_path",
+        lambda: "/tmp/bp.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.apply.resolve_default_labels_path",
+        lambda: "/tmp/labels.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.compute_files_diff",
+        lambda *a, **kw: MagicMock(
+            creates=[],
+            overwrites=[],
+            skipped=[],
+            noops=[],
+            is_empty=True,
+        ),
+    )
+
+    def _raise_404(*a, **kw):
+        raise GhNotFoundError("404")
+
+    monkeypatch.setattr(
+        "gh_manage.github_api.protection.get_branch_protection", _raise_404
+    )
+    monkeypatch.setattr(
+        "gh_manage.protection_sync.compute_protection_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True,
+            changes=(),
+            has_downgrades=False,
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "apply",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--also-protection",
+        ],
+    )
+    assert "branch protection not configured" in result.output
+    assert "owner/repo" in result.output

--- a/tests/unit/commands/test_doctor_logging.py
+++ b/tests/unit/commands/test_doctor_logging.py
@@ -1,0 +1,52 @@
+"""Regression tests for commands/doctor.py log points.
+
+Tests assert on result.output (CliRunner stderr capture) since
+gh_manage logger has propagate=False.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+
+
+@pytest.fixture
+def mock_doctor_deps(monkeypatch):
+    monkeypatch.setattr("gh_manage.doctor.run_on_path", lambda *a, **kw: ())
+    monkeypatch.setattr("gh_manage.doctor.run_on_remote", lambda *a, **kw: ())
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo",
+        lambda p: "owner/repo",
+    )
+
+
+def test_doctor_logs_invocation(mock_doctor_deps, tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["--log-level", "info", "doctor", str(tmp_path), "--exit-zero"],
+    )
+    assert "doctor invoked" in result.output
+
+
+def test_doctor_logs_completion(mock_doctor_deps, tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["--log-level", "info", "doctor", str(tmp_path), "--exit-zero"],
+    )
+    assert "doctor complete" in result.output
+
+
+def test_doctor_logs_warning_on_label_derivation_error(tmp_path, monkeypatch):
+    monkeypatch.setattr("gh_manage.doctor.run_on_path", lambda *a, **kw: ())
+
+    def _raise(p):
+        raise RuntimeError("no git origin")
+
+    monkeypatch.setattr("gh_manage.git_cli.get_origin_owner_repo", _raise)
+    runner = CliRunner()
+    result = runner.invoke(main, ["doctor", str(tmp_path), "--exit-zero"])
+    assert "could not derive owner/repo" in result.output

--- a/tests/unit/commands/test_init_logging.py
+++ b/tests/unit/commands/test_init_logging.py
@@ -1,0 +1,183 @@
+"""Regression tests for commands/init.py log points.
+
+Tests assert on result.output (CliRunner stderr capture) since
+gh_manage logger has propagate=False.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+from gh_manage.github_client import GhNotFoundError
+
+
+@pytest.fixture
+def mock_init_deps(monkeypatch):
+    fake_profile = MagicMock()
+    fake_profile.name = "python-service"
+    fake_profile.protection_policy = None
+
+    def _load(path, cls):
+        if cls.__name__ == "ProfileSpec":
+            return fake_profile
+        return MagicMock()
+
+    monkeypatch.setattr("gh_manage.commands.init.load_config", _load)
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_profile_path",
+        lambda name: "/tmp/fake.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_default_labels_path",
+        lambda: "/tmp/labels.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_templates_root",
+        lambda: "/tmp/tmpl",
+    )
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo",
+        lambda p: "owner/repo",
+    )
+    monkeypatch.setattr("gh_manage.github_api.labels.list_labels", lambda repo: ())
+    monkeypatch.setattr(
+        "gh_manage.labels_sync.compute_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True,
+            total_changes=0,
+            creates=[],
+            updates=[],
+            renames=[],
+        ),
+    )
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.compute_files_diff",
+        lambda *a, **kw: MagicMock(
+            creates=[],
+            overwrites=[],
+            skipped=[],
+            noops=[],
+            is_empty=True,
+        ),
+    )
+
+
+def test_init_logs_invocation(mock_init_deps, tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["--log-level", "info", "init", str(tmp_path), "--profile", "python-service"],
+    )
+    assert "init invoked" in result.output
+    assert "owner/repo" in result.output
+
+
+def test_init_logs_completion(mock_init_deps, tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.apply_files_diff",
+        lambda *a, **kw: [],
+    )
+    monkeypatch.setattr(
+        "gh_manage.labels_sync.apply_diff",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "gh_manage.doctor.run_on_path",
+        lambda *a, **kw: (),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--log-level",
+            "info",
+            "init",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+            "--apply",
+        ],
+    )
+    assert "init complete" in result.output
+
+
+def test_init_logs_warning_on_ghnotfound(tmp_path, monkeypatch):
+    fake_profile = MagicMock()
+    fake_profile.name = "python-service"
+    fake_profile.protection_policy = "standard"
+    fake_bp = MagicMock(policies={"standard": MagicMock()})
+
+    def _load(path, cls):
+        if cls.__name__ == "ProfileSpec":
+            return fake_profile
+        if cls.__name__ == "BranchProtectionConfig":
+            return fake_bp
+        return MagicMock()
+
+    monkeypatch.setattr("gh_manage.commands.init.load_config", _load)
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_profile_path",
+        lambda name: "/tmp/fake.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_branch_protection_path",
+        lambda: "/tmp/bp.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_default_labels_path",
+        lambda: "/tmp/labels.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.init.resolve_templates_root",
+        lambda: "/tmp/tmpl",
+    )
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo",
+        lambda p: "owner/repo",
+    )
+    monkeypatch.setattr("gh_manage.github_api.labels.list_labels", lambda repo: ())
+    monkeypatch.setattr(
+        "gh_manage.labels_sync.compute_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True,
+            total_changes=0,
+            creates=[],
+            updates=[],
+            renames=[],
+        ),
+    )
+    monkeypatch.setattr(
+        "gh_manage.profile_sync.compute_files_diff",
+        lambda *a, **kw: MagicMock(
+            creates=[],
+            overwrites=[],
+            skipped=[],
+            noops=[],
+            is_empty=True,
+        ),
+    )
+
+    def _raise_404(*a, **kw):
+        raise GhNotFoundError("404")
+
+    monkeypatch.setattr(
+        "gh_manage.github_api.protection.get_branch_protection", _raise_404
+    )
+    monkeypatch.setattr(
+        "gh_manage.protection_sync.compute_protection_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True,
+            has_downgrades=False,
+            changes=(),
+        ),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["init", str(tmp_path), "--profile", "python-service"],
+    )
+    assert "branch protection not configured" in result.output

--- a/tests/unit/commands/test_labels_logging.py
+++ b/tests/unit/commands/test_labels_logging.py
@@ -1,0 +1,94 @@
+"""Regression tests for commands/labels.py log points + decorator consolidation.
+
+Tests assert on result.output (CliRunner captures stderr) rather than
+caplog, since gh_manage logger has propagate=False.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+import gh_manage.commands.labels as labels_mod
+from gh_manage.cli import main
+from gh_manage.config import ConfigError
+from gh_manage.github_client import GhError
+
+
+def test_labels_uses_shared_handle_errors():
+    assert not hasattr(labels_mod, "_handle_errors"), (
+        "commands/labels.py should use _shared.handle_errors; "
+        "remove the local _handle_errors decorator."
+    )
+
+
+@pytest.fixture
+def mock_labels_deps(monkeypatch):
+    monkeypatch.setattr("gh_manage.github_api.labels.list_labels", lambda repo: ())
+    monkeypatch.setattr(
+        "gh_manage.commands.labels.load_config",
+        lambda path, cls: MagicMock(labels=[]),
+    )
+    monkeypatch.setattr(
+        "gh_manage.labels_sync.compute_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True,
+            total_changes=0,
+            creates=[],
+            updates=[],
+            renames=[],
+            deletes=[],
+        ),
+    )
+
+
+def test_labels_sync_logs_invocation(mock_labels_deps):
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--log-level", "info", "labels", "sync", "owner/repo"]
+    )
+    assert "labels sync invoked" in result.output
+    assert "owner/repo" in result.output
+
+
+def test_labels_show_logs_invocation(mock_labels_deps):
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--log-level", "info", "labels", "show", "owner/repo"]
+    )
+    assert "labels show invoked" in result.output
+    assert "owner/repo" in result.output
+
+
+def test_labels_diff_logs_invocation(mock_labels_deps):
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--log-level", "info", "labels", "diff", "owner/repo"]
+    )
+    assert "labels diff invoked" in result.output
+    assert "owner/repo" in result.output
+
+
+@pytest.mark.parametrize(
+    "exc_factory",
+    [
+        lambda: GhError("upstream api failed"),
+        lambda: ConfigError("config invalid"),
+    ],
+    ids=["GhError", "ConfigError"],
+)
+def test_labels_exception_behavior_preserved_after_decorator_swap(
+    monkeypatch, exc_factory
+):
+    exc = exc_factory()
+
+    def _raise(*a, **kw):
+        raise exc
+
+    monkeypatch.setattr("gh_manage.github_api.labels.list_labels", _raise)
+    runner = CliRunner()
+    result = runner.invoke(main, ["labels", "show", "owner/repo"])
+    assert result.exit_code != 0
+    assert str(exc) in result.output

--- a/tests/unit/commands/test_protection_logging.py
+++ b/tests/unit/commands/test_protection_logging.py
@@ -1,0 +1,114 @@
+"""Regression tests for commands/protection.py log points.
+
+Tests assert on result.output (CliRunner stderr capture) since
+gh_manage logger has propagate=False.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+from gh_manage.github_client import GhNotFoundError
+
+
+@pytest.fixture
+def mock_protection_deps(monkeypatch):
+    fake_profile = MagicMock()
+    fake_profile.name = "python-service"
+    fake_profile.protection_policy = "standard"
+    fake_policy = MagicMock()
+    fake_bp_config = MagicMock(policies={"standard": fake_policy})
+
+    def _load(path, cls):
+        # Dispatch on cls, not path substring.
+        if cls.__name__ == "ProfileSpec":
+            return fake_profile
+        return fake_bp_config
+
+    monkeypatch.setattr("gh_manage.commands.protection.load_config", _load)
+    monkeypatch.setattr(
+        "gh_manage.commands.protection.resolve_profile_path",
+        lambda name: "/tmp/fake-profile.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.commands.protection.resolve_branch_protection_path",
+        lambda: "/tmp/fake-bp.yml",
+    )
+    monkeypatch.setattr(
+        "gh_manage.git_cli.get_origin_owner_repo", lambda p: "owner/repo"
+    )
+    monkeypatch.setattr(
+        "gh_manage.protection_sync.compute_protection_diff",
+        lambda *a, **kw: MagicMock(
+            is_empty=True,
+            changes=(),
+            has_downgrades=False,
+            downgrades=[],
+        ),
+    )
+    monkeypatch.setattr(
+        "gh_manage.github_api.protection.get_branch_protection",
+        lambda *a, **kw: {},
+    )
+
+
+def test_protection_sync_logs_invocation(mock_protection_deps, tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--log-level",
+            "info",
+            "protection",
+            "sync",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+        ],
+    )
+    assert "protection sync invoked" in result.output
+    assert "owner/repo" in result.output
+
+
+def test_protection_diff_logs_invocation(mock_protection_deps, tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--log-level",
+            "info",
+            "protection",
+            "diff",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+        ],
+    )
+    assert "protection diff invoked" in result.output
+    assert "owner/repo" in result.output
+
+
+def test_protection_logs_warning_on_ghnotfound(
+    mock_protection_deps, tmp_path, monkeypatch
+):
+    def _raise(*a, **kw):
+        raise GhNotFoundError("404")
+
+    monkeypatch.setattr("gh_manage.github_api.protection.get_branch_protection", _raise)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "protection",
+            "sync",
+            str(tmp_path),
+            "--profile",
+            "python-service",
+        ],
+    )
+    assert "branch protection not configured" in result.output
+    assert "owner/repo" in result.output

--- a/tests/unit/drift/test_context.py
+++ b/tests/unit/drift/test_context.py
@@ -1,0 +1,27 @@
+"""Tests for drift_sync/context.py — scan_id ContextVar."""
+
+from __future__ import annotations
+
+from contextvars import copy_context
+
+from gh_manage.drift_sync.context import scan_id_var
+
+
+def test_scan_id_var_defaults_to_empty_string():
+    ctx = copy_context()
+    assert ctx.run(scan_id_var.get) == ""
+
+
+def test_scan_id_var_set_and_reset():
+    token = scan_id_var.set("test-uuid")
+    try:
+        assert scan_id_var.get() == "test-uuid"
+    finally:
+        scan_id_var.reset(token)
+    assert scan_id_var.get() == ""
+
+
+def test_scan_id_var_importable_from_drift_sync_namespace():
+    from gh_manage.drift_sync import scan_id_var as exported
+
+    assert exported is scan_id_var

--- a/tests/unit/drift/test_scan_id_propagation.py
+++ b/tests/unit/drift/test_scan_id_propagation.py
@@ -66,7 +66,7 @@ def test_scan_id_set_at_single_repo_entry(mock_scan_deps, monkeypatch):
         skip_profile_check=True,
     )
     sid = captured["a"]
-    uuid.UUID(sid, version=4)
+    assert uuid.UUID(sid).version == 4
 
 
 def test_scan_id_reset_after_single_repo_exit(mock_scan_deps, monkeypatch):
@@ -129,8 +129,8 @@ def test_scan_id_differs_across_sequential_scans_in_same_thread(
     )
     second = captured["seq"]
     assert first != second
-    uuid.UUID(first, version=4)
-    uuid.UUID(second, version=4)
+    assert uuid.UUID(first).version == 4
+    assert uuid.UUID(second).version == 4
 
 
 def test_scan_id_isolated_per_worker_thread(mock_scan_deps, monkeypatch):
@@ -167,5 +167,51 @@ def test_scan_id_isolated_per_worker_thread(mock_scan_deps, monkeypatch):
     assert len(vals) == 2
     assert vals[0] != vals[1]
     for v in vals:
-        uuid.UUID(v, version=4)
+        assert uuid.UUID(v).version == 4
+    assert scan_id_var.get() == ""
+
+
+def test_scan_id_present_during_worker_failure_logs(mock_scan_deps, monkeypatch):
+    """Codex review finding: failure logs in _scan_worker must inherit scan_id.
+
+    Before the fix, `_scan_single_repo`'s finally reset scan_id before
+    `_scan_worker`'s except blocks could log — meaning the most valuable
+    log records (failures) had no correlation id. Regression guard.
+    """
+    from gh_manage.models.repos import RepoEntry
+
+    drift_cmd = mock_scan_deps
+
+    captured: dict[str, str] = {}
+
+    def _raise_inside_scan(ctx):
+        # Capture scan_id visible to the innermost check
+        captured["inner"] = scan_id_var.get()
+        raise RuntimeError("boom in check")
+
+    monkeypatch.setattr(drift_cmd.drift_sync, "run_all_checks", _raise_inside_scan)
+
+    entry = RepoEntry(name="owner/repo", profile="python-service", enabled=True)
+
+    # Patch log.exception to capture the scan_id visible when the worker
+    # emits the failure record.
+    original_exception = drift_cmd.log.exception
+
+    def _exception_capture(*args, **kwargs):
+        captured["worker_exception"] = scan_id_var.get()
+        return original_exception(*args, **kwargs)
+
+    monkeypatch.setattr(drift_cmd.log, "exception", _exception_capture)
+
+    name, status, _exc = drift_cmd._scan_worker(entry, "low", "stdout", None)
+
+    assert status == "FAILED"
+    # Both inner and worker-exception were captured with a non-empty UUID4
+    inner_sid = captured["inner"]
+    worker_sid = captured["worker_exception"]
+    assert uuid.UUID(inner_sid).version == 4
+    assert uuid.UUID(worker_sid).version == 4
+    # Crucially, they are the SAME id — one logical scan, one correlation id
+    assert inner_sid == worker_sid
+    # After worker returns, scan_id is reset
     assert scan_id_var.get() == ""

--- a/tests/unit/drift/test_scan_id_propagation.py
+++ b/tests/unit/drift/test_scan_id_propagation.py
@@ -1,0 +1,171 @@
+"""Tests for scan_id ContextVar propagation via _scan_single_repo."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
+
+import pytest
+
+from gh_manage.drift_sync.context import scan_id_var
+
+
+@pytest.fixture
+def mock_scan_deps(monkeypatch):
+    """Patch heavy dependencies of _scan_single_repo."""
+    from gh_manage.commands import drift as drift_cmd
+
+    mock_profile = MagicMock(protection_policy=None)
+    mock_labels_config = MagicMock()
+
+    monkeypatch.setattr(drift_cmd.repo_info, "get_default_branch", lambda repo: "main")
+    monkeypatch.setattr(
+        drift_cmd,
+        "load_config",
+        lambda path, cls: (
+            mock_profile if "profile" in str(path) else mock_labels_config
+        ),
+    )
+    monkeypatch.setattr(
+        drift_cmd, "resolve_profile_path", lambda name: "/tmp/fake-profile.yml"
+    )
+    monkeypatch.setattr(
+        drift_cmd, "resolve_default_labels_path", lambda: "/tmp/fake-labels.yml"
+    )
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "format_stdout_report", lambda findings: "report"
+    )
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "_filter_by_severity", lambda findings, sev: findings
+    )
+    return drift_cmd
+
+
+def _make_capturing_stub(captured: dict, key: str):
+    def _stub(ctx):
+        captured[key] = scan_id_var.get()
+        return ()
+
+    return _stub
+
+
+def test_scan_id_set_at_single_repo_entry(mock_scan_deps, monkeypatch):
+    drift_cmd = mock_scan_deps
+    captured: dict = {}
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "run_all_checks", _make_capturing_stub(captured, "a")
+    )
+    drift_cmd._scan_single_repo(
+        "owner/repo",
+        "python-service",
+        "low",
+        "stdout",
+        None,
+        skip_profile_check=True,
+    )
+    sid = captured["a"]
+    uuid.UUID(sid, version=4)
+
+
+def test_scan_id_reset_after_single_repo_exit(mock_scan_deps, monkeypatch):
+    drift_cmd = mock_scan_deps
+    monkeypatch.setattr(drift_cmd.drift_sync, "run_all_checks", lambda ctx: ())
+    drift_cmd._scan_single_repo(
+        "owner/repo",
+        "python-service",
+        "low",
+        "stdout",
+        None,
+        skip_profile_check=True,
+    )
+    assert scan_id_var.get() == ""
+
+
+def test_scan_id_reset_even_on_exception(mock_scan_deps, monkeypatch):
+    drift_cmd = mock_scan_deps
+
+    def _raise(ctx):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(drift_cmd.drift_sync, "run_all_checks", _raise)
+    with pytest.raises(RuntimeError, match="boom"):
+        drift_cmd._scan_single_repo(
+            "owner/repo",
+            "python-service",
+            "low",
+            "stdout",
+            None,
+            skip_profile_check=True,
+        )
+    assert scan_id_var.get() == ""
+
+
+def test_scan_id_differs_across_sequential_scans_in_same_thread(
+    mock_scan_deps, monkeypatch
+):
+    drift_cmd = mock_scan_deps
+    captured: dict = {}
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "run_all_checks", _make_capturing_stub(captured, "seq")
+    )
+    drift_cmd._scan_single_repo(
+        "owner/repo-1",
+        "python-service",
+        "low",
+        "stdout",
+        None,
+        skip_profile_check=True,
+    )
+    first = captured["seq"]
+    drift_cmd._scan_single_repo(
+        "owner/repo-2",
+        "python-service",
+        "low",
+        "stdout",
+        None,
+        skip_profile_check=True,
+    )
+    second = captured["seq"]
+    assert first != second
+    uuid.UUID(first, version=4)
+    uuid.UUID(second, version=4)
+
+
+def test_scan_id_isolated_per_worker_thread(mock_scan_deps, monkeypatch):
+    drift_cmd = mock_scan_deps
+    captured: dict = {}
+    lock = threading.Lock()
+    counter = {"n": 0}
+
+    def _stub(ctx):
+        with lock:
+            counter["n"] += 1
+            key = f"worker_{counter['n']}"
+        captured[key] = scan_id_var.get()
+        return ()
+
+    monkeypatch.setattr(drift_cmd.drift_sync, "run_all_checks", _stub)
+
+    def _call():
+        drift_cmd._scan_single_repo(
+            "owner/repo",
+            "python-service",
+            "low",
+            "stdout",
+            None,
+            skip_profile_check=True,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(_call) for _ in range(2)]
+        for f in futures:
+            f.result()
+
+    vals = list(captured.values())
+    assert len(vals) == 2
+    assert vals[0] != vals[1]
+    for v in vals:
+        uuid.UUID(v, version=4)
+    assert scan_id_var.get() == ""

--- a/tests/unit/test_cli_log_file.py
+++ b/tests/unit/test_cli_log_file.py
@@ -43,3 +43,44 @@ def test_validate_log_file_accepts_existing_path(tmp_path):
     target.write_text("pre-existing content\n", encoding="utf-8")
     _validate_log_file(target)
     assert target.read_text(encoding="utf-8") == "pre-existing content\n"
+
+
+# ---- CLI integration tests (Task 5) ----
+
+from click.testing import CliRunner
+
+from gh_manage.cli import main
+
+
+def test_cli_log_file_env_var_honored(tmp_path, monkeypatch):
+    log_path = tmp_path / "x.log"
+    monkeypatch.setenv("GH_MANAGE_LOG_FILE", str(log_path))
+    runner = CliRunner()
+    # Invoke a subcommand (without required args, so it fails) to trigger the
+    # root callback. The root callback runs before subcommand dispatch.
+    result = runner.invoke(main, ["labels"], env={"GH_MANAGE_LOG_FILE": str(log_path)})
+    # We don't care if the subcommand succeeds; we just want the callback to run.
+    # _validate_log_file touched the file via open("a").
+    assert log_path.exists()
+
+
+def test_cli_log_file_rejects_bad_path(tmp_path):
+    bad = tmp_path / "nonexistent-parent" / "x.log"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["--log-file", str(bad), "labels", "show", "owner/repo"],
+    )
+    assert result.exit_code != 0
+    combined = result.output + (str(result.exception) if result.exception else "")
+    assert "parent directory does not exist" in combined
+
+
+def test_cli_log_file_env_var_rejects_bad_path(tmp_path, monkeypatch):
+    bad = tmp_path / "nonexistent-parent" / "x.log"
+    monkeypatch.setenv("GH_MANAGE_LOG_FILE", str(bad))
+    runner = CliRunner()
+    result = runner.invoke(main, ["labels", "show", "owner/repo"])
+    assert result.exit_code != 0
+    combined = result.output + (str(result.exception) if result.exception else "")
+    assert "parent directory does not exist" in combined

--- a/tests/unit/test_cli_log_file.py
+++ b/tests/unit/test_cli_log_file.py
@@ -1,0 +1,45 @@
+"""Tests for cli.py --log-file validation and option wiring."""
+
+from __future__ import annotations
+
+import os
+import stat
+
+import click
+import pytest
+
+from gh_manage.cli import _validate_log_file
+
+
+def test_validate_log_file_rejects_missing_parent(tmp_path):
+    missing = tmp_path / "nonexistent-dir" / "x.log"
+    with pytest.raises(click.UsageError) as exc:
+        _validate_log_file(missing)
+    assert "parent directory does not exist" in str(exc.value)
+
+
+def test_validate_log_file_rejects_unwritable(tmp_path):
+    if os.geteuid() == 0:
+        pytest.skip("root bypasses permission bits")
+    tmp_path.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        target = tmp_path / "x.log"
+        with pytest.raises(click.UsageError) as exc:
+            _validate_log_file(target)
+        assert "Cannot write" in str(exc.value)
+    finally:
+        tmp_path.chmod(stat.S_IRWXU)
+
+
+def test_validate_log_file_accepts_new_path(tmp_path):
+    target = tmp_path / "new.log"
+    assert not target.exists()
+    _validate_log_file(target)
+    assert target.exists()
+
+
+def test_validate_log_file_accepts_existing_path(tmp_path):
+    target = tmp_path / "existing.log"
+    target.write_text("pre-existing content\n", encoding="utf-8")
+    _validate_log_file(target)
+    assert target.read_text(encoding="utf-8") == "pre-existing content\n"

--- a/tests/unit/test_cli_log_file.py
+++ b/tests/unit/test_cli_log_file.py
@@ -7,8 +7,9 @@ import stat
 
 import click
 import pytest
+from click.testing import CliRunner
 
-from gh_manage.cli import _validate_log_file
+from gh_manage.cli import _validate_log_file, main
 
 
 def test_validate_log_file_rejects_missing_parent(tmp_path):
@@ -47,20 +48,15 @@ def test_validate_log_file_accepts_existing_path(tmp_path):
 
 # ---- CLI integration tests (Task 5) ----
 
-from click.testing import CliRunner
-
-from gh_manage.cli import main
-
 
 def test_cli_log_file_env_var_honored(tmp_path, monkeypatch):
     log_path = tmp_path / "x.log"
     monkeypatch.setenv("GH_MANAGE_LOG_FILE", str(log_path))
     runner = CliRunner()
-    # Invoke a subcommand (without required args, so it fails) to trigger the
-    # root callback. The root callback runs before subcommand dispatch.
-    result = runner.invoke(main, ["labels"], env={"GH_MANAGE_LOG_FILE": str(log_path)})
-    # We don't care if the subcommand succeeds; we just want the callback to run.
-    # _validate_log_file touched the file via open("a").
+    # Invoke a subcommand (no required args → subcommand fails) to trigger the
+    # root callback. The root callback runs before subcommand dispatch, which
+    # is enough to touch the log file via _validate_log_file.
+    runner.invoke(main, ["labels"], env={"GH_MANAGE_LOG_FILE": str(log_path)})
     assert log_path.exists()
 
 

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -150,3 +150,62 @@ def test_plain_formatter_omits_scan_id():
     finally:
         scan_id_var.reset(token)
     assert "would-be-visible" not in stream.getvalue()
+
+
+# ---- log_file + dual handler tests (cli/v1.9.0) ----
+
+
+def test_configure_logging_with_log_file_adds_file_handler(tmp_path):
+    log_path = tmp_path / "x.log"
+    configure_logging(level="info", log_file=log_path)
+    handlers = logging.getLogger("gh_manage").handlers
+    assert len(handlers) == 2
+    types = {type(h).__name__ for h in handlers}
+    assert types == {"StreamHandler", "FileHandler"}
+
+
+def test_log_file_mode_is_append(tmp_path):
+    log_path = tmp_path / "x.log"
+    log_path.write_text("pre-existing\n", encoding="utf-8")
+    configure_logging(level="info", log_file=log_path)
+    logging.getLogger("gh_manage.test").info("new-entry")
+    for h in logging.getLogger("gh_manage").handlers:
+        h.flush()
+    content = log_path.read_text(encoding="utf-8")
+    assert content.startswith("pre-existing\n")
+    assert "new-entry" in content
+
+
+def test_log_file_encoding_is_utf8(tmp_path):
+    log_path = tmp_path / "x.log"
+    configure_logging(level="info", log_file=log_path)
+    logging.getLogger("gh_manage.test").info("日本語テスト")
+    for h in logging.getLogger("gh_manage").handlers:
+        h.flush()
+    content = log_path.read_bytes().decode("utf-8")
+    assert "日本語テスト" in content
+
+
+def test_log_file_and_stderr_get_same_record(tmp_path):
+    log_path = tmp_path / "x.log"
+    stream = io.StringIO()
+    configure_logging(level="info", log_file=log_path, stream=stream)
+    logging.getLogger("gh_manage.test").info("dual-msg")
+    for h in logging.getLogger("gh_manage").handlers:
+        h.flush()
+    assert "dual-msg" in stream.getvalue()
+    assert "dual-msg" in log_path.read_text(encoding="utf-8")
+
+
+def test_file_handler_inherits_scan_id_formatter(tmp_path):
+    log_path = tmp_path / "x.log"
+    configure_logging(level="info", json=True, log_file=log_path)
+    token = scan_id_var.set("file-scan-id")
+    try:
+        logging.getLogger("gh_manage.test").info("msg")
+    finally:
+        scan_id_var.reset(token)
+    for h in logging.getLogger("gh_manage").handlers:
+        h.flush()
+    first_line = log_path.read_text(encoding="utf-8").splitlines()[0]
+    assert json.loads(first_line)["scan_id"] == "file-scan-id"

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -30,13 +30,11 @@ def _reset_gh_manage_logger():
 
 
 def test_configure_logging_default_level_is_warning() -> None:
-
     configure_logging()
     assert logging.getLogger("gh_manage").level == logging.WARNING
 
 
 def test_configure_logging_sets_explicit_level() -> None:
-
     configure_logging(level="info")
     assert logging.getLogger("gh_manage").level == logging.INFO
 
@@ -73,7 +71,6 @@ def test_configure_logging_json_explicit_arg_overrides_env(
 
 
 def test_configure_logging_idempotent() -> None:
-
     configure_logging(level="info")
     configure_logging(level="debug")
     gh_logger = logging.getLogger("gh_manage")
@@ -91,13 +88,12 @@ def test_configure_logging_writes_to_stream_argument() -> None:
 
 
 def test_configure_logging_does_not_add_handler_to_root_logger() -> None:
-
     root_handlers_before = list(logging.getLogger().handlers)
     configure_logging()
     root_handlers_after = list(logging.getLogger().handlers)
-    assert root_handlers_before == root_handlers_after, (
-        "configure_logging must not touch the root logger — only the `gh_manage` tree."
-    )
+    assert (
+        root_handlers_before == root_handlers_after
+    ), "configure_logging must not touch the root logger — only the `gh_manage` tree."
 
 
 def test_configure_logging_sets_propagate_false() -> None:

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -7,9 +7,13 @@ so tests don't interfere with each other or with pytest's own logger.
 from __future__ import annotations
 
 import io
+import json
 import logging
 
 import pytest
+
+from gh_manage.drift_sync.context import scan_id_var
+from gh_manage.logging_config import configure_logging
 
 
 @pytest.fixture(autouse=True)
@@ -26,14 +30,12 @@ def _reset_gh_manage_logger():
 
 
 def test_configure_logging_default_level_is_warning() -> None:
-    from gh_manage.logging_config import configure_logging
 
     configure_logging()
     assert logging.getLogger("gh_manage").level == logging.WARNING
 
 
 def test_configure_logging_sets_explicit_level() -> None:
-    from gh_manage.logging_config import configure_logging
 
     configure_logging(level="info")
     assert logging.getLogger("gh_manage").level == logging.INFO
@@ -43,7 +45,6 @@ def test_configure_logging_plain_formatter_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("GH_MANAGE_LOG_JSON", raising=False)
-    from gh_manage.logging_config import configure_logging
 
     configure_logging()
     handler = logging.getLogger("gh_manage").handlers[0]
@@ -53,7 +54,6 @@ def test_configure_logging_plain_formatter_by_default(
 
 def test_configure_logging_json_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GH_MANAGE_LOG_JSON", "1")
-    from gh_manage.logging_config import configure_logging
     from pythonjsonlogger.jsonlogger import JsonFormatter
 
     configure_logging()
@@ -66,7 +66,6 @@ def test_configure_logging_json_explicit_arg_overrides_env(
 ) -> None:
     """Env says yes; explicit arg says no. Explicit wins."""
     monkeypatch.setenv("GH_MANAGE_LOG_JSON", "1")
-    from gh_manage.logging_config import configure_logging
 
     configure_logging(json=False)
     handler = logging.getLogger("gh_manage").handlers[0]
@@ -74,7 +73,6 @@ def test_configure_logging_json_explicit_arg_overrides_env(
 
 
 def test_configure_logging_idempotent() -> None:
-    from gh_manage.logging_config import configure_logging
 
     configure_logging(level="info")
     configure_logging(level="debug")
@@ -85,7 +83,6 @@ def test_configure_logging_idempotent() -> None:
 
 def test_configure_logging_writes_to_stream_argument() -> None:
     """Stream override is how unit tests isolate from real stderr."""
-    from gh_manage.logging_config import configure_logging
 
     buf = io.StringIO()
     configure_logging(level="info", stream=buf)
@@ -94,7 +91,6 @@ def test_configure_logging_writes_to_stream_argument() -> None:
 
 
 def test_configure_logging_does_not_add_handler_to_root_logger() -> None:
-    from gh_manage.logging_config import configure_logging
 
     root_handlers_before = list(logging.getLogger().handlers)
     configure_logging()
@@ -113,7 +109,6 @@ def test_configure_logging_sets_propagate_false() -> None:
     through the logging tree — testing both is necessary to fully lock
     down the isolation contract (addresses Codex review LOW).
     """
-    from gh_manage.logging_config import configure_logging
 
     configure_logging()
     assert logging.getLogger("gh_manage").propagate is False
@@ -121,21 +116,16 @@ def test_configure_logging_sets_propagate_false() -> None:
 
 # ---- scan_id injection tests (cli/v1.9.0) ----
 
-import json as _json
-
-from gh_manage.drift_sync.context import scan_id_var
-from gh_manage.logging_config import configure_logging as _configure_logging
-
 
 def _parse_first_json(stream: io.StringIO) -> dict:
     text = stream.getvalue().strip()
     assert text, "expected at least one log line"
-    return _json.loads(text.splitlines()[0])
+    return json.loads(text.splitlines()[0])
 
 
 def test_json_formatter_includes_scan_id_when_set():
     stream = io.StringIO()
-    _configure_logging(level="info", json=True, stream=stream)
+    configure_logging(level="info", json=True, stream=stream)
     token = scan_id_var.set("test-uuid-123")
     try:
         logging.getLogger("gh_manage.test").info("hello")
@@ -146,14 +136,14 @@ def test_json_formatter_includes_scan_id_when_set():
 
 def test_json_formatter_omits_scan_id_when_unset():
     stream = io.StringIO()
-    _configure_logging(level="info", json=True, stream=stream)
+    configure_logging(level="info", json=True, stream=stream)
     logging.getLogger("gh_manage.test").info("hello")
     assert "scan_id" not in _parse_first_json(stream)
 
 
 def test_plain_formatter_omits_scan_id():
     stream = io.StringIO()
-    _configure_logging(level="info", json=False, stream=stream)
+    configure_logging(level="info", json=False, stream=stream)
     token = scan_id_var.set("would-be-visible-if-not-omitted")
     try:
         logging.getLogger("gh_manage.test").info("hello")

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -99,9 +99,9 @@ def test_configure_logging_does_not_add_handler_to_root_logger() -> None:
     root_handlers_before = list(logging.getLogger().handlers)
     configure_logging()
     root_handlers_after = list(logging.getLogger().handlers)
-    assert (
-        root_handlers_before == root_handlers_after
-    ), "configure_logging must not touch the root logger — only the `gh_manage` tree."
+    assert root_handlers_before == root_handlers_after, (
+        "configure_logging must not touch the root logger — only the `gh_manage` tree."
+    )
 
 
 def test_configure_logging_sets_propagate_false() -> None:
@@ -117,3 +117,46 @@ def test_configure_logging_sets_propagate_false() -> None:
 
     configure_logging()
     assert logging.getLogger("gh_manage").propagate is False
+
+
+# ---- scan_id injection tests (cli/v1.9.0) ----
+
+import json as _json
+
+from gh_manage.drift_sync.context import scan_id_var
+from gh_manage.logging_config import configure_logging as _configure_logging
+
+
+def _parse_first_json(stream: io.StringIO) -> dict:
+    text = stream.getvalue().strip()
+    assert text, "expected at least one log line"
+    return _json.loads(text.splitlines()[0])
+
+
+def test_json_formatter_includes_scan_id_when_set():
+    stream = io.StringIO()
+    _configure_logging(level="info", json=True, stream=stream)
+    token = scan_id_var.set("test-uuid-123")
+    try:
+        logging.getLogger("gh_manage.test").info("hello")
+    finally:
+        scan_id_var.reset(token)
+    assert _parse_first_json(stream)["scan_id"] == "test-uuid-123"
+
+
+def test_json_formatter_omits_scan_id_when_unset():
+    stream = io.StringIO()
+    _configure_logging(level="info", json=True, stream=stream)
+    logging.getLogger("gh_manage.test").info("hello")
+    assert "scan_id" not in _parse_first_json(stream)
+
+
+def test_plain_formatter_omits_scan_id():
+    stream = io.StringIO()
+    _configure_logging(level="info", json=False, stream=stream)
+    token = scan_id_var.set("would-be-visible-if-not-omitted")
+    try:
+        logging.getLogger("gh_manage.test").info("hello")
+    finally:
+        scan_id_var.reset(token)
+    assert "would-be-visible" not in stream.getvalue()

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "gh-manage"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bundles three structured-logging follow-ups from PR #66 / cli/v1.8.0 into one cli/v1.9.0 release.

- **#63** (command rollout): INFO/WARNING coverage across `apply`, `labels`, `protection`, `init`, `doctor`
- **#64** (scan_id): ContextVar-based UUID4 per scan; `_ScanIdJsonFormatter` auto-attaches `scan_id` field to JSON output; plain-text unchanged
- **#65** (`--log-file`): dual stderr+file output; `GH_MANAGE_LOG_FILE` envvar; fail-fast validate at CLI startup with `UsageError`

Side cleanup: `labels.py` local `_handle_errors` consolidated onto `_shared.handle_errors` (wider exception catch; parametrized preservation test included).

## Design

- Spec: `docs/specs/2026-04-20-structured-logging-followups-design.md`
- Plan: `docs/plans/2026-04-20-structured-logging-followups-plan.md`
- Decisions from brainstorming Q1–Q4: single PR, ContextVar with JsonFormatter auto-attach, dual output, fail-fast validate.

## Intentional deviation from plan (tests)

The plan's caplog-based tests for command rollout (apply/labels/protection/init/doctor) do not work because \`configure_logging\` sets \`gh_manage.propagate = False\` (intentional — prevents log duplication when users configure a root handler). Tests assert on \`result.output\` from \`CliRunner\` instead, which captures stderr where the StreamHandler writes. Semantic coverage is equivalent (both verify that expected log substrings appear in stderr output).

## Test plan

- [x] \`uv run pytest -q\` — 630 passed (baseline 587 + ~43 new)
- [x] \`uvx ruff@0.8.0 check src/ tests/\` clean
- [x] \`uvx ruff@0.8.0 format --check src/ tests/\` clean
- [x] \`uv run mypy src/\` clean
- [ ] Manual smoke: \`--log-file\` dual output; \`GH_MANAGE_LOG_JSON=1\` drift scan emits scan_id; invalid \`--log-file\` path fail-fast; command rollout INFO visible at \`--log-level info\`

Closes #63
Closes #64
Closes #65
Refs #47

Generated with [Claude Code](https://claude.ai/code)