### PR TITLE
fix: address gh-manage self-drift (#20) — rename ci.yml job + register gh-manage:drift label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,13 @@ permissions:
 
 jobs:
   pr-gate:
-    name: PR Gate (self-dogfood)
+    # Job name is deliberately "PR Gate" (matching the template invariant
+    # documented in src/gh_manage/data/templates/ci/python-ci.yml). The
+    # self-dogfood behavior — running THIS PR's tree, not a tagged release —
+    # is delivered via `gh-manage-ref: ${{ github.sha }}` below, not via the
+    # display label. Keep `name: PR Gate` so branch-protection context
+    # "PR Gate / PR Gate" resolves correctly.
+    name: PR Gate
     uses: ./.github/workflows/reusable-pr-gate-python.yml
     with:
       python-version: "3.12"

--- a/src/gh_manage/data/labels.yml
+++ b/src/gh_manage/data/labels.yml
@@ -20,3 +20,7 @@ categories:
       - { name: "invalid",          color: "e4e669", description: "Not actionable" }
       - { name: "question",         color: "d876e3", description: "Further information is requested" }
       - { name: "wontfix",          color: "ffffff", description: "This will not be worked on" }
+  automation:
+    description: "Automated-tool labels (auto-applied by gh-manage scanners)"
+    labels:
+      - { name: "gh-manage:drift", color: "d4c5f9", description: "Automated drift report from gh-manage scanner" }

--- a/tests/fixtures/drift-scenarios/labels/color-mismatch.yml
+++ b/tests/fixtures/drift-scenarios/labels/color-mismatch.yml
@@ -19,6 +19,7 @@ inputs:
     - {name: "invalid", color: "e4e669", description: "Not actionable"}
     - {name: "question", color: "d876e3", description: "Further information is requested"}
     - {name: "wontfix", color: "ffffff", description: "This will not be worked on"}
+    - {name: "gh-manage:drift", color: "d4c5f9", description: "Automated drift report from gh-manage scanner"}
 expected_findings:
   - severity: medium
     check: labels

--- a/tests/fixtures/drift-scenarios/labels/description-mismatch.yml
+++ b/tests/fixtures/drift-scenarios/labels/description-mismatch.yml
@@ -19,6 +19,7 @@ inputs:
     - {name: "invalid", color: "e4e669", description: "Not actionable"}
     - {name: "question", color: "d876e3", description: "Further information is requested"}
     - {name: "wontfix", color: "ffffff", description: "This will not be worked on"}
+    - {name: "gh-manage:drift", color: "d4c5f9", description: "Automated drift report from gh-manage scanner"}
 expected_findings:
   - severity: medium
     check: labels

--- a/tests/fixtures/drift-scenarios/labels/extra-unknown-label.yml
+++ b/tests/fixtures/drift-scenarios/labels/extra-unknown-label.yml
@@ -19,6 +19,7 @@ inputs:
     - {name: "invalid", color: "e4e669", description: "Not actionable"}
     - {name: "question", color: "d876e3", description: "Further information is requested"}
     - {name: "wontfix", color: "ffffff", description: "This will not be worked on"}
+    - {name: "gh-manage:drift", color: "d4c5f9", description: "Automated drift report from gh-manage scanner"}
     - {name: "custom/legacy-label", color: "000000", description: "User-added legacy label"}
 expected_findings:
   - severity: low

--- a/tests/fixtures/drift-scenarios/labels/missing-meta-labels.yml
+++ b/tests/fixtures/drift-scenarios/labels/missing-meta-labels.yml
@@ -38,3 +38,7 @@ expected_findings:
     check: labels
     field_path_contains: "wontfix"
     message_contains: "missing"
+  - severity: high
+    check: labels
+    field_path_contains: "gh-manage:drift"
+    message_contains: "missing"


### PR DESCRIPTION
## Summary

Tier 1 of the self-dogfood drift triage (#20). Two small changes that resolve 1 LOW and set up the HIGH/MEDIUM protection fix via follow-up \`protection sync\`.

### `.github/workflows/ci.yml`

Rename job name from \`"PR Gate (self-dogfood)"\` to \`"PR Gate"\` so the Actions status context \`"PR Gate / PR Gate"\` matches what our branch-protection policy will enforce after the follow-up \`protection sync\` call. The self-dogfood behavior (running THIS PR's tree) is already carried by \`gh-manage-ref: \${{ github.sha }}\` — \`(self-dogfood)\` in the display label was decorative. Added an inline comment linking to the template invariant.

### `src/gh_manage/data/labels.yml`

Added \`gh-manage:drift\` under a new \`automation\` category. Scanner auto-creates this label when filing drift issues (\`src/gh_manage/github_api/issues.py:ensure_drift_label\`); having it in the canonical list removes the \"extra label\" LOW drift finding without suppressing the scanner's behavior. Color / description match the scanner's constants.

## Drift reduction

Before: **6 findings** (1 HIGH, 3 MEDIUM, 2 LOW)
After this PR: **5 findings** (1 HIGH, 3 MEDIUM, 1 LOW)
After follow-up \`protection sync\`: **3 findings** (3 MEDIUM) — all related to inherent self-referencing limitations in the scanner, tracked as Tier 2 issues.

## Follow-ups

- Run \`gh-manage protection sync yakkuro/gh-manage --profile python-service --apply\` after merge to resolve HIGH + MEDIUM protection findings.
- File Tier 2 issues: (a) scanner should recognize \`./\` relative reusable paths as adoption; (b) scanner should treat self-referencing repos (gh-manage itself) as exempt from the \"ci.yml drifted from template\" check.

Refs #20.

Generated with [Claude Code](https://claude.ai/code)