### PR TITLE
fix(drift): populate live_required_contexts in ScanContext

### DIFF
--- a/src/gh_manage/commands/drift.py
+++ b/src/gh_manage/commands/drift.py
@@ -38,8 +38,9 @@ from gh_manage.drift_sync import (
     ScanContext,
 )
 from gh_manage.git_cli import GitError
+from gh_manage.github_api import protection as protection_api
 from gh_manage.github_api import repo_info
-from gh_manage.github_client import GhError
+from gh_manage.github_client import GhError, GhNotFoundError
 from gh_manage.models.branch_protection import BranchProtectionConfig
 from gh_manage.models.labels import LabelsConfig
 from gh_manage.models.profiles import ProfileSpec
@@ -113,6 +114,25 @@ def _scan_single_repo(
         else:
             scan_path = Path.cwd().resolve()
 
+        # Fetch live branch-protection contexts up-front so the shape
+        # check can compare profile-declared `required_contexts` against
+        # reality. Previously this was left empty and the
+        # `shape/required-contexts-match` check reported every
+        # profile-declared context as "missing" on every repo — a
+        # silent false-HIGH across the fleet.
+        live_contexts: tuple[str, ...] = ()
+        if profile.protection_policy is not None:
+            try:
+                live_protection = protection_api.get_branch_protection(
+                    owner_repo, default_branch
+                )
+            except GhNotFoundError:
+                live_protection = {}
+            live_contexts = tuple(
+                live_protection.get("required_status_checks", {}).get("contexts", [])
+                or []
+            )
+
         ctx = ScanContext(
             path=scan_path,
             repo=owner_repo,
@@ -120,6 +140,7 @@ def _scan_single_repo(
             profile=profile,
             labels_config=labels_config,
             bp_config=bp_config,
+            live_required_contexts=live_contexts,
         )
 
         all_findings = drift_sync.run_all_checks(ctx)

--- a/tests/unit/cli/test_drift.py
+++ b/tests/unit/cli/test_drift.py
@@ -23,6 +23,14 @@ def _patch_git_and_repo(
         "gh_manage.commands.drift.repo_info.get_default_branch",
         return_value="main",
     )
+    # Stub the live-protection fetch that _scan_single_repo performs when
+    # the profile declares a protection_policy. Tests that need a specific
+    # `live_required_contexts` value can re-patch this mock after calling
+    # _patch_git_and_repo.
+    mocker.patch(
+        "gh_manage.commands.drift.protection_api.get_branch_protection",
+        return_value={},
+    )
 
 
 def _patch_run_all_checks(mocker: MockerFixture, findings: tuple[Finding, ...]) -> None:

--- a/tests/unit/drift/test_live_contexts.py
+++ b/tests/unit/drift/test_live_contexts.py
@@ -1,0 +1,165 @@
+"""Regression test for populating live_required_contexts in ScanContext.
+
+Before this fix, `_scan_single_repo` built a ScanContext without
+populating `live_required_contexts`, so the doctor-bridged check
+`shape/required-contexts-match` always saw an empty tuple and reported
+every profile-declared required context as "missing" on every repo.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gh_manage.drift_sync.context import ScanContext
+from gh_manage.github_client import GhNotFoundError
+
+
+@pytest.fixture
+def mock_deps_with_protection(monkeypatch):
+    """Set up heavy-dependency mocks for _scan_single_repo with a profile
+    that declares a protection_policy (so the live-contexts fetch path fires)."""
+    from gh_manage.commands import drift as drift_cmd
+
+    fake_profile = MagicMock()
+    fake_profile.protection_policy = "standard"
+    fake_profile.name = "python-service"
+    fake_labels_config = MagicMock()
+    fake_policy = MagicMock()
+    fake_bp_config = MagicMock(policies={"standard": fake_policy})
+
+    def _load(path, cls):
+        if cls.__name__ == "ProfileSpec":
+            return fake_profile
+        if cls.__name__ == "BranchProtectionConfig":
+            return fake_bp_config
+        return fake_labels_config
+
+    monkeypatch.setattr(drift_cmd.repo_info, "get_default_branch", lambda repo: "main")
+    monkeypatch.setattr(drift_cmd, "load_config", _load)
+    monkeypatch.setattr(
+        drift_cmd, "resolve_profile_path", lambda name: "/tmp/fake-profile.yml"
+    )
+    monkeypatch.setattr(
+        drift_cmd, "resolve_default_labels_path", lambda: "/tmp/fake-labels.yml"
+    )
+    monkeypatch.setattr(
+        drift_cmd, "resolve_branch_protection_path", lambda: "/tmp/fake-bp.yml"
+    )
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "format_stdout_report", lambda findings: "report"
+    )
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "_filter_by_severity", lambda findings, sev: findings
+    )
+    return drift_cmd
+
+
+def _capture_ctx_stub(captured: dict, key: str):
+    """run_all_checks stub that snapshots the ScanContext it was called with."""
+
+    def _stub(ctx: ScanContext):
+        captured[key] = ctx
+        return ()
+
+    return _stub
+
+
+def test_live_required_contexts_populated_when_protection_exists(
+    mock_deps_with_protection, monkeypatch
+):
+    drift_cmd = mock_deps_with_protection
+
+    monkeypatch.setattr(
+        drift_cmd.protection_api,
+        "get_branch_protection",
+        lambda repo, branch: {
+            "required_status_checks": {
+                "contexts": ["PR Gate / PR Gate", "lint"],
+                "strict": True,
+            }
+        },
+    )
+
+    captured: dict[str, ScanContext] = {}
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "run_all_checks", _capture_ctx_stub(captured, "ctx")
+    )
+    drift_cmd._scan_single_repo(
+        "owner/repo", "python-service", "low", "stdout", None, skip_profile_check=True
+    )
+    ctx = captured["ctx"]
+    assert ctx.live_required_contexts == ("PR Gate / PR Gate", "lint")
+
+
+def test_live_required_contexts_empty_when_protection_404(
+    mock_deps_with_protection, monkeypatch
+):
+    drift_cmd = mock_deps_with_protection
+
+    def _raise_404(*a, **kw):
+        raise GhNotFoundError("404 no protection configured")
+
+    monkeypatch.setattr(drift_cmd.protection_api, "get_branch_protection", _raise_404)
+
+    captured: dict[str, ScanContext] = {}
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "run_all_checks", _capture_ctx_stub(captured, "ctx")
+    )
+    drift_cmd._scan_single_repo(
+        "owner/repo", "python-service", "low", "stdout", None, skip_profile_check=True
+    )
+    ctx = captured["ctx"]
+    assert ctx.live_required_contexts == ()
+
+
+def test_live_required_contexts_empty_when_profile_has_no_policy(monkeypatch):
+    """If profile.protection_policy is None, we don't fetch protection at all
+    — live_required_contexts stays at its default empty tuple."""
+    from gh_manage.commands import drift as drift_cmd
+
+    fake_profile = MagicMock(protection_policy=None)
+    fake_profile.name = "python-service"
+    fake_labels_config = MagicMock()
+
+    monkeypatch.setattr(drift_cmd.repo_info, "get_default_branch", lambda repo: "main")
+    monkeypatch.setattr(
+        drift_cmd,
+        "load_config",
+        lambda path, cls: (
+            fake_profile if "profile" in str(path) else fake_labels_config
+        ),
+    )
+    monkeypatch.setattr(
+        drift_cmd, "resolve_profile_path", lambda name: "/tmp/fake-profile.yml"
+    )
+    monkeypatch.setattr(
+        drift_cmd, "resolve_default_labels_path", lambda: "/tmp/fake-labels.yml"
+    )
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "format_stdout_report", lambda findings: "report"
+    )
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "_filter_by_severity", lambda findings, sev: findings
+    )
+
+    # Sentinel: if protection_api.get_branch_protection IS called, fail the test.
+    def _should_not_be_called(*a, **kw):
+        raise AssertionError(
+            "protection_api.get_branch_protection called when profile has no protection_policy"
+        )
+
+    monkeypatch.setattr(
+        drift_cmd.protection_api, "get_branch_protection", _should_not_be_called
+    )
+
+    captured: dict[str, ScanContext] = {}
+    monkeypatch.setattr(
+        drift_cmd.drift_sync, "run_all_checks", _capture_ctx_stub(captured, "ctx")
+    )
+    drift_cmd._scan_single_repo(
+        "owner/repo", "python-service", "low", "stdout", None, skip_profile_check=True
+    )
+    ctx = captured["ctx"]
+    assert ctx.live_required_contexts == ()


### PR DESCRIPTION
## Problem

\`_scan_single_repo\` builds \`ScanContext\` without passing \`live_required_contexts\`, leaving it at the dataclass default (empty tuple). The doctor-bridged \`shape/required-contexts-match\` check then compares profile-declared required contexts against an empty set and reports **every declared context as "missing" on every repo** — a silent false-HIGH across the fleet.

Observed while triaging #20 (gh-manage's own drift report): the HIGH finding persisted even after \`protection sync\` successfully enforced \"PR Gate / PR Gate\" — because the scanner was never loading the live value to compare against.

## Fix

When \`profile.protection_policy\` is set, fetch live branch protection up-front in \`_scan_single_repo\`, extract the \`required_status_checks.contexts\` list, and pass it into the ScanContext. 404 → empty tuple (same as \`check_protection\`'s own 404 handling).

When \`profile.protection_policy\` is None (opt-out), we skip the fetch entirely.

## Tests

3 regression tests in \`tests/unit/drift/test_live_contexts.py\`:
- contexts populated when live protection exists
- empty tuple when 404
- no API call at all when profile has no protection_policy

## Effect

On yakkuro/gh-manage's own drift scan, after also merging #69:

Before: 1 HIGH + 3 MEDIUM + 1 LOW
After:  0 HIGH + 2 MEDIUM + 1 LOW

(The remaining 2 MEDIUM are self-dogfood inherent; 1 LOW is CLAUDE.md user-editable.)

Fleet-wide impact: every repo scanned by \`drift --all\` using the \`python-service\` profile (which declares \`required_contexts: [\"PR Gate / PR Gate\"]\`) should stop receiving the spurious HIGH finding on the next cron run.

Refs #20.

Generated with [Claude Code](https://claude.ai/code)